### PR TITLE
Handle error messages in the watcher

### DIFF
--- a/src/KubernetesClient/KubernetesException.cs
+++ b/src/KubernetesClient/KubernetesException.cs
@@ -12,12 +12,19 @@ namespace k8s
     public class KubernetesException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="EtcdException"/> class.
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class.
         /// </summary>
         public KubernetesException()
         {
         }
 
+        /// <summary>
+        /// Initializes a ne winstance of the <see cref="KubernetesException"/> class using
+        /// the data from a <see cref="V1Status"/> object.
+        /// </summary>
+        /// <param name="status">
+        /// A status message which triggered this exception to be thrown.
+        /// </param>
         public KubernetesException(V1Status status)
             : this(status?.Message)
         {
@@ -25,7 +32,7 @@ namespace k8s
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EtcdException"/> class with an error message.
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class with an error message.
         /// </summary>
         /// <param name="message">
         /// The error message that explains the reason for the exception.
@@ -36,7 +43,7 @@ namespace k8s
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EtcdException"/> class with a specified error
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class with a specified error
         /// message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
@@ -53,7 +60,7 @@ namespace k8s
 
 #if !NETSTANDARD1_4
         /// <summary>
-        /// Initializes a new instance of the <see cref="EtcdException"/> class with serialized data.
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class with serialized data.
         /// </summary>
         /// <param name="info">
         /// The <see cref="SerializationInfo"/> that holds the serialized

--- a/src/KubernetesClient/KubernetesException.cs
+++ b/src/KubernetesClient/KubernetesException.cs
@@ -49,9 +49,9 @@ namespace k8s
         /// <param name="message">
         /// The error message that explains the reason for the exception.
         /// </param>
-        /// <param name="inner">
+        /// <param name="innerException">
         /// The exception that is the cause of the current exception, or <see langword="null"/>
-        ///  if no inner exception is specified.
+        /// if no inner exception is specified.
         /// </param>
         public KubernetesException(string message, Exception innerException)
             : base(message, innerException)

--- a/src/KubernetesClient/KubernetesException.cs
+++ b/src/KubernetesClient/KubernetesException.cs
@@ -1,0 +1,82 @@
+using k8s.Models;
+using System;
+#if !NETSTANDARD1_4
+using System.Runtime.Serialization;
+#endif
+
+namespace k8s
+{
+    /// <summary>
+    /// Represents an error message returned by the Kubernetes API server.
+    /// </summary>
+    public class KubernetesException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EtcdException"/> class.
+        /// </summary>
+        public KubernetesException()
+        {
+        }
+
+        public KubernetesException(V1Status status)
+            : this(status?.Message)
+        {
+            this.Status = status;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EtcdException"/> class with an error message.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        public KubernetesException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EtcdException"/> class with a specified error
+        /// message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="inner">
+        /// The exception that is the cause of the current exception, or <see langword="null"/>
+        ///  if no inner exception is specified.
+        /// </param>
+        public KubernetesException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if !NETSTANDARD1_4
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EtcdException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the serialized
+        /// object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains contextual information
+        /// about the source or destination.
+        /// </param>
+        protected KubernetesException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Gets, when this exception was raised because of a Kubernetes status message, the underlying
+        /// Kubernetes status message.
+        /// </summary>
+        public V1Status Status
+        {
+            get;
+            private set;
+        }
+    }
+}

--- a/src/KubernetesClient/KubernetesObject.cs
+++ b/src/KubernetesClient/KubernetesObject.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace k8s
+{
+    /// <summary>
+    /// Represents a generic Kubernetes object.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="KubernetesObject"/> if you receive JSON from a Kubernetes API server but
+    /// are unsure which object the API server is about to return. You can parse the JSON as a <see cref="KubernetesObject"/>
+    /// and use the <see cref="ApiVersion"/> and <see cref="Kind"/> properties to get basic metadata about any Kubernetes object.
+    /// You can then 
+    /// </remarks>
+    public class KubernetesObject
+    {
+        /// <summary>
+        /// Gets or sets aPIVersion defines the versioned schema of this
+        /// representation of an object. Servers should convert recognized
+        /// schemas to the latest internal value, and may reject unrecognized
+        /// values. More info:
+        /// https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+        /// </summary>
+        [JsonProperty(PropertyName = "apiVersion")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets kind is a string value representing the REST resource
+        /// this object represents. Servers may infer this from the endpoint
+        /// the client submits requests to. Cannot be updated. In CamelCase.
+        /// More info:
+        /// https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+        /// </summary>
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+    }
+}

--- a/tests/KubernetesClient.Tests/WatcherTests.cs
+++ b/tests/KubernetesClient.Tests/WatcherTests.cs
@@ -1,0 +1,45 @@
+using k8s.Models;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace k8s.tests
+{
+    public class WatcherTests
+    {
+        [Fact]
+        public void ReadError()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("{\"type\":\"ERROR\",\"object\":{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"too old resource version: 44982(53593)\",\"reason\":\"Gone\",\"code\":410}}");
+
+            using (MemoryStream stream = new MemoryStream(data))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                Exception recordedException = null;
+                ManualResetEvent mre = new ManualResetEvent(false);
+
+                Watcher<V1Pod> watcher = new Watcher<V1Pod>(
+                    reader,
+                    null,
+                    (exception) =>
+                    {
+                        recordedException = exception;
+                        mre.Set();
+                    });
+
+                mre.WaitOne();
+
+                Assert.NotNull(recordedException);
+
+                var k8sException = recordedException as KubernetesException;
+
+                Assert.NotNull(k8sException);
+                Assert.NotNull(k8sException.Status);
+                Assert.Equal("too old resource version: 44982(53593)", k8sException.Message);
+                Assert.Equal("too old resource version: 44982(53593)", k8sException.Status.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `Watcher` currently always expects `WatchEvent<T>` messages to be sent by the server (e.g. `WatchEvent<V1Pod>`).

That's not always the case, the server may also respond with a `WatchEvent<V1Status>` message in case an error occured. For example, if the resourceVersion set in the watch request is outdated, you may get a `HTTP 200` response with a single Error event - see https://github.com/kubernetes/kubernetes/pull/25369. 

This PR makes the watcher handle that scenario a bit better:
- It introduces a generic `KubernetesObject` class which you can use to parse _any_ JSON object returned by the Kubernetes API server. It exposes the ApiVersion and Kind properties which help you determine what object type is actually being returned.
- It introduces a `KubernetesException` object which wraps an `V1Status` message. That's useful because the Watcher currently uses `Exception` objects to relay errors.
- Updates the `Watcher` class to parse the JSON as a `KubernetesObject`,  and decide whether it's an error message or not, and handle things properly from there.
- Makes the constructor for the `Watcher` public. This helps with unit testing & will also help others when mocking, extending,...

A unit test is included.