### PR TITLE
Add support for watching individual objects.

### DIFF
--- a/src/KubernetesClient/IKubernetes.Watch.cs
+++ b/src/KubernetesClient/IKubernetes.Watch.cs
@@ -1,0 +1,748 @@
+using k8s.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    public partial interface IKubernetes
+    {
+        /// <summary>
+        /// Watch changes to an object of kind ConfigMap
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1ConfigMap>> WatchNamespacedConfigMapAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1ConfigMap> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind Endpoints
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1Endpoints>> WatchNamespacedEndpointAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Endpoints> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind Event
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1Event>> WatchNamespacedEventAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Event> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind LimitRange
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1LimitRange>> WatchNamespacedLimitRangeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1LimitRange> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind Namespace
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1Namespace>> WatchNamespaceAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Namespace> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind Node
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1Node>> WatchNodeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Node> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind PersistentVolumeClaim
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1PersistentVolumeClaim>> WatchNamespacedPersistentVolumeClaimAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PersistentVolumeClaim> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind PersistentVolume
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1PersistentVolume>> WatchPersistentVolumeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PersistentVolume> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind Pod
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1Pod>> WatchNamespacedPodAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Pod> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind PodTemplate
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1PodTemplate>> WatchNamespacedPodTemplateAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PodTemplate> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Watch changes to an object of kind ReplicationController
+        /// </summary>
+        /// <param name="name">
+        /// name of the ConfigMap
+        /// </param>
+        /// <param name="namespace">
+        /// object name and auth scope, such as for teams and projects
+        /// </param>
+        /// <param name="continue">
+        /// The continue option should be set when retrieving more results from the server.
+        /// Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters
+        /// (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is
+        /// no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will
+        /// respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not
+        /// supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+        /// </param>
+        /// <param name="fieldSelector">
+        /// A selector to restrict the list of returned objects by their fields. Defaults to everything.
+        /// </param>
+        /// <param name="includeUninitialized">
+        /// If true, partially initialized resources are included in the response.
+        /// </param>
+        /// <param name="labelSelector">
+        /// A selector to restrict the list of returned objects by their labels. Defaults to everything.
+        /// </param>
+        /// <param name="limit">
+        /// limit is a maximum number of responses to return for a list call.
+        /// If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results.
+        /// Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the
+        /// presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results.
+        /// If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+        /// The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or
+        /// deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client
+        /// that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object
+        /// that was present at the time the first list result was calculated is returned
+        /// </param>
+        /// <param name="pretty">
+        /// If 'true', then the output is pretty printed.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+        /// </param>
+        /// <param name="resourceVersion">
+        /// When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.
+        /// When specified for list:
+        /// - if unset, then the result is returned from remote storage based on quorum-read flag;
+        /// - if it's 0, then we simply return what we currently have in cache, no guarantee;
+        /// - if set to non zero, then the result is at least as fresh as given rv.
+        /// </param>
+        /// <param name="customHeaders">
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation, and returns a new watcher.
+        /// </returns>
+        Task<Watcher<V1ReplicationController>> WatchNamespacedReplicationControllerAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1ReplicationController> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/KubernetesClient/Kubernetes.Watch.cs
+++ b/src/KubernetesClient/Kubernetes.Watch.cs
@@ -1,0 +1,243 @@
+using k8s.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Rest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    public partial class Kubernetes
+    {
+        /// <inheritdoc/>
+        public Task<Watcher<V1ConfigMap>> WatchNamespacedConfigMapAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1ConfigMap> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1ConfigMap>("configmaps", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1Endpoints>> WatchNamespacedEndpointAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Endpoints> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1Endpoints>("endpoints", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1Event>> WatchNamespacedEventAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Event> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1Event>("events", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1LimitRange>> WatchNamespacedLimitRangeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1LimitRange> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1LimitRange>("limitranges", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1Namespace>> WatchNamespaceAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Namespace> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchObjectAsync<V1Namespace>("namespaces", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1Node>> WatchNodeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Node> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchObjectAsync<V1Node>("nodes", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1PersistentVolumeClaim>> WatchNamespacedPersistentVolumeClaimAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PersistentVolumeClaim> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1PersistentVolumeClaim>("persistentvolumeclaims", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1PersistentVolume>> WatchPersistentVolumeAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PersistentVolume> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchObjectAsync<V1PersistentVolume>("persistentvolumes", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1Pod>> WatchNamespacedPodAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1Pod> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1Pod>("pods", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1PodTemplate>> WatchNamespacedPodTemplateAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1PodTemplate> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1PodTemplate>("podtemplates", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<Watcher<V1ReplicationController>> WatchNamespacedReplicationControllerAsync(string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, V1ReplicationController> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WatchNamespacedObjectAsync<V1ReplicationController>("replicationcontrollers", name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+        
+        public Task<Watcher<T>> WatchNamespacedObjectAsync<T>(string resourceType, string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, T> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+
+            if (@namespace == null)
+            {
+                throw new ArgumentNullException(nameof(@namespace));
+            }
+
+            return WatchObjectAsync<T>(resourceType, name, @namespace, @continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, timeoutSeconds, resourceVersion, customHeaders, onEvent, onError, cancellationToken);
+        }
+
+        public async Task<Watcher<T>> WatchObjectAsync<T>(string resourceType, string name, string @namespace, string @continue = null, string fieldSelector = null, bool? includeUninitialized = null, string labelSelector = null, int? limit = null, bool? pretty = null, int? timeoutSeconds = null, int? resourceVersion = null, Dictionary<string, List<string>> customHeaders = null, Action<WatchEventType, T> onEvent = null, Action<Exception> onError = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("name", name);
+                tracingParameters.Add("namespace", @namespace);
+                tracingParameters.Add("continue", @continue);
+                tracingParameters.Add("fieldSelector", fieldSelector);
+                tracingParameters.Add("includeUninitialized", includeUninitialized);
+                tracingParameters.Add("labelSelector", labelSelector);
+                tracingParameters.Add("limit", limit);
+                tracingParameters.Add("pretty", pretty);
+                tracingParameters.Add("timeoutSeconds", timeoutSeconds);
+                tracingParameters.Add("resourceVersion", resourceVersion);
+                ServiceClientTracing.Enter(_invocationId, this, nameof(WatchNamespacedPodAsync), tracingParameters);
+            }
+
+            // Construct URL
+            var uriBuilder = new UriBuilder(this.BaseUri);
+            if (!uriBuilder.Path.EndsWith("/"))
+            {
+                uriBuilder.Path += "/";
+            }
+
+            uriBuilder.Path += "api/v1/watch";
+
+            if (@namespace != null)
+            {
+                uriBuilder.Path += $"/namespaces/{@namespace}";
+            }
+
+            uriBuilder.Path += $"/{resourceType}/{name}";
+
+            var query = string.Empty;
+
+            // Don't sent watch, because setting that value will cause the WatcherDelegatingHandler to kick in. That class
+            // "eats" the first line, which is something we don't want.
+            // query = QueryHelpers.AddQueryString(query, "watch", "true");
+
+            if (@continue != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "continue", Uri.EscapeDataString(@continue));
+            }
+
+            if (fieldSelector != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "fieldSelector", Uri.EscapeDataString(fieldSelector));
+            }
+
+            if (includeUninitialized != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "includeUninitialized", includeUninitialized.Value ? "true" : "false");
+            }
+
+            if (labelSelector != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "labelSelector", Uri.EscapeDataString(labelSelector));
+            }
+
+            if (limit != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "limit", limit.Value.ToString());
+            }
+
+            if (pretty != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "pretty", pretty.Value ? "true" : "false");
+            }
+
+            if (timeoutSeconds != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "timeoutSeconds", timeoutSeconds.Value.ToString());
+            }
+
+            if (resourceVersion != null)
+            {
+                query = QueryHelpers.AddQueryString(query, "resourceVersion", resourceVersion.Value.ToString());
+            }
+
+            uriBuilder.Query = query;
+
+            // Create HTTP transport objects
+            var httpRequest = new HttpRequestMessage(HttpMethod.Get, uriBuilder.ToString());
+
+            // Set Credentials
+            if (this.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await this.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Set Headers
+            if (customHeaders != null)
+            {
+                foreach (var header in customHeaders)
+                {
+                    if (httpRequest.Headers.Contains(header.Key))
+                    {
+                        httpRequest.Headers.Remove(header.Key);
+                    }
+
+                    httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, httpRequest);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var httpResponse = await HttpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, httpResponse);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (httpResponse.StatusCode != HttpStatusCode.OK)
+            {
+                string responseContent = string.Empty;
+
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", httpResponse.StatusCode));
+                if (httpResponse.Content != null)
+                {
+                    responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+
+                ex.Request = new HttpRequestMessageWrapper(httpRequest, responseContent);
+                ex.Response = new HttpResponseMessageWrapper(httpResponse, string.Empty);
+
+                httpRequest.Dispose();
+                httpResponse?.Dispose();
+                throw ex;
+            }
+
+            var stream = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            StreamReader reader = new StreamReader(stream);
+
+            return new Watcher<T>(reader, onEvent, onError);
+        }
+    }
+}


### PR DESCRIPTION
This adds support for the `/api/v1/watch/[namespaces/{namespace}]/{objectType}/{name}` watchers.
Currently includes for v1 objects only.

The heavy lifting is done in the `WatchObjectAsync<T>` method, so support for  other objects can be added fairly easily.