### PR TITLE
WebSocketNamespacedPodExecAsync: Support specifying command arguments

### DIFF
--- a/src/IKubernetes.WebSocket.cs
+++ b/src/IKubernetes.WebSocket.cs
@@ -52,6 +52,53 @@ namespace k8s
         /// <return>
         /// A <see cref="ClientWebSocket"/> which can be used to communicate with the process running in the pod.
         /// </return>
+        Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", string command = null, string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Executes a command in a pod.
+        /// </summary>
+        /// <param name='name'>
+        /// name of the Pod
+        /// </param>
+        /// <param name='namespace'>
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name='command'>
+        /// Command is the remote command to execute. argv array. Not executed within a
+        /// shell.
+        /// </param>
+        /// <param name='container'>
+        /// Container in which to execute the command. Defaults to only container if
+        /// there is only one container in the pod.
+        /// </param>
+        /// <param name='stderr'>
+        /// Redirect the standard error stream of the pod for this call. Defaults to
+        /// <see langword="true"/>.
+        /// </param>
+        /// <param name='stdin'>
+        /// Redirect the standard input stream of the pod for this call. Defaults to
+        /// <see langword="true"/>.
+        /// </param>
+        /// <param name='stdout'>
+        /// Redirect the standard output stream of the pod for this call. Defaults to
+        /// <see langword="true"/>.
+        /// </param>
+        /// <param name='tty'>
+        /// TTY if true indicates that a tty will be allocated for the exec call.
+        /// Defaults to <see langword="true"/>.
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <return>
+        /// A <see cref="ClientWebSocket"/> which can be used to communicate with the process running in the pod.
+        /// </return>
         Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", IEnumerable<string> command = null, string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/IKubernetes.WebSocket.cs
+++ b/src/IKubernetes.WebSocket.cs
@@ -52,7 +52,7 @@ namespace k8s
         /// <return>
         /// A <see cref="ClientWebSocket"/> which can be used to communicate with the process running in the pod.
         /// </return>
-        Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", string command = "/bin/bash", string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", IEnumerable<string> command = null, string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Start port forwarding one or more ports of a pod.

--- a/src/Kubernetes.WebSocket.cs
+++ b/src/Kubernetes.WebSocket.cs
@@ -20,6 +20,12 @@ namespace k8s
         public Func<WebSocketBuilder> CreateWebSocketBuilder { get; set; } = () => new WebSocketBuilder();
 
         /// <inheritdoc/>
+        public Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", string command = null, string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WebSocketNamespacedPodExecAsync(name, @namespace, new string[] { command }, container, stderr, stdin, stdout, tty, customHeaders, cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public Task<WebSocket> WebSocketNamespacedPodExecAsync(string name, string @namespace = "default", IEnumerable<string> command = null, string container = null, bool stderr = true, bool stdin = true, bool stdout = true, bool tty = true, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (name == null)
@@ -90,7 +96,7 @@ namespace k8s
                 {"stdin", stdin ? "1" : "0"},
                 {"stdout", stdout ? "1" : "0"},
                 {"tty", tty ? "1" : "0"}
-            });
+            }).TrimStart('?');
 
             uriBuilder.Query = query;
 

--- a/src/Kubernetes.WebSocket.cs
+++ b/src/Kubernetes.WebSocket.cs
@@ -37,7 +37,7 @@ namespace k8s
                 throw new ArgumentNullException(nameof(command));
             }
 
-            if (command.Count() == 0)
+            if (!command.Any())
             {
                 throw new ArgumentOutOfRangeException(nameof(command));
             }
@@ -72,24 +72,27 @@ namespace k8s
 
             uriBuilder.Path += $"api/v1/namespaces/{@namespace}/pods/{name}/exec";
 
-            List<string> queryParameters = new List<string>();
+            var query = string.Empty;
 
             foreach (var c in command)
             {
-                queryParameters.Add(string.Format("command={0}", Uri.EscapeDataString(c)));
+                query = QueryHelpers.AddQueryString(query, "command", c);
             }
 
             if (container != null)
             {
-                queryParameters.Add(string.Format("container={0}", Uri.EscapeDataString(container)));
+                query = QueryHelpers.AddQueryString(query, "container", Uri.EscapeDataString(container));
             }
 
-            queryParameters.Add(string.Format("stderr={0}", stderr ? 1 : 0));
-            queryParameters.Add(string.Format("stdin={0}", stdin ? 1 : 0));
-            queryParameters.Add(string.Format("stdout={0}", stdout ? 1 : 0));
-            queryParameters.Add(string.Format("tty={0}", tty ? 1 : 0));
+            query = QueryHelpers.AddQueryString(query, new Dictionary<string, string>
+            {
+                {"stderr", stderr ? "1" : "0"},
+                {"stdin", stdin ? "1" : "0"},
+                {"stdout", stdout ? "1" : "0"},
+                {"tty", tty ? "1" : "0"}
+            });
 
-            uriBuilder.Query = string.Join("&", queryParameters);
+            uriBuilder.Query = query;
 
             return this.StreamConnectAsync(uriBuilder.Uri, _invocationId, customHeaders, cancellationToken);
         }

--- a/tests/Kubernetes.Exec.Tests.cs
+++ b/tests/Kubernetes.Exec.Tests.cs
@@ -54,7 +54,7 @@ namespace k8s.Tests
                 WebSocket clientSocket = await client.WebSocketNamespacedPodExecAsync(
                     name: "mypod",
                     @namespace: "mynamespace",
-                    command: "/bin/bash",
+                    command: new string[] { "/bin/bash" },
                     container: "mycontainer",
                     stderr: false,
                     stdin: false,

--- a/tests/Kubernetes.WebSockets.Tests.cs
+++ b/tests/Kubernetes.WebSockets.Tests.cs
@@ -39,7 +39,7 @@ namespace k8s.tests
             var webSocket = await client.WebSocketNamespacedPodExecAsync(
                 name: "mypod",
                 @namespace: "mynamespace",
-                command: new string[] { "/bin/bash", "-c", $"echo Hello, World!\nexit 0\n" },
+                command: new string[] { "/bin/bash", "-c", $"echo Hello, World\nexit 0\n" },
                 container: "mycontainer",
                 stderr: true,
                 stdin: true,
@@ -58,7 +58,7 @@ namespace k8s.tests
             };
 
             Assert.Equal(mockWebSocketBuilder.PublicWebSocket, webSocket); // Did the method return the correct web socket?
-            Assert.Equal(new Uri("ws://localhost/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&command=-c&command=echo%20Hello,%20World%21%0Aexit%200%0A&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
+            Assert.Equal(new Uri("ws://localhost/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&command=-c&command=echo%20Hello,%20World%0Aexit%200%0A&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
             Assert.Empty(mockWebSocketBuilder.Certificates); // No certificates were used in this test
             Assert.Equal(expectedHeaders, mockWebSocketBuilder.RequestHeaders); // Did we use the expected headers
         }

--- a/tests/Kubernetes.WebSockets.Tests.cs
+++ b/tests/Kubernetes.WebSockets.Tests.cs
@@ -39,7 +39,7 @@ namespace k8s.tests
             var webSocket = await client.WebSocketNamespacedPodExecAsync(
                 name: "mypod",
                 @namespace: "mynamespace",
-                command: "/bin/bash",
+                command: new string[] { "/bin/bash", "-c", $"echo Hello, World!\nexit 0\n" },
                 container: "mycontainer",
                 stderr: true,
                 stdin: true,
@@ -58,7 +58,7 @@ namespace k8s.tests
             };
 
             Assert.Equal(mockWebSocketBuilder.PublicWebSocket, webSocket); // Did the method return the correct web socket?
-            Assert.Equal(new Uri("ws://localhost:80/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
+            Assert.Equal(new Uri("ws://localhost/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&command=-c&command=echo%20Hello%2C%20World%21%0Aexit%200%0A&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
             Assert.Empty(mockWebSocketBuilder.Certificates); // No certificates were used in this test
             Assert.Equal(expectedHeaders, mockWebSocketBuilder.RequestHeaders); // Did we use the expected headers
         }

--- a/tests/Kubernetes.WebSockets.Tests.cs
+++ b/tests/Kubernetes.WebSockets.Tests.cs
@@ -58,7 +58,7 @@ namespace k8s.tests
             };
 
             Assert.Equal(mockWebSocketBuilder.PublicWebSocket, webSocket); // Did the method return the correct web socket?
-            Assert.Equal(new Uri("ws://localhost/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&command=-c&command=echo%20Hello%2C%20World%21%0Aexit%200%0A&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
+            Assert.Equal(new Uri("ws://localhost/api/v1/namespaces/mynamespace/pods/mypod/exec?command=%2Fbin%2Fbash&command=-c&command=echo%20Hello,%20World%21%0Aexit%200%0A&container=mycontainer&stderr=1&stdin=1&stdout=1&tty=1"), mockWebSocketBuilder.Uri); // Did we connect to the correct URL?
             Assert.Empty(mockWebSocketBuilder.Certificates); // No certificates were used in this test
             Assert.Equal(expectedHeaders, mockWebSocketBuilder.RequestHeaders); // Did we use the expected headers
         }


### PR DESCRIPTION
In the current implementation, `WebSocketNamespacedPodExecAsync` only allows a single command (`command` is a single string). 

The Kubernetes API allows you to pass a command with arguments, such as `/bin/bash -c "echo Hello, World!\nexit 0\n"`.

This PR changes the `command` argument to be an `IEnumerable<string>`, allowing you to pass parameters.