### PR TITLE
add az pipepline yaml

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -60,6 +60,8 @@ jobs:
       command: pack
       packagesToPack: src/KubernetesClient/KubernetesClient.csproj
       packDirectory: '$(Build.ArtifactStagingDirectory)/nupkg'
+      majorVersion: 1
+      minorVersion: 4      
       versioningScheme: byPrereleaseNumber
 
 

--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -1,0 +1,72 @@
+jobs:
+
+- job: Build
+  pool:
+    vmImage: 'VS2017-Win2016'
+
+
+  steps:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build'
+    inputs:
+      projects: '**/*.sln'
+
+  # - task: MSBuild@1
+  #   displayName: 'Build solution **/*.sln'
+  #   inputs:
+  #     msbuildArchitecture: x64
+
+  #     configuration: Release
+
+  # - task: VSTest@2
+  #   displayName: 'VsTest - testAssemblies'
+  #   inputs:
+  #     testAssemblyVer2: |
+  #       tests\**\*Tests*.dll
+  #       !**\obj\**
+
+  #     codeCoverageEnabled: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet test'
+    inputs:
+      command: test
+      projects: tests\**\*.csproj
+      arguments: /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'publish coverage results'
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'  
+
+  - task: alanwales.resharper-code-analysis.custom-build-task.ResharperCli@1
+    displayName: 'Automated code quality checks'
+    inputs:
+      SolutionOrProjectPath: 'kubernetes-client.sln'
+
+      FailBuildOnCodeIssues: false
+
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet pack'
+    inputs:
+      command: pack
+      packagesToPack: src/KubernetesClient/KubernetesClient.csproj
+      packDirectory: '$(Build.ArtifactStagingDirectory)/nupkg'
+      versioningScheme: byPrereleaseNumber
+
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    inputs:
+      PathtoPublish: '$(build.artifactstagingdirectory)/nupkg'
+
+
+

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -9,7 +9,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
-    <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1</TargetFrameworks>
+    <!-- <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks> -->
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>
@@ -20,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -9,8 +9,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
-    <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1</TargetFrameworks>
-    <!-- <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks> -->
+    <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TF_BUILD)' == 'True'">netstandard1.4;net452;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
+++ b/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
@@ -20,6 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
+
+    <PackageReference Include="coverlet.msbuild" Version="2.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" NoWarn="NU1701" />

--- a/version.json
+++ b/version.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4",
-  "publicReleaseRefSpec": [
-    "^refs/heads/master$", // we release out of master
-  ],
-}


### PR DESCRIPTION
First step to enable Azure Pipeline
Example result
<https://farmer1992.visualstudio.com/opensources/_build/results?buildId=270>

 * #16 Add coverage report (via coverlet)
 * #37 Add Resharper code style checker (not enforce)
 * #187 Azure pipeline
 * #239 targeting net452

Built on Windows, as a result, add targeting `net452` to nupkg.
However, `xamarinios10`, `monoandroid81` still cannot be included due to that ios/android sdk are not shipped with azure pipeline image.


Need to create an instance for this report to enable azure pipeline
