### PR TITLE
Allow CI to push to NuGet feeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,11 @@ script:
 
 after_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./integration-tests.sh; fi
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: dotnet nuget push src/KubernetesClient/bin/Release/KubernetesClient.*.nupkg --api-key $NUGET_API_KEY --source $NUGET_SOURCE
+  on:
+    branch: master
+    condition: '"x${NUGET_API_KEY}" != "x" && "x$NUGET_SOURCE" != "x" && "$TRAVIS_OS_NAME" == "linux"'

--- a/ci.sh
+++ b/ci.sh
@@ -6,8 +6,14 @@ set -e
 # Ensure no compile errors in all projects
 find . -name *.csproj -exec dotnet build {} \;
 
+# Create the NuGet package
+cd src/KubernetesClient/
+dotnet pack -c Release
+cd ../..
+
 # Execute Unit tests
 cd tests/KubernetesClient.Tests
 dotnet restore
 dotnet test
 
+cd ../..


### PR DESCRIPTION
The C# client for Kubernetes is changing rapidly and I often find myself in a scenario where I want to use a version which is newer than what is available on NuGet.org.

This PR adds a deployment step to the Travis CI script which will push builds of the master branch to a NuGet repository (it can be any NuGet repository feed, such as NuGet.org or MyGet), if the `NUGET_API_KEY` and `NUGET_SOURCE` environment variables are set. You would normally set those via the Travis job options.

This allows for a couple of scenarios:
1. For the upstream kubernets-client/sharp repository, nothing changes (the PR is a no-op) becuase `NUGET_API_KEY` and `NUGET_SOURCE` are not set.
2. Anyone can mirror the repo, set up Travis builds, and have Travis push builds to a MyGet/NuGet/VSTS/... feed. For example, I've set up a MyGet feed at https://www.myget.org/feed/Packages/kubernetes-client
3. This project could set up a MyGet feed with NuGet packages based off the latest code in master. It would requiring setting up a feed on MyGet (or an alternative) and updating the `NUGET_API_KEY` and `NUGET_SOURCE` variables.

It would be cool if option 3 would become reality 😄.