### PR TITLE
Fix build warnings in the StreamDemuxerTests

### DIFF
--- a/src/KubernetesClient/StreamDemuxer.cs
+++ b/src/KubernetesClient/StreamDemuxer.cs
@@ -182,6 +182,9 @@ namespace k8s
 
         protected async Task RunLoop(CancellationToken cancellationToken)
         {
+            // This is a background task. Immediately yield to the caller.
+            await Task.Yield();
+
             // Get a 1KB buffer
             byte[] buffer = ArrayPool<byte>.Shared.Rent(1024 * 1024);
             // This maps remembers bytes skipped for each stream.

--- a/tests/KubernetesClient.Tests/StreamDemuxerTests.cs
+++ b/tests/KubernetesClient.Tests/StreamDemuxerTests.cs
@@ -24,6 +24,7 @@ namespace k8s.Tests
         public async Task SendDataRemoteCommand()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws))
             {
                 List<byte> sentBuffer = new List<byte>();
                 ws.MessageSent += (sender, args) =>
@@ -31,8 +32,7 @@ namespace k8s.Tests
                     sentBuffer.AddRange(args.Data.Buffer);
                 };
 
-                StreamDemuxer demuxer = new StreamDemuxer(ws);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 byte channelIndex = 12;
                 var stream = demuxer.GetStream(channelIndex, channelIndex);
@@ -50,6 +50,7 @@ namespace k8s.Tests
         public async Task SendMultipleDataRemoteCommand()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws))
             {
                 List<byte> sentBuffer = new List<byte>();
                 ws.MessageSent += (sender, args) =>
@@ -57,8 +58,7 @@ namespace k8s.Tests
                     sentBuffer.AddRange(args.Data.Buffer);
                 };
 
-                StreamDemuxer demuxer = new StreamDemuxer(ws);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 byte channelIndex = 12;
                 var stream = demuxer.GetStream(channelIndex, channelIndex);
@@ -80,9 +80,9 @@ namespace k8s.Tests
         public async Task ReceiveDataRemoteCommand()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws))
             {
-                StreamDemuxer demuxer = new StreamDemuxer(ws);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 List<byte> receivedBuffer = new List<byte>();
                 byte channelIndex = 12;
@@ -129,9 +129,9 @@ namespace k8s.Tests
         public async Task ReceiveDataPortForward()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward))
             {
-                StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 List<byte> receivedBuffer = new List<byte>();
                 byte channelIndex = 12;
@@ -179,9 +179,9 @@ namespace k8s.Tests
         public async Task ReceiveDataPortForwardOneByteMessage()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward))
             {
-                StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 List<byte> receivedBuffer = new List<byte>();
                 byte channelIndex = 12;
@@ -227,9 +227,9 @@ namespace k8s.Tests
         public async Task ReceiveDataRemoteCommandMultipleStream()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws))
             {
-                StreamDemuxer demuxer = new StreamDemuxer(ws);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 List<byte> receivedBuffer1 = new List<byte>();
                 byte channelIndex1 = 1;
@@ -304,9 +304,9 @@ namespace k8s.Tests
         public async Task ReceiveDataPortForwardMultipleStream()
         {
             using (MockWebSocket ws = new MockWebSocket())
+            using (StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward))
             {
-                StreamDemuxer demuxer = new StreamDemuxer(ws, StreamType.PortForward);
-                Task.Run(() => demuxer.Start());
+                demuxer.Start();
 
                 List<byte> receivedBuffer1 = new List<byte>();
                 byte channelIndex1 = 1;
@@ -325,8 +325,8 @@ namespace k8s.Tests
 
                 var t1 = Task.Run(async () =>
                 {
-                    // Simulate WebSocket received remote data to multiple streams
-                    await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(100, channelIndex1, 0xE1, true)), WebSocketMessageType.Binary, true);
+                        // Simulate WebSocket received remote data to multiple streams
+                        await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(100, channelIndex1, 0xE1, true)), WebSocketMessageType.Binary, true);
                     await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(200, channelIndex2, 0xE2, true)), WebSocketMessageType.Binary, true);
                     await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(300, channelIndex1, 0xE3, false)), WebSocketMessageType.Binary, true);
 
@@ -378,7 +378,6 @@ namespace k8s.Tests
                 Assert.True(receivedBuffer2[196] == 0xE2, "The first payload incorrect!");
             }
         }
-
 
         private static byte[] GenerateRandomBuffer(int length, byte channelIndex, byte content, bool portForward)
         {

--- a/tests/KubernetesClient.Tests/StreamDemuxerTests.cs
+++ b/tests/KubernetesClient.Tests/StreamDemuxerTests.cs
@@ -325,8 +325,8 @@ namespace k8s.Tests
 
                 var t1 = Task.Run(async () =>
                 {
-                        // Simulate WebSocket received remote data to multiple streams
-                        await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(100, channelIndex1, 0xE1, true)), WebSocketMessageType.Binary, true);
+                    // Simulate WebSocket received remote data to multiple streams
+                    await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(100, channelIndex1, 0xE1, true)), WebSocketMessageType.Binary, true);
                     await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(200, channelIndex2, 0xE2, true)), WebSocketMessageType.Binary, true);
                     await ws.InvokeReceiveAsync(new ArraySegment<byte>(GenerateRandomBuffer(300, channelIndex1, 0xE3, false)), WebSocketMessageType.Binary, true);
 


### PR DESCRIPTION
The `StreamDemuxerTests` were causing build warnings like this:

```
StreamDemuxerTests.cs(35,17): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call. 
```

This was cause by this line:

```
Task.Run(() => demuxer.Start());
```

which creates a background task but never `await`s it.

`StreamDemuxer.Start` should return immediately, but it was possible for that call to block. I've fixed that.

I've also found an issue in the `ReceiveAsync` method of the `MockWebSocket` class, where it didn't honor the `CancellationToken`, and fixed that as well.
