### PR TITLE
Create KubernetesClientConfiguration from pre-loaded K8SConfiguration

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -39,6 +39,7 @@ namespace k8s
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesClientConfiguration" /> from config file
         /// </summary>
         /// <param name="kubeconfig">Fileinfo of the kubeconfig, cannot be null</param>
         /// <param name="currentContext">override the context in config file, set null if do not want to override</param>
@@ -60,8 +61,9 @@ namespace k8s
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesClientConfiguration" /> from config file
         /// </summary>
-        /// <param name="kubeconfig">Fileinfo of the kubeconfig, cannot be null, whitespaced or empty</param>
+        /// <param name="kubeconfig">Stream of the kubeconfig, cannot be null</param>
         /// <param name="currentContext">override the context in config file, set null if do not want to override</param>
         /// <param name="masterUrl">overrider kube api server endpoint, set null if do not want to override</param>
         public static KubernetesClientConfiguration BuildConfigFromConfigFile(Stream kubeconfig,
@@ -84,6 +86,15 @@ namespace k8s
 
             return k8SConfiguration;
         }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="KubernetesClientConfiguration"/> from pre-loaded config object.
+        /// </summary>
+        /// <param name="k8sConfig">A <see cref="K8SConfiguration"/>, for example loaded from <see cref="LoadKubeConfigAsync(string, bool)" /></param>
+        /// <param name="currentContext">Override the current context in config, set null if do not want to override</param>
+        /// <param name="masterUrl">overrider kube api server endpoint, set null if do not want to override</param>
+        public static KubernetesClientConfiguration BuildConfig(K8SConfiguration k8SConfig, string currentContext = null, string masterUrl = null)
+            => GetKubernetesClientConfiguration(currentContext, masterUrl, k8SConfig);
 
         private static KubernetesClientConfiguration GetKubernetesClientConfiguration(string currentContext, string masterUrl, K8SConfiguration k8SConfig)
         {

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -138,6 +138,14 @@ namespace k8s.Tests
                 KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, "context-not-found"));
         }
 
+        [Fact]
+        public void CreatedFromPreLoadedConfig()
+        {
+            var k8sConfig = KubernetesClientConfiguration.LoadKubeConfig(new FileInfo("assets/kubeconfig.yml"), useRelativePaths: false);
+            var cfg = KubernetesClientConfiguration.BuildConfig(k8sConfig);
+            Assert.NotNull(cfg.Host);
+        }
+
         /// <summary>
         ///     Checks Host is loaded from the default configuration file
         /// </summary>
@@ -295,6 +303,32 @@ namespace k8s.Tests
         public void DefaultConfigurationAsStringLoaded()
         {
             var filePath = "assets/kubeconfig.yml";
+            var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(filePath, null, null, useRelativePaths: false);
+            Assert.NotNull(cfg.Host);
+        }
+
+
+        /// <summary>
+        ///     Checks Host is loaded from the default configuration file as stream
+        /// </summary>
+        [Fact]
+        public void DefaultConfigurationAsStreamLoaded()
+        {
+            using (var stream = File.OpenRead("assets/kubeconfig.yml"))
+            {
+                var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(stream);
+                Assert.NotNull(cfg.Host);
+            }
+        }
+
+        /// <summary>
+        ///     Checks users.as-user-extra is loaded correctly from a configuration file.
+        /// </summary>
+        [Fact]
+        public void AsUserExtra()
+        {
+            var filePath = "assets/kubeconfig.as-user-extra.yml";
+
             var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(filePath, null, null, useRelativePaths: false);
             Assert.NotNull(cfg.Host);
         }


### PR DESCRIPTION
Recreates #170 by @markrendle (with Mark's consent, as he does not have bandwidth to update it).  From the original description:

"Hi. I'm working on a GUI application that loads the K8SConfiguration, then creates KubernetesClientConfiguration instances based on user selection. Since I've already got the config data loaded, it makes sense to be able to create the client config directly from it, so I've added a new static method BuildConfig that takes the K8SConfiguration instance as a parameter. I guess I could have made the existing GetKubernetesClientConfiguration method public, but I don't like messing with existing API.

Oh, I also fixed up a doc comment that was wrong :)"

And I tweaked a couple more doc comments too.