### PR TITLE
Fix for delete post-config-load.

### DIFF
--- a/src/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClientConfiguration.ConfigFile.cs
@@ -223,7 +223,10 @@ namespace k8s
 
             var deserializeBuilder = new DeserializerBuilder();
             var deserializer = deserializeBuilder.Build();
-            return deserializer.Deserialize<K8SConfiguration>(kubeconfig.OpenText());
+            using (var kubeConfigTextStream = kubeconfig.OpenText())
+            {
+                return deserializer.Deserialize<K8SConfiguration>(kubeConfigTextStream);
+            }
         }
     }
 }

--- a/tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClientConfigurationTests.cs
@@ -259,5 +259,31 @@ namespace k8s.Tests
             var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, masterUrl: "http://test.server");
             Assert.Equal("http://test.server", cfg.Host);
         }
+
+        /// <summary>
+        ///     Checks that loading a configuration from a file leaves no outstanding handles to the file.
+        /// </summary>
+        /// <remarks>
+        ///     This test fails only on Windows.
+        /// </remarks>
+        [Fact]
+        public void DeletedConfigurationFile()
+        {
+            var assetFileInfo = new FileInfo("assets/kubeconfig.yml");
+            var tempFileInfo = new FileInfo(Path.GetTempFileName());
+            
+            File.Copy(assetFileInfo.FullName, tempFileInfo.FullName, /* overwrite: */ true);
+
+            KubernetesClientConfiguration config;
+
+            try
+            {
+                config = KubernetesClientConfiguration.BuildConfigFromConfigFile(tempFileInfo);
+            }
+            finally
+            {
+                File.Delete(tempFileInfo.FullName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for #67 where deleting a configuration file post-load results in an `IOException` on Windows.

Updates `LoadKubeConfig()` to dispose of the opened `Stream` after its contents have been deserialized. Adds a test for fix (that would only ever fail on Windows, though not sure how feasible it would be to add a Windows image to the CI test matrix).