### PR TITLE
Run integration tests as part of CI (after #129)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ before_install:
 
 script:
   - ./ci.sh
+
+after_script:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./integration-tests.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
 language: csharp
 mono: none
 env:
-  - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_TELEMETRY_OPTOUT=1
+  - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_TELEMETRY_OPTOUT=1 COMPlus_UseManagedHttpClientHandler=true
 
 # We need the .NET Core 2.1 (preview 1) SDK to build. Travis doesn't know how to install this yet.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
+sudo: required
+dist: trusty
+
+os:
+  - osx
+  - linux
+
 language: csharp
-sudo: false
-matrix:
-  include:
-    - mono: none
-      dist: trusty
-      # We need the .NET Core 2.1 (preview 1) SDK to build. Travis doesn't know how to install this yet.
-      before_install:
-      - echo 'Installing .NET Core...'
-      - export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-      - export DOTNET_CLI_TELEMETRY_OPTOUT=1
-      - curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-      - sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-      - sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
-      - sudo apt-get -qq update
-      - sudo apt-get install -y dotnet-sdk-2.1.300-preview1-008174
+mono: none
+env:
+  - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# We need the .NET Core 2.1 (preview 1) SDK to build. Travis doesn't know how to install this yet.
+before_install:
+  - ./install-$TRAVIS_OS_NAME.sh
 
 script:
   - ./ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,16 @@ os:
 language: csharp
 mono: none
 env:
-  - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_TELEMETRY_OPTOUT=1 COMPlus_UseManagedHttpClientHandler=true
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+    - DOTNET_CLI_TELEMETRY_OPTOUT=1
+    - COMPlus_UseManagedHttpClientHandler=true
+
+# minikube-related changes
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - KUBECONFIG=/home/travis/.kube/config
 
 # We need the .NET Core 2.1 (preview 1) SDK to build. Travis doesn't know how to install this yet.
 before_install:

--- a/examples/nginx.yml
+++ b/examples/nginx.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.7.9
+    ports:
+    - containerPort: 80

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,0 +1,8 @@
+echo 'Installing .NET Core...'
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+sudo apt-get -qq update
+sudo apt-get install -y dotnet-sdk-2.1.300-preview1-008174

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,8 +1,27 @@
+#!/bin/sh
 echo 'Installing .NET Core...'
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-get -qq update
 sudo apt-get install -y dotnet-sdk-2.1.300-preview1-008174
+
+echo 'Installing kubecl'
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+
+echo 'Installing minikube'
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+
+echo 'Creating the minikube cluster'
+sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
+minikube update-context
+minikube addons disable dashboard
+
+echo 'Waiting for the cluster nodes to be ready'
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
+  until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo 'Installing .NET Core...'
+
+wget https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg -O ~/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg
+sudo installer -pkg ~/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg -target /
+
+# https://github.com/dotnet/cli/issues/2544
+ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+cd examples
+
+echo 'Creating a nginx pod in the default namespace'
+kubectl create -f nginx.yml
+
+echo 'Running the simple example'
+cd simple
+dotnet run
+
+echo 'Running the exec example'
+cd ../exec
+dotnet run
+
+echo 'Running the labels example'
+cd ../labels
+dotnet run
+
+echo 'Running the namespace example'
+cd ../namespace
+dotnet run

--- a/src/Kubernetes.WebSocket.cs
+++ b/src/Kubernetes.WebSocket.cs
@@ -216,12 +216,16 @@ namespace k8s
                 webSocketBuilder.AddClientCertificate(cert);
             }
 
-            HttpRequestMessage message = new HttpRequestMessage();
-            await this.Credentials.ProcessHttpRequestAsync(message, cancellationToken);
-
-            foreach (var _header in message.Headers)
+            if (this.Credentials != null)
             {
-                webSocketBuilder.SetRequestHeader(_header.Key, string.Join(" ", _header.Value));
+                // Copy the default (credential-related) request headers from the HttpClient to the WebSocket
+                HttpRequestMessage message = new HttpRequestMessage();
+                await this.Credentials.ProcessHttpRequestAsync(message, cancellationToken);
+
+                foreach (var _header in message.Headers)
+                {
+                    webSocketBuilder.SetRequestHeader(_header.Key, string.Join(" ", _header.Value));
+                }
             }
 
 #if NETCOREAPP2_1


### PR DESCRIPTION
We spent some time paying off our technical debt this week. That included upgrading to the latest version of the C# Kubernetes client, Kubernetes and .NET Core 2.1 Preview.

Quite a few things broke, especially in stuff related to WebSockets and SSL. Things broke in different ways on Windows, Mac and Linux.

Hence, we thought it might be useful to add integration tests to the kubernetes-csharp client. This PR adds that for Travis on Linux, using minikube. I assume we can replicate the same behavior on macOS, too, but that's not included here.

It'll take a couple of commits to get things right, so please bear with me.