### PR TITLE
Generate XML documentation for the KubernetesClient project

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>
@@ -14,6 +14,8 @@
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>kubernetes-client.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+      <NoWarn>1701;1702;1591;1570;1572;1573;1574</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -15,7 +15,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>kubernetes-client.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-      <NoWarn>1701;1702;1591;1570;1572;1573;1574</NoWarn>
+    <NoWarn>1701;1702;1591;1570;1572;1573;1574</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The code generates do a lot of work to generate code documentation which can show up in IntelliSense in Visual Studio.

However, the XML documentation for the KubernetesClient project was not being generated, so consumers of the KubernetesClient project wouldn't get IntelliSense.

This PR enables XML documentation (and suppresses the warnings for missing/invalid/... documentation, as most of it is auto-generated).