### PR TITLE
fix a race condition.

### DIFF
--- a/src/KubernetesClient/StreamDemuxer.cs
+++ b/src/KubernetesClient/StreamDemuxer.cs
@@ -98,9 +98,9 @@ namespace k8s
         /// </returns>
         public Stream GetStream(byte? inputIndex, byte? outputIndex)
         {
-            if (inputIndex != null && !this.buffers.ContainsKey(inputIndex.Value))
+            lock (this.buffers)
             {
-                lock (this.buffers)
+                if (inputIndex != null && !this.buffers.ContainsKey(inputIndex.Value))
                 {
                     var buffer = new ByteBuffer();
                     this.buffers.Add(inputIndex.Value, buffer);


### PR DESCRIPTION
when multiple call to GetStream happens around the same time, on the
same inputIndex, a race condition will cause this.buffers.Add() to throw
exception.