### PR TITLE
Allows execution on Windows

### DIFF
--- a/src/KubernetesClientConfiguration.cs
+++ b/src/KubernetesClientConfiguration.cs
@@ -6,6 +6,7 @@ namespace k8s
     using k8s.Exceptions;
     using k8s.KubeConfigModels;
     using YamlDotNet.Serialization;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Represents a set of kubernetes client configuration settings
@@ -31,7 +32,9 @@ namespace k8s
         /// <summary>
         /// kubeconfig Default Location
         /// </summary>
-        private static readonly string KubeConfigDefaultLocation = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".kube/config");
+        private static readonly string KubeConfigDefaultLocation = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), @".kube\config") :
+            Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".kube/config");
 
         /// <summary>
         /// Gets CurrentContext

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -4,6 +4,7 @@
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
+    using System.Runtime.InteropServices;
     using System.Text;
     using System.Threading.Tasks;
 
@@ -37,7 +38,10 @@
         /// TODO: kabhishek8260 Remplace the method with X509 Certificate with private key(in dotnet 2.0)
         public static async Task<string> GeneratePfxAsync(KubernetesClientConfiguration config)
         {
-            var userHomeDir = Environment.GetEnvironmentVariable("HOME");
+            var userHomeDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                Environment.GetEnvironmentVariable("USERPROFILE") :
+                Environment.GetEnvironmentVariable("HOME");
+
             var certDirPath = Path.Combine(userHomeDir, ".k8scerts");
             Directory.CreateDirectory(certDirPath);
 
@@ -61,13 +65,8 @@
             var process = new Process();
             process.StartInfo = new ProcessStartInfo()
             {
-                FileName = @"/bin/bash",
-                Arguments = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "-c \"openssl pkcs12 -export -out {0} -inkey {1} -in {2} -passout pass:\"",
-                    pfxFilePath,
-                    keyFilePath,
-                    certFilePath),
+                FileName = @"openssl",
+                Arguments = $"pkcs12 -export -out {pfxFilePath} -inkey {keyFilePath} -in {certFilePath} -passout pass:",
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true


### PR DESCRIPTION
Removed hard Linux dependencies. 

- User directory on Windows is not in HOME environment variable.
- When calling openssl directly (instead of bash before), it also works on Windows.  