### PR TITLE
Update the Kubernetes configuration model

### DIFF
--- a/src/KubeConfigModels/Cluster.cs
+++ b/src/KubeConfigModels/Cluster.cs
@@ -1,12 +1,21 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Relates nicknames to cluster information.
+    /// </summary>
     public class Cluster
     {
+        /// <summary>
+        /// Gets or sets the cluster information.
+        /// </summary>
         [YamlMember(Alias = "cluster")]
         public ClusterEndpoint ClusterEndpoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets the nickname for this Cluster.
+        /// </summary>
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
     }

--- a/src/KubeConfigModels/ClusterEndpoint.cs
+++ b/src/KubeConfigModels/ClusterEndpoint.cs
@@ -1,19 +1,42 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
+    using System.Collections.Generic;
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Contains information about how to communicate with a kubernetes cluster
+    /// </summary>
     public class ClusterEndpoint
     {
+        /// <summary>
+        /// Gets or sets the path to a cert file for the certificate authority.
+        /// </summary>
         [YamlMember(Alias = "certificate-authority")]
         public string CertificateAuthority {get; set; }
 
+        /// <summary>
+        /// Gets or sets =PEM-encoded certificate authority certificates. Overrides <see cref="CertificateAuthority"/>.
+        /// </summary>
         [YamlMember(Alias = "certificate-authority-data")]
         public string CertificateAuthorityData { get; set; }
 
+        /// <summary>
+        /// Gets or sets the address of the kubernetes cluster (https://hostname:port).
+        /// </summary>
         [YamlMember(Alias = "server")]
         public string Server { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the validity check for the server's certificate.
+        /// This will make your HTTPS connections insecure.
+        /// </summary>
         [YamlMember(Alias = "insecure-skip-tls-verify")]
         public bool SkipTlsVerify { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
+        /// </summary>
+        [YamlMember(Alias = "extensions")]
+        public IDictionary<string, dynamic> Extensions { get; set; }
     }
 }

--- a/src/KubeConfigModels/Context.cs
+++ b/src/KubeConfigModels/Context.cs
@@ -1,12 +1,21 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Relates nicknames to context information.
+    /// </summary>
     public class Context
     {
+        /// <summary>
+        /// Gets or sets the context information.
+        /// </summary>
         [YamlMember(Alias = "context")]
         public ContextDetails ContextDetails { get; set; }
 
+        /// <summary>
+        /// Gets or sets the nickname for this context.
+        /// </summary>
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
 

--- a/src/KubeConfigModels/ContextDetails.cs
+++ b/src/KubeConfigModels/ContextDetails.cs
@@ -1,17 +1,36 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
-    using YamlDotNet.RepresentationModel;
+    using System.Collections.Generic;
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Represents a tuple of references to a cluster (how do I communicate with a kubernetes cluster),
+    /// a user (how do I identify myself), and a namespace (what subset of resources do I want to work with)
+    /// </summary>
     public class ContextDetails
     {
+        /// <summary>
+        /// Gets or sets the name of the cluster for this context.
+        /// </summary>
         [YamlMember(Alias = "cluster")]
         public string Cluster { get; set; }
 
+        /// <summary>
+        /// Gets or sets the anem of the user for this context.
+        /// </summary>
         [YamlMember(Alias = "user")]
         public string User { get; set; }
 
+        /// <summary>
+        /// /Gets or sets the default namespace to use on unspecified requests.
+        /// </summary>
         [YamlMember(Alias = "namespace")]
         public string Namespace { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
+        /// </summary>
+        [YamlMember(Alias = "extensions")]
+        public IDictionary<string, dynamic> Extensions { get; set; }
     }
 }

--- a/src/KubeConfigModels/K8SConfiguration.cs
+++ b/src/KubeConfigModels/K8SConfiguration.cs
@@ -4,10 +4,17 @@ namespace k8s.KubeConfigModels
     using YamlDotNet.Serialization;
 
     /// <summary>
-    /// kubeconfig configuration model
+    /// kubeconfig configuration model. Holds the information needed to build connect to remote
+    /// Kubernetes clusters as a given user.
     /// </summary>
+    /// <remarks>
+    /// Should be kept in sync with https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+    /// </remarks>
     public class K8SConfiguration
     {
+        /// <summary>
+        /// Gets or sets general information to be use for CLI interactions
+        /// </summary>
         [YamlMember(Alias = "preferences")]
         public IDictionary<string, object> Preferences{ get; set; }
 
@@ -17,16 +24,34 @@ namespace k8s.KubeConfigModels
         [YamlMember(Alias = "kind")]
         public string Kind { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the context that you would like to use by default.
+        /// </summary>
         [YamlMember(Alias = "current-context")]
         public string CurrentContext { get; set; }
 
+        /// <summary>
+        /// Gets or sets a map of referencable names to context configs.
+        /// </summary>
         [YamlMember(Alias = "contexts")]
         public IEnumerable<Context> Contexts { get; set; } = new Context[0];
 
+        /// <summary>
+        /// Gets or sets a map of referencable names to cluster configs.
+        /// </summary>
         [YamlMember(Alias = "clusters")]
         public IEnumerable<Cluster> Clusters { get; set; } = new Cluster[0];
 
+        /// <summary>
+        /// Gets or sets a map of referencable names to user configs
+        /// </summary>
         [YamlMember(Alias = "users")]
         public IEnumerable<User> Users { get; set; } = new User[0];
+
+        /// <summary>
+        /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
+        /// </summary>
+        [YamlMember(Alias = "extensions")]
+        public IDictionary<string, dynamic> Extensions { get; set; }
     }
 }

--- a/src/KubeConfigModels/User.cs
+++ b/src/KubeConfigModels/User.cs
@@ -1,13 +1,21 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
-    using YamlDotNet.RepresentationModel;
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Relates nicknames to auth information.
+    /// </summary>
     public class User
     {
+        /// <summary>
+        /// Gets or sets the auth information.
+        /// </summary>
         [YamlMember(Alias = "user")]
         public UserCredentials UserCredentials { get; set; }
 
+        /// <summary>
+        /// Gets or sets the nickname for this auth information.
+        /// </summary>
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
     }

--- a/src/KubeConfigModels/UserCredentials.cs
+++ b/src/KubeConfigModels/UserCredentials.cs
@@ -1,33 +1,84 @@
-﻿namespace k8s.KubeConfigModels
+namespace k8s.KubeConfigModels
 {
     using System.Collections.Generic;
     using YamlDotNet.RepresentationModel;
     using YamlDotNet.Serialization;
 
+    /// <summary>
+    /// Contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.
+    /// </summary>
     public class UserCredentials
     {
+        /// <summary>
+        /// Gets or sets PEM-encoded data from a client cert file for TLS. Overrides <see cref="ClientCertificate"/>.
+        /// </summary>
         [YamlMember(Alias = "client-certificate-data")]
         public string ClientCertificateData { get; set; }
 
+        /// <summary>
+        /// Gets or sets the path to a client cert file for TLS.
+        /// </summary>
         [YamlMember(Alias = "client-certificate")]
         public string ClientCertificate { get; set; }
 
+        /// <summary>
+        /// Gets or sets PEM-encoded data from a client key file for TLS. Overrides <see cref="ClientKey"/>.
+        /// </summary>
         [YamlMember(Alias = "client-key-data")]
         public string ClientKeyData { get; set; }
 
+        /// <summary>
+        /// Gets or sets the path to a client key file for TLS.
+        /// </summary>
         [YamlMember(Alias = "client-key")]
         public string ClientKey { get; set; }
 
+        /// <summary>
+        /// Gets or sets the bearer token for authentication to the kubernetes cluster.
+        /// </summary>
         [YamlMember(Alias = "token")]
         public string Token { get; set; }
 
+        /// <summary>
+        /// Gets or sets the username to imperonate. The name matches the flag.
+        /// </summary>
+        [YamlMember(Alias = "as")]
+        public string Impersonate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the groups to imperonate.
+        /// </summary>
+        [YamlMember(Alias = "as-groups")]
+        public IEnumerable<string> ImpersonateGroups { get; set; } = new string[0];
+
+        /// <summary>
+        /// Gets or sets additional information for impersonated user.
+        /// </summary>
+        [YamlMember(Alias = "as-user-extra")]
+        public Dictionary<string, string> ImpersonateUserExtra { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets or sets the username for basic authentication to the kubernetes cluster.
+        /// </summary>
         [YamlMember(Alias = "username")]
         public string UserName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the password for basic authentication to the kubernetes cluster.
+        /// </summary>
         [YamlMember(Alias = "password")]
         public string Password { get; set; }
 
+        /// <summary>
+        /// Gets or sets custom authentication plugin for the kubernetes cluster.
+        /// </summary>
         [YamlMember(Alias = "auth-provider")]
         public Dictionary<string, dynamic> AuthProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
+        /// </summary>
+        [YamlMember(Alias = "extensions")]
+        public IDictionary<string, dynamic> Extensions { get; set; }
     }
 }

--- a/tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClientConfigurationTests.cs
@@ -311,5 +311,17 @@ namespace k8s.Tests
                 Assert.NotNull(cfg.Host);
             }
         }
+
+        /// <summary>
+        ///     Checks users.as-user-extra is loaded correctly from a configuration file.
+        /// </summary>
+        [Fact]
+        public void AsUserExtra()
+        {
+            var txt = File.ReadAllText("assets/kubeconfig.as-user-extra.yml");
+
+            var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(txt, null, null);
+            Assert.NotNull(cfg.Host);
+        }
     }
 }

--- a/tests/assets/kubeconfig.as-user-extra.yml
+++ b/tests/assets/kubeconfig.as-user-extra.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: assets/ca.crt
+    server: https://10.20.0.56:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    as-user-extra: {}
+    client-certificate: assets/client.crt
+    client-key: assets/client.key


### PR DESCRIPTION
Updates the `K8SConfiguration` object based on the latest information in [types.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go):

- Copies over documentation
- Adds the `Extensions` property
- Adds the `as`, `as-groups` and `as-user-extra` properties to the User configuration

Fixes #93