### PR TITLE
Make MSBuild.Sdk.Extras private, it is a build-time only dependency.

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>
@@ -25,7 +25,7 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.4.0" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.68" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />


### PR DESCRIPTION
Since #140 the [KubernetesClient package took a public dependency on MSBuild.Sdk.Extras](https://www.nuget.org/packages/KubernetesClient/1.5.1-g60ffd20a7c).

MSBuild.Sdk.Extras is a (very specialized) build-time dependency, and we shouldn't force users of the KubernetesClient to take a dependency on this. This PR marks it as private instead.