### PR TITLE
simplifying certificate chain handling

### DIFF
--- a/src/Kubernetes.Auth.cs
+++ b/src/Kubernetes.Auth.cs
@@ -105,13 +105,12 @@
             // If there are errors in the certificate chain, look at each error to determine the cause.
             if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0)
             {
-                X509Chain chain0 = new X509Chain();
-                chain0.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 // add all your extra certificate chain
-                chain0.ChainPolicy.ExtraStore.Add(this.CaCert);
-                chain0.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-                var isValid = chain0.Build((X509Certificate2)certificate);
+                chain.ChainPolicy.ExtraStore.Add(this.CaCert);
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+                var isValid = chain.Build((X509Certificate2)certificate);
                 return isValid;
             }
             else


### PR DESCRIPTION
Hey guys,
I've recently needed to call Kube API from my C# application (just 2 methods, not all Kube API is covered like yours) and my server validation used the same X509Chain object from WebRequestHandler (it doesn't create an additional one). Here is my implementation:
```cs
private bool ServerCertificateValidationCallback(object sender, X509Certificate x509Certificate, X509Chain x509Chain, SslPolicyErrors sslPolicyErrors)
{
    if (sslPolicyErrors.Equals(SslPolicyErrors.None))
        return true;

    if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) > 0)
    {
        x509Chain.ChainPolicy.ExtraStore.Add(_caCertificate);
        x509Chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
        return x509Chain.Build((X509Certificate2)x509Certificate);
    }

    return false;
}
```