### PR TITLE
introduce watch api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-sudo: required
+sudo: false 
 matrix:
   include:
     - dotnet: 2.0.0

--- a/src/Kubernetes.Auth.cs
+++ b/src/Kubernetes.Auth.cs
@@ -45,7 +45,7 @@ namespace k8s
 
             // set credentails for the kubernernet client
             this.SetCredentials(config, handler);
-            this.InitializeHttpClient(handler);
+            this.InitializeHttpClient(handler, new DelegatingHandler[]{new WatcherDelegatingHandler()});
         }
 
         private X509Certificate2 CaCert { get; set; }
@@ -78,6 +78,7 @@ namespace k8s
                       !string.IsNullOrWhiteSpace(config.ClientKey)))
             {
                 var cert = Utils.GeneratePfx(config);
+
                 handler.ClientCertificates.Add(cert);
             }
         }

--- a/src/KubernetesClient.csproj
+++ b/src/KubernetesClient.csproj
@@ -8,6 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />

--- a/src/Watcher.cs
+++ b/src/Watcher.cs
@@ -22,12 +22,15 @@ namespace k8s
 
     public class Watcher<T> : IDisposable
     {
+        /// <summary>
+        /// indicate if the watch object is alive
+        /// </summary>
         public bool Watching { get; private set; }
 
         private readonly CancellationTokenSource _cts;
         private readonly StreamReader _streamReader;
 
-        public Watcher(StreamReader streamReader, Action<WatchEventType, T> onEvent, Action<Exception> onError)
+        internal Watcher(StreamReader streamReader, Action<WatchEventType, T> onEvent, Action<Exception> onError)
         {
             _streamReader = streamReader;
             OnEvent += onEvent;
@@ -82,7 +85,14 @@ namespace k8s
             _streamReader.Dispose();
         }
 
+        /// <summary>
+        /// add/remove callbacks when any event raised from api server
+        /// </summary>
         public event Action<WatchEventType, T> OnEvent;
+
+        /// <summary>
+        /// add/remove callbacks when any exception was caught during watching
+        /// </summary>
         public event Action<Exception> OnError;
 
         public class WatchEvent
@@ -95,6 +105,14 @@ namespace k8s
 
     public static class WatcherExt
     {
+        /// <summary>
+        /// create a watch object from a call to api server with watch=true
+        /// </summary>
+        /// <typeparam name="T">type of the event object</typeparam>
+        /// <param name="response">the api response</param>
+        /// <param name="onEvent">a callback when any event raised from api server</param>
+        /// <param name="onError">a callbak when any exception was caught during watching</param>
+        /// <returns>a watch object</returns>
         public static Watcher<T> Watch<T>(this HttpOperationResponse response,
             Action<WatchEventType, T> onEvent,
             Action<Exception> onError = null)
@@ -107,6 +125,14 @@ namespace k8s
             return new Watcher<T>(content.StreamReader, onEvent, onError);
         }
 
+        /// <summary>
+        /// create a watch object from a call to api server with watch=true
+        /// </summary>
+        /// <typeparam name="T">type of the event object</typeparam>
+        /// <param name="response">the api response</param>
+        /// <param name="onEvent">a callback when any event raised from api server</param>
+        /// <param name="onError">a callbak when any exception was caught during watching</param>
+        /// <returns>a watch object</returns>
         public static Watcher<T> Watch<T>(this HttpOperationResponse<T> response,
             Action<WatchEventType, T> onEvent,
             Action<Exception> onError = null)

--- a/src/Watcher.cs
+++ b/src/Watcher.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Exceptions;
+using Microsoft.Rest;
+using Microsoft.Rest.Serialization;
+
+namespace k8s
+{
+    public enum WatchEventType
+    {
+        [EnumMember(Value = "ADDED")] Added,
+
+        [EnumMember(Value = "MODIFIED")] Modified,
+
+        [EnumMember(Value = "DELETED")] Deleted,
+
+        [EnumMember(Value = "ERROR")] Error
+    }
+
+    public class Watcher<T> : IDisposable
+    {
+        private readonly StreamReader _streamReader;
+        private readonly CancellationTokenSource _cts;
+
+        public Watcher(StreamReader streamReader, Action<WatchEventType, T> onEvent, Action<Exception> onError)
+        {
+            _streamReader = streamReader;
+            OnEvent += onEvent;
+            OnError += onError;
+
+            _cts = new CancellationTokenSource();
+
+            var token = _cts.Token;
+
+            Task.Run(async () =>
+            {
+                while (!streamReader.EndOfStream)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        var line = await streamReader.ReadLineAsync();
+                        var @event = SafeJsonConvert.DeserializeObject<WatchEvent>(line);
+
+                        OnEvent?.Invoke(@event.Type, @event.Object);
+                    }
+                    catch (Exception e)
+                    {
+                        OnError?.Invoke(e);
+                    }
+                }
+            }, token);
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _streamReader.Dispose();
+        }
+
+        public event Action<WatchEventType, T> OnEvent;
+        public event Action<Exception> OnError;
+
+        public class WatchEvent
+        {
+            public WatchEventType Type { get; set; }
+
+            public T Object { get; set; }
+        }
+    }
+
+    public static class WatcherExt
+    {
+        public static Watcher<T> Watch<T>(this HttpOperationResponse response,
+            Action<WatchEventType, T> onEvent,
+            Action<Exception> onError = null)
+        {
+            if (!(response.Response.Content is WatcherDelegatingHandler.LineSeparatedHttpContent content))
+            {
+                throw new KubernetesClientException("not a watchable request or failed response");
+            }
+
+            return new Watcher<T>(content.StreamReader, onEvent, onError);
+        }
+
+        public static Watcher<T> Watch<T>(this HttpOperationResponse<T> response,
+            Action<WatchEventType, T> onEvent,
+            Action<Exception> onError = null)
+        {
+            return Watch((HttpOperationResponse) response, onEvent, onError);
+        }
+    }
+}

--- a/src/WatcherDelegatingHandler.cs
+++ b/src/WatcherDelegatingHandler.cs
@@ -6,6 +6,10 @@ using System.Threading.Tasks;
 
 namespace k8s
 {
+    /// <summary>
+    /// This HttpDelegatingHandler is to rewrite the response and return first line to autorest client
+    /// then use WatchExt to create a watch object which interact with the replaced http response to get watch works.
+    /// </summary>
     internal class WatcherDelegatingHandler : DelegatingHandler
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,

--- a/src/WatcherDelegatingHandler.cs
+++ b/src/WatcherDelegatingHandler.cs
@@ -1,0 +1,61 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    internal class WatcherDelegatingHandler : DelegatingHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var originResponse = await base.SendAsync(request, cancellationToken);
+
+            if (originResponse.IsSuccessStatusCode)
+            {
+                if ($"{request.RequestUri.Query}".Contains("watch=true"))
+                {
+                    originResponse.Content = new LineSeparatedHttpContent(originResponse.Content);
+                }
+            }
+            return originResponse;
+        }
+
+        internal class LineSeparatedHttpContent : HttpContent
+        {
+            private readonly HttpContent _originContent;
+            private Stream _originStream;
+
+            public LineSeparatedHttpContent(HttpContent originContent)
+            {
+                _originContent = originContent;
+            }
+
+            internal StreamReader StreamReader { get; private set; }
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                _originStream = await _originContent.ReadAsStreamAsync();
+
+                StreamReader = new StreamReader(_originStream);
+
+                var firstLine = await StreamReader.ReadLineAsync();
+                var writer = new StreamWriter(stream);
+
+//                using (writer) // leave open
+                {
+                    await writer.WriteAsync(firstLine);
+                    await writer.FlushAsync();
+                }
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/src/WatcherDelegatingHandler.cs
+++ b/src/WatcherDelegatingHandler.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace k8s
 {
@@ -19,7 +21,9 @@ namespace k8s
 
             if (originResponse.IsSuccessStatusCode)
             {
-                if ($"{request.RequestUri.Query}".Contains("watch=true"))
+                var query = QueryHelpers.ParseQuery(request.RequestUri.Query);
+
+                if (query.TryGetValue("watch", out var values) && values.Any(v => v == "true"))
                 {
                     originResponse.Content = new LineSeparatedHttpContent(originResponse.Content);
                 }

--- a/tests/AuthTests.cs
+++ b/tests/AuthTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using k8s.Models;
 using k8s.Tests.Mock;
 using Microsoft.AspNetCore.Hosting;
@@ -39,7 +40,7 @@ namespace k8s.Tests
             using (var server = new MockKubeApiServer(cxt =>
             {
                 cxt.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
-                return false;
+                return Task.FromResult(false);
             }))
             {
                 var client = new Kubernetes(new KubernetesClientConfiguration
@@ -69,10 +70,10 @@ namespace k8s.Tests
                 if (header != expect)
                 {
                     cxt.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
-                    return false;
+                    return Task.FromResult(false);
                 }
 
-                return true;
+                return Task.FromResult(true);
             }))
             {
                 {
@@ -256,10 +257,10 @@ namespace k8s.Tests
                 if (header != expect)
                 {
                     cxt.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
-                    return false;
+                    return Task.FromResult(false);
                 }
 
-                return true;
+                return Task.FromResult(true);
             }))
             {
                 {

--- a/tests/WatchTests.cs
+++ b/tests/WatchTests.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Exceptions;
+using k8s.Models;
+using k8s.Tests.Mock;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class WatchTests
+    {
+        private static readonly string MockAddedEventStreamLine = BuildWatchEventStreamLine(WatchEventType.Added);
+        private static readonly string MockDeletedStreamLine = BuildWatchEventStreamLine(WatchEventType.Deleted);
+        private static readonly string MockModifiedStreamLine = BuildWatchEventStreamLine(WatchEventType.Modified);
+        private static readonly string MockErrorStreamLine = BuildWatchEventStreamLine(WatchEventType.Error);
+        private static readonly string MockBadStreamLine = "bad json";
+
+        private static string BuildWatchEventStreamLine(WatchEventType eventType)
+        {
+            var corev1PodList = JsonConvert.DeserializeObject<Corev1PodList>(MockKubeApiServer.MockPodResponse);
+            return JsonConvert.SerializeObject(new Watcher<Corev1Pod>.WatchEvent
+            {
+                Type = eventType,
+                Object = corev1PodList.Items.First()
+            }, new StringEnumConverter());
+        }
+
+        private static async Task WriteStreamLine(HttpContext httpContext, string reponseLine)
+        {
+            const string crlf = "\r\n";
+            await httpContext.Response.WriteAsync(reponseLine.Replace(crlf, ""));
+            await httpContext.Response.WriteAsync(crlf);
+            await httpContext.Response.Body.FlushAsync();
+        }
+
+        [Fact]
+        public void TestCannotWatch()
+        {
+            using (var server = new MockKubeApiServer())
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                // did not pass watch param
+                {
+                    var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default").Result;
+                    Assert.ThrowsAny<KubernetesClientException>(() =>
+                    {
+                        listTask.Watch<Corev1Pod>((type, item) => { });
+                    });
+                }
+
+                // server did not response line by line
+                {
+                    Assert.ThrowsAny<Exception>(() =>
+                    {
+                        var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
+
+                        // this line did not throw
+                        // listTask.Watch<Corev1Pod>((type, item) => { });
+                    });
+                }
+            }
+        }
+
+        [Fact]
+        public void TestSuriveBadLine()
+        {
+            using (var server = new MockKubeApiServer(async httpContext =>
+            {
+                httpContext.Response.StatusCode = (int) HttpStatusCode.OK;
+                httpContext.Response.ContentLength = null;
+
+                await WriteStreamLine(httpContext, MockKubeApiServer.MockPodResponse);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockBadStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockAddedEventStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockBadStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockModifiedStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                // make server alive, cannot set to int.max as of it would block response
+                await Task.Delay(TimeSpan.FromDays(1));
+                return false;
+            }))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
+
+
+                var events = new HashSet<WatchEventType>();
+                var errors = 0;
+
+                var watcher = listTask.Watch<Corev1Pod>(
+                    (type, item) => { events.Add(type); },
+                    e => { errors += 1; }
+                );
+
+                // wait server yields all events
+                Thread.Sleep(TimeSpan.FromMilliseconds(1000));
+
+                Assert.Contains(WatchEventType.Added, events);
+                Assert.Contains(WatchEventType.Modified, events);
+
+                Assert.Equal(2, errors);
+
+                Assert.True(watcher.Watching);
+
+                // prevent from server down exception trigger
+                Thread.Sleep(TimeSpan.FromMilliseconds(1000));
+            }
+        }
+
+        [Fact]
+        public void TestDisposeWatch()
+        {
+            using (var server = new MockKubeApiServer(async httpContext =>
+            {
+                await WriteStreamLine(httpContext, MockKubeApiServer.MockPodResponse);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                for (;;)
+                {
+                await WriteStreamLine(httpContext, MockAddedEventStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                    
+                }
+            }))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
+
+
+                var events = new HashSet<WatchEventType>();
+
+                var watcher = listTask.Watch<Corev1Pod>(
+                    (type, item) => { events.Add(type); }
+                );
+
+                // wait at least an event
+                Thread.Sleep(TimeSpan.FromMilliseconds(300));
+
+                Assert.NotEmpty(events);
+                Assert.True(watcher.Watching);
+
+                watcher.Dispose();
+
+                events.Clear();
+
+                // make sure wait event called
+                Thread.Sleep(TimeSpan.FromMilliseconds(300));
+                Assert.Empty(events);
+                Assert.False(watcher.Watching);
+                
+            }
+        }
+
+        [Fact]
+        public void TestWatchAllEvents()
+        {
+            using (var server = new MockKubeApiServer(async httpContext =>
+            {
+                await WriteStreamLine(httpContext, MockKubeApiServer.MockPodResponse);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockAddedEventStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockDeletedStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockModifiedStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                await WriteStreamLine(httpContext, MockErrorStreamLine);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                // make server alive, cannot set to int.max as of it would block response
+                await Task.Delay(TimeSpan.FromDays(1));
+                return false;
+            }))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
+
+
+                var events = new HashSet<WatchEventType>();
+                var errors = 0;
+
+                var watcher = listTask.Watch<Corev1Pod>(
+                    (type, item) => { events.Add(type); },
+                    e => { errors += 1; }
+                );
+
+                // wait server yields all events
+                Thread.Sleep(TimeSpan.FromMilliseconds(750));
+
+                Assert.Contains(WatchEventType.Added, events);
+                Assert.Contains(WatchEventType.Deleted, events);
+                Assert.Contains(WatchEventType.Modified, events);
+                Assert.Contains(WatchEventType.Error, events);
+
+
+                Assert.Equal(0, errors);
+
+                Assert.True(watcher.Watching);
+            }
+        }
+
+        [Fact]
+        public void TestWatchServerDisconnect()
+        {
+            Watcher<Corev1Pod> watcher;
+            Exception exceptionCatched = null;
+
+            using (var server = new MockKubeApiServer(async httpContext =>
+            {
+                await WriteStreamLine(httpContext, MockKubeApiServer.MockPodResponse);
+
+                // make sure watch success
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+                throw new IOException("server down");
+            }))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
+
+                watcher = listTask.Watch<Corev1Pod>(
+                    (type, item) => { },
+                    e => { exceptionCatched = e; });
+            }
+
+            // wait server down
+            Thread.Sleep(TimeSpan.FromMilliseconds(500));
+
+            Assert.False(watcher.Watching);
+            Assert.IsType<IOException>(exceptionCatched);
+        }
+    }
+}


### PR DESCRIPTION
fix #8 

The API is like

```
var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default", watch: true).Result;
listTask.Watch<Corev1Pod>((type, item) =>
{
    Console.WriteLine("==on watch event==");
    Console.WriteLine(type);
    Console.WriteLine(item.Metadata.Name);
    Console.WriteLine("==on watch event==");
});
```

since autorest generated code use `ReadAsString` to receive the data from api server, json stream would be hang.

I tried to hack autorest first, but it is hard to change the template for k8s client.

The implementation used an HttpDelegatingHandler to rewrite the response and return first line to autorest client, then use WatchExt to create a watch object which interact with the replaced http response to get watch works.
