### PR TITLE
Fix an issue where growing the ByteBuffer would fail

### DIFF
--- a/src/KubernetesClient/ByteBuffer.cs
+++ b/src/KubernetesClient/ByteBuffer.cs
@@ -287,22 +287,19 @@ namespace k8s
 
             var newBuffer = ArrayPool<byte>.Shared.Rent(size);
 
-            if (this.WriteWaterMark <= this.ReadWaterMark)
+            if (this.WriteWaterMark < this.ReadWaterMark)
             {
                 // Copy the data at the start
                 Array.Copy(this.buffer, 0, newBuffer, 0, this.WriteWaterMark);
 
-                if (this.ReadWaterMark > 0)
-                {
-                    int trailingDataLength = this.buffer.Length - this.ReadWaterMark;
-                    Array.Copy(this.buffer,
-                        sourceIndex: this.ReadWaterMark,
-                        destinationArray: newBuffer,
-                        destinationIndex: newBuffer.Length - trailingDataLength,
-                        length: trailingDataLength);
+                int trailingDataLength = this.buffer.Length - this.ReadWaterMark;
+                Array.Copy(this.buffer,
+                    sourceIndex: this.ReadWaterMark,
+                    destinationArray: newBuffer,
+                    destinationIndex: newBuffer.Length - trailingDataLength,
+                    length: trailingDataLength);
 
-                    this.ReadWaterMark += newBuffer.Length - this.buffer.Length;
-                }
+                this.ReadWaterMark += newBuffer.Length - this.buffer.Length;
             }
             else
             {

--- a/src/KubernetesClient/ByteBuffer.cs
+++ b/src/KubernetesClient/ByteBuffer.cs
@@ -68,6 +68,14 @@ namespace k8s
         }
 
         /// <summary>
+        /// Gets the maximum allowed size of the buffer.
+        /// </summary>
+        public int MaximumSize
+        {
+            get { return this.maximumSize; }
+        }
+
+        /// <summary>
         /// Gets the offset from which the next byte will be read. Increased every time a caller reads data.
         /// </summary>
         public int ReadWaterMark
@@ -260,6 +268,11 @@ namespace k8s
         }
 
         /// <summary>
+        /// The event which is raised when the buffer is resized.
+        /// </summary>
+        public event EventHandler OnResize;
+
+        /// <summary>
         /// Increases the buffer size. Any call to this method must be protected with a lock.
         /// </summary>
         /// <param name="size">
@@ -279,14 +292,17 @@ namespace k8s
                 // Copy the data at the start
                 Array.Copy(this.buffer, 0, newBuffer, 0, this.WriteWaterMark);
 
-                int trailingDataLength = this.buffer.Length - this.ReadWaterMark;
-                Array.Copy(this.buffer,
-                    sourceIndex: this.ReadWaterMark,
-                    destinationArray: newBuffer,
-                    destinationIndex: newBuffer.Length - trailingDataLength,
-                    length: trailingDataLength);
+                if (this.ReadWaterMark > 0)
+                {
+                    int trailingDataLength = this.buffer.Length - this.ReadWaterMark;
+                    Array.Copy(this.buffer,
+                        sourceIndex: this.ReadWaterMark,
+                        destinationArray: newBuffer,
+                        destinationIndex: newBuffer.Length - trailingDataLength,
+                        length: trailingDataLength);
 
-                this.ReadWaterMark += newBuffer.Length - this.buffer.Length;
+                    this.ReadWaterMark += newBuffer.Length - this.buffer.Length;
+                }
             }
             else
             {
@@ -298,6 +314,7 @@ namespace k8s
             this.buffer = newBuffer;
 
             Debug.Assert(this.bytesRead + this.AvailableReadableBytes == this.bytesWritten);
+            this.OnResize?.Invoke(this, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
There was a bug in the `ByteBuffer` class where growing the buffer would fail if the read water mark was 0.

Having the read water mark at 0 means that there is no data available to read, but this was incorrectly treated as "all data in the buffer is available for reading".

I added a couple of extra unit tests for this behavior.