### PR TITLE
KubernetesWebSocketOptions.EnabledSslProtocols now defaults to None.

### DIFF
--- a/src/WebSocketBuilder.NetCoreApp2.1.cs
+++ b/src/WebSocketBuilder.NetCoreApp2.1.cs
@@ -133,7 +133,10 @@ namespace k8s
         /// <summary>
         ///     An <see cref="SslProtocols"/> value representing the SSL protocols that the client supports.
         /// </summary>
-        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.Tls;
+        /// <remarks>
+        ///     Defaults to <see cref="SslProtocols.None"/>, which lets the platform select the most appropriate protocol.
+        /// </remarks>
+        public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.None;
 
         /// <summary>
         ///     The WebSocket keep-alive interval.


### PR DESCRIPTION
This lets the the local platform select the most appropriate protocol(s).

Resolves kubernetes-client/csharp#112.