### PR TITLE
Update example for new config file loading.

### DIFF
--- a/examples/simple/PodList.cs
+++ b/examples/simple/PodList.cs
@@ -8,7 +8,7 @@ namespace simple
     {
         static void Main(string[] args)
         {
-            var k8sClientConfig = new KubernetesClientConfiguration();
+            var k8sClientConfig = KubernetesClientConfiguration.BuildConfigFromConfigFile();
             IKubernetes client = new Kubernetes(k8sClientConfig);
             Console.WriteLine("Starting Request!");
             var listTask = client.ListNamespacedPodWithHttpMessagesAsync("default").Result;


### PR DESCRIPTION
The example didn't work (at least for me) it crashed with:

```
Unhandled Exception: System.ArgumentNullException: Value cannot be null.
Parameter name: uriString
   at System.Uri..ctor(String uriString)
   at k8s.Kubernetes..ctor(KubernetesClientConfiguration config) in /home/bburns/kubernetes-client/csharp/src/Kubernetes.Auth.cs:line 25
   at simple.PodList.Main(String[] args) in /home/bburns/kubernetes-client/csharp/examples/simple/PodList.cs:line 12
```

This fixes it for the new config file approach.
@tg123 