### PR TITLE
Fix up YAML serialisation to understand AutoRest property renaming

### DIFF
--- a/src/KubernetesClient/Yaml.cs
+++ b/src/KubernetesClient/Yaml.cs
@@ -1,4 +1,8 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using YamlDotNet.Core;
@@ -29,6 +33,7 @@ namespace k8s
             var deserializer =
                 new DeserializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeInspector(ti => new AutoRestTypeInspector(ti))
                 .Build();
             var obj = deserializer.Deserialize<T>(content);
             return obj;
@@ -43,12 +48,96 @@ namespace k8s
             var serializer =
                 new SerializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeInspector(ti => new AutoRestTypeInspector(ti))
                 .BuildValueSerializer();
             emitter.Emit(new StreamStart());
             emitter.Emit(new DocumentStart());
             serializer.SerializeValue(emitter, value, typeof(T));
 
             return stringBuilder.ToString();
+        }
+
+        private class AutoRestTypeInspector : ITypeInspector
+        {
+            private readonly ITypeInspector _inner;
+
+            public AutoRestTypeInspector(ITypeInspector inner)
+            {
+                _inner = inner;
+            }
+
+            public IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+            {
+                var pds = _inner.GetProperties(type, container);
+                return pds.Select(pd => TrimPropertySuffix(pd, type)).ToList();
+            }
+
+            public IPropertyDescriptor GetProperty(Type type, object container, string name, bool ignoreUnmatched)
+            {
+                try
+                {
+                    return _inner.GetProperty(type, container, name, ignoreUnmatched);
+                }
+                catch (System.Runtime.Serialization.SerializationException)
+                {
+                    return _inner.GetProperty(type, container, name + "Property", ignoreUnmatched);
+                }
+            }
+
+            private IPropertyDescriptor TrimPropertySuffix(IPropertyDescriptor pd, Type type)
+            {
+                if (!pd.Name.EndsWith("Property"))
+                {
+                    return pd;
+                }
+
+                // This might have been renamed by AutoRest.  See if there is a
+                // JsonPropertyAttribute.PropertyName and use that instead if there is.
+                var jpa = pd.GetCustomAttribute<JsonPropertyAttribute>();
+                if (jpa == null || String.IsNullOrEmpty(jpa.PropertyName))
+                {
+                    return pd;
+                }
+
+                return new RenamedPropertyDescriptor(pd, jpa.PropertyName);
+            }
+
+            private class RenamedPropertyDescriptor : IPropertyDescriptor
+            {
+                private readonly IPropertyDescriptor _inner;
+                private readonly string _name;
+
+                public RenamedPropertyDescriptor(IPropertyDescriptor inner, string name)
+                {
+                    _inner = inner;
+                    _name = name;
+                }
+
+                public string Name => _name;
+
+                public bool CanWrite => _inner.CanWrite;
+
+                public Type Type => _inner.Type;
+
+                public Type TypeOverride { get => _inner.TypeOverride; set => _inner.TypeOverride = value; }
+                public int Order { get => _inner.Order; set => _inner.Order = value; }
+                public ScalarStyle ScalarStyle { get => _inner.ScalarStyle; set => _inner.ScalarStyle = value; }
+
+                public T GetCustomAttribute<T>() where T : Attribute
+                {
+                    return _inner.GetCustomAttribute<T>();
+                }
+
+                public IObjectDescriptor Read(object target)
+                {
+                    return _inner.Read(target);
+                }
+
+                public void Write(object target, object value)
+                {
+                    _inner.Write(target, value);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
AutoRest renames properties such as 'namespace' and 'readOnly' to avoid clashes with keywords in common .NET languages.  It uses `JsonPropertyAttribute` to map these back to the right names in JSON.  However, the YAML serialiser isn't aware of the JSON mappings, so loading YAML including such properties fails (similarly, writing them out produces the wrong YAML text).  This PR adds a custom type inspector to the YAML serialisation stack which performs the additional mapping needed.

Fixes #208.