### PR TITLE
Don't throw an exception on MuxedStream.Flush

### DIFF
--- a/src/KubernetesClient/MuxedStream.cs
+++ b/src/KubernetesClient/MuxedStream.cs
@@ -62,7 +62,8 @@ namespace k8s
 
         public override void Flush()
         {
-            throw new NotSupportedException();
+            // Whenever we call muxer.Write, a message is immediately sent over the wire, so we don't need/support flushing.
+            // Implement flushing as a no-op operation as opposed to throwing a NotSupportedException.
         }
 
         public override long Seek(long offset, SeekOrigin origin)


### PR DESCRIPTION
The `MuxedStream` class currently throws a `NotSupportedException` on `Flush`.

However, since all data which is written to this stream is immediately sent to the remote server (e.g. there is no local buffering/queueing), `Flush` can be implemented as a no-op.

This fix is useful when people use other classes, such as `StreamWriter`, on top of a `MuxedStream`. `StreamWriter` will call `.Flush` so throwing there would break things.