### PR TITLE
Fix NuGet package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_install:
   - ./install-$TRAVIS_OS_NAME.sh
 
 script:
+# Make NB.GV recognize the branch we're building, by setting environment variables.
+  - export BUILD_SOURCEBRANCH=${TRAVIS_BRANCH}
+  - export SYSTEM_TEAMPROJECTID=${TRAVIS_BUILD_ID}
   - ./ci.sh
 
 after_script:

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" PrivateAssets="all" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />


### PR DESCRIPTION
The version numbers of the NuGet packages which are pushed to nuget.org currently include the Git commit ID as a suffix (e.g. 1.5.1-g60ffd20a7c).

This causes NuGet to mark those packages as prerelease, and as a result most people stick to the 1.2.0 version, which is about 8 months old.

NB.GV drops the build suffix when building from master (as specified in `version.json`). Because Travis checks out the commits in a detached head state, NB.GV doesn't detect this and adds the suffix anyway.

NB.GV detects 'cloud build services' using environment variables, but doesn't have built in support for Travis (yet, see AArnott/Nerdbank.GitVersioning#310).

As a workaround, set the environment variables used by other cloud build services.