### PR TITLE
Improve error messaging with OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,58 @@
 # csharp
 Work In Progress
-Currently only supported on Linux
 
 [![Travis](https://img.shields.io/travis/kubernetes-client/csharp.svg)](https://travis-ci.org/kubernetes-client/csharp)
 
-# Generating the client code
+# Generating the Client Code
 
 ## Prerequisites
 
 Check out the generator project into some other directory
 (henceforth `$GEN_DIR`)
 
-```
+```bash
 cd $GEN_DIR/..
 git clone https://github.com/kubernetes-client/gen
 ```
 
 Install the [`autorest` tool](https://github.com/azure/autorest):
 
-```
+```bash
 npm install autorest
 ```
 
 ## Generating code
 
-```
+```bash
 # Where REPO_DIR points to the root of the csharp repository
 cd ${REPO_DIR}/csharp/src
 ${GEN_DIR}/openapi/csharp.sh generated csharp.settings
 ```
 
-# Testing
+# Usage
+
+## Prerequisities
+
+* [OpenSSL](https://www.openssl.org/)
+* For Linux/Mac:
+    * LibCurl built with OpenSSL (Mac: `brew install curl --with-nghttp2`)
+
+## Running the Examples
+
+```bash
+git clone git@github.com:kubernetes-client/csharp.git
+cd csharp\examples\simple
+dotnet run
+```
+
+## Testing
 
 The project uses [XUnit](https://xunit.github.io) as unit testing framework.
 
-To run the tests you need to:
+To run the tests
 
 ```bash
-cd tests
+cd csharp\tests
 dotnet restore
 dotnet xunit
 ```

--- a/src/Kubernetes.Auth.cs
+++ b/src/Kubernetes.Auth.cs
@@ -71,10 +71,6 @@
                       !string.IsNullOrWhiteSpace(config.ClientKey)))
             {
                 var pfxFilePath = await Utils.GeneratePfxAsync(config).ConfigureAwait(false);
-                if (string.IsNullOrWhiteSpace(pfxFilePath))
-                {
-                    throw new KubernetesClientException("Failed to generate pfx file");
-                }
 
                 var cert = new X509Certificate2(pfxFilePath, string.Empty, X509KeyStorageFlags.PersistKeySet);
                 handler.ClientCertificates.Add(cert);

--- a/tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClientConfigurationTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Xunit;
-using k8s;
+﻿using Xunit;
 using System.IO;
 
 namespace k8s.Tests


### PR DESCRIPTION
* Confirmed this works on MacOS + Windows. Updated documentation to reflect dependencies needed
*  Simplified `KubernetesClientConfiguration` getting rid of some duplicate logic
* Improve error messaging when calling `OpenSSL`