### PR TITLE
Upgrade to .NET Core 2.1 RC1

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -5,7 +5,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-get -qq update
-sudo apt-get install -y dotnet-sdk-2.1.300-preview2-008533 
+sudo apt-get install -y dotnet-sdk-2.1.300-rc1-008673
 
 echo 'Installing kubecl'
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 echo 'Installing .NET Core...'
 
-wget https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg -O ~/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg
-sudo installer -pkg ~/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg -target /
+wget https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.300-rc1-008673/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg -O ~/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg
+sudo installer -pkg ~/dotnet-sdk-2.1.300-rc1-008673-osx-x64.pkg -target /
 
 # https://github.com/dotnet/cli/issues/2544
 ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/


### PR DESCRIPTION
.NET Core 2.1 RC1 is being released, so let's try to use that instead of preview2.