### PR TITLE
better way to #46

### DIFF
--- a/src/Kubernetes.Auth.cs
+++ b/src/Kubernetes.Auth.cs
@@ -1,3 +1,5 @@
+using k8s.Models;
+
 namespace k8s
 {
     using System;
@@ -46,6 +48,8 @@ namespace k8s
             // set credentails for the kubernernet client
             this.SetCredentials(config, handler);
             this.InitializeHttpClient(handler, new DelegatingHandler[]{new WatcherDelegatingHandler()});
+
+            DeserializationSettings.Converters.Add(new V1Status.V1StatusObjectViewConverter());
         }
 
         private X509Certificate2 CaCert { get; set; }

--- a/src/V1Status.ObjectView.cs
+++ b/src/V1Status.ObjectView.cs
@@ -1,0 +1,52 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace k8s.Models
+{
+    public partial class V1Status
+    {
+        internal class V1StatusObjectViewConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                serializer.Serialize(writer, value);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                JsonSerializer serializer)
+            {
+                var obj = JToken.Load(reader);
+
+                try
+                {
+                    return obj.ToObject(objectType);
+                }
+                catch (JsonException)
+                {
+                    // should be an object
+                }
+
+                return new V1Status
+                {
+                    _original = obj,
+                    HasObject = true
+                };
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return typeof(V1Status) == objectType;
+            }
+        }
+
+        private JToken _original;
+
+        public bool HasObject { get; private set; }
+
+        public T ObjectView<T>()
+        {
+            return _original.ToObject<T>();
+        }
+    }
+}

--- a/tests/V1StatusObjectViewTests.cs
+++ b/tests/V1StatusObjectViewTests.cs
@@ -1,0 +1,68 @@
+using k8s.Models;
+using k8s.Tests.Mock;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class V1StatusObjectViewTests
+    {
+        [Fact]
+        public void TestReturnStatus()
+        {
+            var v1Status = new V1Status
+            {
+                Message = "test message",
+                Status = "test status"
+            };
+
+            using (var server = new MockKubeApiServer(resp: JsonConvert.SerializeObject(v1Status)))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var status = client.DeleteNamespace(new V1DeleteOptions(), "test");
+
+                Assert.False(status.HasObject);
+                Assert.Equal(v1Status.Message, status.Message);
+                Assert.Equal(v1Status.Status, status.Status);
+            }
+        }
+
+        [Fact]
+        public void TestReturnObject()
+        {
+            var corev1Namespace = new Corev1Namespace()
+            {
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "test name"
+                },
+                Status = new Corev1NamespaceStatus()
+                {
+                    Phase = "test termating"
+                }
+            };
+
+            using (var server = new MockKubeApiServer(resp: JsonConvert.SerializeObject(corev1Namespace)))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration
+                {
+                    Host = server.Uri.ToString()
+                });
+
+                var status = client.DeleteNamespace(new V1DeleteOptions(), "test");
+
+                Assert.True(status.HasObject);
+
+                var obj = status.ObjectView<Corev1Namespace>();
+
+                Assert.Equal(obj.Metadata.Name, corev1Namespace.Metadata.Name);
+                Assert.Equal(obj.Status.Phase, corev1Namespace.Status.Phase);
+            }
+
+        }
+    }
+    }

--- a/tests/WatchTests.cs
+++ b/tests/WatchTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -163,7 +163,7 @@ namespace k8s.Tests
                 );
 
                 // wait at least an event
-                Thread.Sleep(TimeSpan.FromMilliseconds(300));
+                Thread.Sleep(TimeSpan.FromMilliseconds(500));
 
                 Assert.NotEmpty(events);
                 Assert.True(watcher.Watching);
@@ -173,7 +173,7 @@ namespace k8s.Tests
                 events.Clear();
 
                 // make sure wait event called
-                Thread.Sleep(TimeSpan.FromMilliseconds(300));
+                Thread.Sleep(TimeSpan.FromMilliseconds(500));
                 Assert.Empty(events);
                 Assert.False(watcher.Watching);
                 


### PR DESCRIPTION
try to fix #44 #46 

different from #46  this is to hide the util call  from user side by add a jsonconverter to k8s client when deserializing.

the user side api is like.

this will not break the ext api `client.DeleteNamespace()` either.

```
var response = client.DeleteNamespaceWithHttpMessagesAsync(new V1DeleteOptions(), ns.Metadata.Name).Result;

Console.WriteLine(response.Body.HasObject); // true
Console.WriteLine(response.Body.ObjectView<Corev1Namespace>()); // 
```

@brendandburns @mbohlool @krabhishek8260 

I will add some tests after the api is confirmed with you.