### PR TITLE
Use automatic versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+# Don't do shallow clones
+git:
+  depth: false
+
 os:
   - osx
   - linux

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.7.0-beta</PackageVersion>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>
     <Description>Client library for the Kubernetes open source container orchestrator.</Description>
@@ -17,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Fractions" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.7.0-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+  ],
+}


### PR DESCRIPTION
Currently, the version of the C# client is updated manually by editing `KubernetesClient.csproj`.

That's fine, but if you're working with interim versions of the package you'll need to manually update the version every time you push a new version to a feed.

This PR updates the process so that it uses [NerdBank.GitVersioning](https://github.com/AArnott/Nerdbank.GitVersioning) to automatically generate version numbers.

Roughly, the idea is:
1. In `version.json`, you specify the 'official' version (such as 0.7.0-beta)
2. If you build from a clean checkout of master, you'll get a version number like 0.7.0-beta.{gitHeight}, where gitHeight is the number of commits to master since you last changed the version number.
3. If you build from anything else, the Git SHA commit will be added

For bonus points, the NerdBank.GitVersioning will always inject certain information, such as the Git commit ID, as assembly attributes, so you can always trace back a version of the .dll to a Git commit.

The dependency is marked as `PrivateAssets="all"` so that it is a development dependency only; consumers of this library do not need to install NerdBank.GitVersioning.