### PR TITLE
revert changes to ci.sh in c0a42ad8847f1401ec0ffa2786e3f710a72699f0

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,12 +4,9 @@
 set -e
 
 # Ensure no compile errors in all projects
-dotnet restore
-dotnet build --no-restore
+find . -name *.csproj -exec dotnet build {} \;
 
 # Execute Unit tests
 cd tests
-dotnet test --no-restore --no-build
-if [[ $? != 0 ]]; then
-    exit 1
-fi
+dotnet restore
+dotnet test


### PR DESCRIPTION
hi @tintoy 

 * `find . -name *.csproj -exec dotnet build {} \; ` should not be removed, it is to ensure all examples could be compiled before code check in.
 * no need to test $? because  `set -e` is already set.

any comments?
