### PR TITLE
Don't throw in StreamDemuxer.Dispose

### DIFF
--- a/src/StreamDemuxer.cs
+++ b/src/StreamDemuxer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
@@ -29,10 +30,18 @@ namespace k8s
 
         public void Dispose()
         {
-            if (this.runLoop != null)
+            try
             {
-                this.cts.Cancel();
-                this.runLoop.Wait();
+                if (this.runLoop != null)
+                {
+                    this.cts.Cancel();
+                    this.runLoop.Wait();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Dispose methods can never throw.
+                Debug.Write(ex);
             }
         }
 


### PR DESCRIPTION
In `StreamMuxer.Dispose`,  we cancel the run loop and wait for the run loop to complete.
If the run loop exists with an exception, `this.runloop.Wait()` will cause that exception to be rethrown.
However, Dispose methods should never throw - see https://msdn.microsoft.com/en-us/library/bb386039.aspx.

This PR adds a try/catch statement.