### PR TITLE
Add code coverage, Linux & macOS leg to Azure CI

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -1,6 +1,6 @@
 jobs:
 
-- job: build_xamarin
+- job: xamarin_build
   pool:
     vmImage: 'VS2017-Win2016'
   steps:
@@ -21,10 +21,9 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)/nupkg/'
 
-- job: Build
+- job: windows_build
   pool:
     vmImage: 'VS2017-Win2016'
-
 
   steps:
   - task: DotNetCoreCLI@2
@@ -37,22 +36,6 @@ jobs:
     inputs:
       projects: '**/*.sln'
 
-  # - task: MSBuild@1
-  #   displayName: 'Build solution **/*.sln'
-  #   inputs:
-  #     msbuildArchitecture: x64
-
-  #     configuration: Release
-
-  # - task: VSTest@2
-  #   displayName: 'VsTest - testAssemblies'
-  #   inputs:
-  #     testAssemblyVer2: |
-  #       tests\**\*Tests*.dll
-  #       !**\obj\**
-
-  #     codeCoverageEnabled: true
-
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test'
     inputs:
@@ -64,15 +47,13 @@ jobs:
     displayName: 'publish coverage results'
     inputs:
       codeCoverageTool: 'cobertura'
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'  
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
 
   - task: alanwales.resharper-code-analysis.custom-build-task.ResharperCli@1
     displayName: 'Automated code quality checks'
     inputs:
       SolutionOrProjectPath: 'kubernetes-client.sln'
-
       FailBuildOnCodeIssues: false
-
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -81,15 +62,60 @@ jobs:
       command: pack
       packagesToPack: src/KubernetesClient/KubernetesClient.csproj
       packDirectory: '$(Build.ArtifactStagingDirectory)/nupkg'
-      majorVersion: 1
-      minorVersion: 4      
-      versioningScheme: byPrereleaseNumber
-
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
     inputs:
-      PathtoPublish: '$(build.artifactstagingdirectory)/nupkg'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/nupkg'
 
+- job: macos_build
+  pool:
+    vmImage: 'xcode9-macos10.13'
+  steps:
+  - script: |
+      brew install coreutils
+      which realpath
+      ./ci.sh
+    displayName: 'Build & Test'
 
+  - task: PublishTestResults@1
+    displayName: 'Publish Test Results'
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '$(Build.SourcesDirectory)/tests/**/*.xunit.trx'
+    condition: succeededOrFailed()
 
+  - task: PublishCodeCoverageResults@1
+    displayName: 'publish coverage results'
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(Build.SourcesDirectory)/tests/coveragereport/Cobertura.xml'
+      reportDirectory: '$(Build.SourcesDirectory)/tests/coveragereport/'
+    condition: succeededOrFailed()
+
+- job: ubuntu_build
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      ./install-linux.sh
+    displayName: 'Install .NET & set up minikube'
+
+  - script: |
+      ./ci.sh
+    displayName: 'Build & Test'
+
+  - task: PublishTestResults@1
+    displayName: 'Publish Test Results'
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '$(Build.SourcesDirectory)/tests/**/*.xunit.trx'
+    condition: succeededOrFailed()
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'publish coverage results'
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(Build.SourcesDirectory)/tests/coveragereport/Cobertura.xml'
+      reportDirectory: '$(Build.SourcesDirectory)/tests/coveragereport/'
+    condition: succeededOrFailed()

--- a/ci.sh
+++ b/ci.sh
@@ -14,6 +14,26 @@ cd ../..
 # Execute Unit tests
 cd tests/KubernetesClient.Tests
 dotnet restore
-dotnet test
+# Save the test results to a file
+# Collect code coverage of the KuberetsClient assembly, but exclude the
+# auto-generated models from the coverage reports.
+dotnet test \
+    -l "trx;LogFileName=KubernetesClient.Tests.xunit.trx" \
+    /p:CollectCoverage=true \
+    /p:Include="[KubernetesClient]*" \
+    /p:Exclude="[KubernetesClient]k8s.Models.*" \
+    /p:Exclude="[KubernetesClient]k8s.Internal.*" \
+    /p:CoverletOutputFormat="opencover" \
+    /p:CoverletOutput="KubernetesClient.Tests.opencover.xml"
 
-cd ../..
+cd ..
+echo Generating Code Coverage reports
+export PATH="$PATH:$HOME/.dotnet/tools"
+export DOTNET_ROOT=$(dirname $(realpath $(which dotnet))) # https://github.com/dotnet/cli/issues/9114#issuecomment-401670622
+dotnet tool install --global dotnet-reportgenerator-globaltool --version 4.0.15
+reportgenerator "-reports:**/*.opencover.xml" "-targetdir:coveragereport" "-reporttypes:HTMLInline;Cobertura"
+
+ls coveragereport
+ls coveragereport/Cobertura.xml
+
+cd ..

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -21,6 +21,9 @@ echo 'Creating the minikube cluster'
 sudo minikube start --vm-driver=none --kubernetes-version=v1.13.4 --extra-config=apiserver.authorization-mode=RBAC
 sudo chown -R $USER $HOME/.minikube
 sudo chgrp -R $USER $HOME/.minikube
+sudo chown -R $USER $HOME/.kube
+sudo chgrp -R $USER $HOME/.kube
+
 minikube update-context
 
 echo 'Waiting for the cluster nodes to be ready'


### PR DESCRIPTION
This PR adds a macOS and Linux leg to the Azure CI pipeline script.
It reuses the CI scripts which are used on Travis.

Especially the Linux leg is of interest as it runs integration tests against a real Kubernetes cluster.

It also sets up code coverage reports which show line and branch coverage.

![image](https://user-images.githubusercontent.com/9918129/54823252-9126cf80-4ca7-11e9-8e8c-7b94d8e7a764.png)
