### PR TITLE
Fix YAML serialization of ResourceQuantity values

### DIFF
--- a/src/Yaml.cs
+++ b/src/Yaml.cs
@@ -30,5 +30,15 @@ namespace k8s
             var obj = deserializer.Deserialize<T>(content);
             return obj;
         }
+
+        public static string SaveToString<T>(T value)
+        {
+            var serializer =
+                new SerializerBuilder()
+                .WithNamingConvention(new CamelCaseNamingConvention())
+                .Build();
+            var obj = serializer.Serialize(value);
+            return obj;
+        }
     }
 }

--- a/src/Yaml.cs
+++ b/src/Yaml.cs
@@ -1,5 +1,8 @@
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -17,13 +20,13 @@ namespace k8s
         }
 
         public static async Task<T> LoadFromFileAsync<T> (string file) {
-            using (FileStream fs = File.OpenRead(file)) { 
+            using (FileStream fs = File.OpenRead(file)) {
                 return await LoadFromStreamAsync<T>(fs);
             }
         }
 
         public static T LoadFromString<T>(string content) {
-            var deserializer = 
+            var deserializer =
                 new DeserializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
@@ -33,12 +36,19 @@ namespace k8s
 
         public static string SaveToString<T>(T value)
         {
+            var stringBuilder = new StringBuilder();
+            var writer = new StringWriter(stringBuilder);
+            var emitter = new Emitter(writer);
+
             var serializer =
                 new SerializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
-                .Build();
-            var obj = serializer.Serialize(value);
-            return obj;
+                .BuildValueSerializer();
+            emitter.Emit(new StreamStart());
+            emitter.Emit(new DocumentStart());
+            serializer.SerializeValue(emitter, value, typeof(T));
+
+            return stringBuilder.ToString();
         }
     }
 }

--- a/tests/QuantityValueTests.cs
+++ b/tests/QuantityValueTests.cs
@@ -166,6 +166,12 @@ namespace k8s.Tests
         }
 
         [Fact]
+        public void ConstructorTest()
+        {
+            Assert.Throws<FormatException>(() => new ResourceQuantity(string.Empty));
+        }
+
+        [Fact]
         public void QuantityString()
         {
             foreach (var (input, expect, alternate) in new[]
@@ -246,7 +252,7 @@ namespace k8s.Tests
         public void SerializeYaml()
         {
             var value = Yaml.SaveToString(new ResourceQuantity(1, -1, DecimalSI));
-            Assert.Equal("100m\r\n...\r\n", value);
+            Assert.Equal("100m", value);
         }
     }
 }

--- a/tests/QuantityValueTests.cs
+++ b/tests/QuantityValueTests.cs
@@ -234,5 +234,19 @@ namespace k8s.Tests
                 Assert.Equal("\"12e3\"", JsonConvert.SerializeObject(quantity));
             }
         }
+
+        [Fact]
+        public void DeserializeYaml()
+        {
+            var value = Yaml.LoadFromString<ResourceQuantity>("\"1\"");
+            Assert.Equal(new ResourceQuantity(1, 0, DecimalSI), value);
+        }
+
+        [Fact]
+        public void SerializeYaml()
+        {
+            var value = Yaml.SaveToString(new ResourceQuantity(1, -1, DecimalSI));
+            Assert.Equal("100m\r\n...\r\n", value);
+        }
     }
 }

--- a/tests/YamlTests.cs
+++ b/tests/YamlTests.cs
@@ -53,8 +53,7 @@ metadata:
             Assert.Equal(@"apiVersion: v1
 kind: Pod
 metadata:
-  name: foo
-", yaml);
+  name: foo", yaml);
         }
 
         [Fact]

--- a/tests/YamlTests.cs
+++ b/tests/YamlTests.cs
@@ -35,5 +35,67 @@ metadata:
                 Assert.Equal("foo", obj.Metadata.Name);
             }
         }
+
+        [Fact]
+        public void WriteToString()
+        {
+            var pod = new V1Pod()
+            {
+                ApiVersion = "v1",
+                Kind = "Pod",
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "foo"
+                }
+            };
+
+            var yaml = Yaml.SaveToString(pod);
+            Assert.Equal(@"apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+", yaml);
+        }
+
+        [Fact]
+        public void CpuRequestAndLimitFromString()
+        {
+            // Taken from https://raw.githubusercontent.com/kubernetes/website/master/docs/tasks/configure-pod-container/cpu-request-limit.yaml, although
+            // the 'namespace' property on 'metadata' was removed since it was rejected by the C# client.
+            var content = @"apiVersion: v1
+kind: Pod
+metadata:
+  name: cpu-demo
+spec:
+  containers:
+  - name: cpu-demo-ctr
+    image: vish/stress
+    resources:
+      limits:
+        cpu: ""1""
+      requests:
+        cpu: ""0.5""
+    args:
+            - -cpus
+            - ""2""";
+
+            var obj = Yaml.LoadFromString<V1Pod>(content);
+
+            Assert.NotNull(obj?.Spec?.Containers);
+            var container = Assert.Single(obj.Spec.Containers);
+
+            Assert.NotNull(container.Resources);
+            Assert.NotNull(container.Resources.Limits);
+            Assert.NotNull(container.Resources.Requests);
+
+            var cpuLimit = Assert.Single(container.Resources.Limits);
+            var cpuRequest = Assert.Single(container.Resources.Requests);
+
+            Assert.Equal("cpu", cpuLimit.Key);
+            Assert.Equal("1", cpuLimit.Value.ToString());
+
+            Assert.Equal("cpu", cpuRequest.Key);
+            Assert.Equal("500m", cpuRequest.Value.ToString());
+        }
     }
 }


### PR DESCRIPTION
We recently upgraded from version 0.3 to 0.6 and noticed that reading YAML files which contain resource quantities (such as pods with resource constraints) would fail.

The difference appears to be that in 0.3, resource quantities were treated as `string` values and in 0.6 they are treated as first-class citizens.

However, no YAML serialization/deserialization was present for ResourceQuantity objects and hence (de)serialization would fail.

This PR fixes that problem by implementing the `IYamlConvertible` interface.

Unit tests are included; to be able to test serialization I also added the `Yaml.WriteToString` method.