### PR TITLE
Use the Git height as the third component in the version number

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
   ],


### PR DESCRIPTION
At the moment, the version in `version.json` is set to `1.1.0`. It causes the NerdBank.GitVersioning plugin to always append the Git Commit ID to the package number, such as `1.1.0-gf488d54ce7`.

That doesn't make for very good version numbers because you can't tell which version is newer by looking at the Git Commit ID.

If you specify _two_ version numbers (`1.1`), NerdBank.GitVersioning will set the third number to be the 'git height', which is the number of commits since you last increased the version number. So that would be `1.1.0`, `1.1.1`, and so on.
Plus, when releasing form branches other than `master`,  a `-{commitId}` suffix would be added, used to mark the version as prerelease.

https://github.com/AArnott/Nerdbank.GitVersioning/blob/master/doc/versionJson.md explains it better.