### PR TITLE
Use mainstream and strongly-named versions of BouncyCastle, YamlDotNet

### DIFF
--- a/src/KubernetesClient.csproj
+++ b/src/KubernetesClient.csproj
@@ -16,13 +16,13 @@
     <Compile Remove="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Fractions" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2"/>
+    <PackageReference Include="YamlDotNet" Version="4.2.3" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/KubernetesClient.csproj
+++ b/src/KubernetesClient.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="YamlDotNet" Version="4.2.3" />
+    <PackageReference Include="YamlDotNet.Signed" Version="4.2.3" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use Portable.BouncyCastle instead of BouncyCastle.NetCore. The portable version has > 1.4M downloads on NuGet and tracks upstream BouncyCastle
- Use YamlDotNet.Signed instead of YamlDotNet.NetCore, YamlDotNet.Signed is the package maintained by the YamlDotNet author.

Split off from #76