### PR TITLE
Bump version to 1.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
   ],


### PR DESCRIPTION
Current builds from master will be marked as 1.0.0-something, which NuGet considers to be prerelease versions of 1.0.0 (and hence older than the currently released 1.0.0 version).

This PR changes the version number so that new packages will be versioned `1.1-something`.

NuGet will then detect them as:
- Newer than 1.0.0
- Prerelease versions