### PR TITLE
Mark all Fractions classes as internal

### DIFF
--- a/src/KubernetesClient/Fractions/Extensions/MathExt.cs
+++ b/src/KubernetesClient/Fractions/Extensions/MathExt.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Fractions.Extensions {
+namespace k8s.Internal.Fractions.Extensions {
     internal static class MathExt {
         /// <summary>
         /// Checks for an even number.

--- a/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatProvider.cs
+++ b/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatProvider.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Fractions.Formatter {
+namespace k8s.Internal.Fractions.Formatter {
     /// <summary>
     /// Default <see cref="Fraction.ToString()"/> formatter.
     /// </summary>

--- a/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatProvider.cs
+++ b/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatProvider.cs
@@ -4,7 +4,7 @@ namespace Fractions.Formatter {
     /// <summary>
     /// Default <see cref="Fraction.ToString()"/> formatter.
     /// </summary>
-    public class DefaultFractionFormatProvider : IFormatProvider {
+    internal class DefaultFractionFormatProvider : IFormatProvider {
         /// <summary>
         /// Singleton instance
         /// </summary>

--- a/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatter.cs
+++ b/src/KubernetesClient/Fractions/Formatter/DefaultFractionFormatter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Text;
 
-namespace Fractions.Formatter {
+namespace k8s.Internal.Fractions.Formatter {
     internal class DefaultFractionFormatter : ICustomFormatter {
         public static readonly ICustomFormatter Instance = new DefaultFractionFormatter();
 

--- a/src/KubernetesClient/Fractions/Fraction.CompareTo.cs
+++ b/src/KubernetesClient/Fractions/Fraction.CompareTo.cs
@@ -2,7 +2,7 @@ using System;
 using System.Numerics;
 
 namespace Fractions {
-    public partial struct Fraction
+    internal partial struct Fraction
     {
         /// <summary>
         /// Compares the calculated value with the supplied <paramref name="other"/>.

--- a/src/KubernetesClient/Fractions/Fraction.CompareTo.cs
+++ b/src/KubernetesClient/Fractions/Fraction.CompareTo.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Numerics;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction
     {
         /// <summary>

--- a/src/KubernetesClient/Fractions/Fraction.Constructors.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Constructors.cs
@@ -2,7 +2,7 @@ using System;
 using System.Numerics;
 
 namespace Fractions {
-    public partial struct Fraction
+    internal partial struct Fraction
     {
         /// <summary>
         /// Create a fraction with <paramref name="numerator"/>, <paramref name="denominator"/> and the fraction' <paramref name="state"/>.

--- a/src/KubernetesClient/Fractions/Fraction.Constructors.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Constructors.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Numerics;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction
     {
         /// <summary>

--- a/src/KubernetesClient/Fractions/Fraction.ConvertFrom.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ConvertFrom.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 using Fractions.Extensions;
 
 namespace Fractions {
-    public partial struct Fraction {
+    internal partial struct Fraction {
         /// <summary>
         /// Converts a string to a fraction. Example: "3/4" or "4.5" (the decimal separator character is depending on the system culture).
         /// If the number contains a decimal separator it will be parsed as <see cref="decimal"/>.

--- a/src/KubernetesClient/Fractions/Fraction.ConvertFrom.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ConvertFrom.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Globalization;
 using System.Numerics;
-using Fractions.Extensions;
+using k8s.Internal.Fractions.Extensions;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction {
         /// <summary>
         /// Converts a string to a fraction. Example: "3/4" or "4.5" (the decimal separator character is depending on the system culture).

--- a/src/KubernetesClient/Fractions/Fraction.ConvertTo.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ConvertTo.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Numerics;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction {
         /// <summary>
         /// Returns the fraction as signed 32bit integer.

--- a/src/KubernetesClient/Fractions/Fraction.ConvertTo.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ConvertTo.cs
@@ -2,7 +2,7 @@ using System;
 using System.Numerics;
 
 namespace Fractions {
-    public partial struct Fraction {
+    internal partial struct Fraction {
         /// <summary>
         /// Returns the fraction as signed 32bit integer.
         /// </summary>

--- a/src/KubernetesClient/Fractions/Fraction.Equality.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Equality.cs
@@ -1,6 +1,6 @@
 
 namespace Fractions {
-    public partial struct Fraction
+    internal partial struct Fraction
     {
         /// <summary>
         /// Tests if the calculated value of this fraction equals to the calculated value of <paramref name="other"/>.

--- a/src/KubernetesClient/Fractions/Fraction.Equality.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Equality.cs
@@ -1,5 +1,5 @@
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction
     {
         /// <summary>

--- a/src/KubernetesClient/Fractions/Fraction.Math.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Math.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Numerics;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction {
         /// <summary>
         /// Calculates the remainder of the division with the fraction's value and the supplied <paramref name="divisor"/> (% operator).

--- a/src/KubernetesClient/Fractions/Fraction.Math.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Math.cs
@@ -2,7 +2,7 @@ using System;
 using System.Numerics;
 
 namespace Fractions {
-    public partial struct Fraction {
+    internal partial struct Fraction {
         /// <summary>
         /// Calculates the remainder of the division with the fraction's value and the supplied <paramref name="divisor"/> (% operator).
         /// </summary>

--- a/src/KubernetesClient/Fractions/Fraction.Operators.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Operators.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 
 namespace Fractions {
-    public partial struct Fraction {
+    internal partial struct Fraction {
 #pragma warning disable 1591
         public static bool operator ==(Fraction left, Fraction right) {
             return left.Equals(right);

--- a/src/KubernetesClient/Fractions/Fraction.Operators.cs
+++ b/src/KubernetesClient/Fractions/Fraction.Operators.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction {
 #pragma warning disable 1591
         public static bool operator ==(Fraction left, Fraction right) {

--- a/src/KubernetesClient/Fractions/Fraction.ToString.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ToString.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using Fractions.Formatter;
 
 namespace Fractions {
-    public partial struct Fraction {
+    internal partial struct Fraction {
         /// <summary>
         /// Returns the fraction as "numerator/denominator" or just "numerator" if the denominator has a value of 1.
         /// The returning value is culture invariant (<see cref="CultureInfo" />).

--- a/src/KubernetesClient/Fractions/Fraction.ToString.cs
+++ b/src/KubernetesClient/Fractions/Fraction.ToString.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Globalization;
-using Fractions.Formatter;
+using k8s.Internal.Fractions.Formatter;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     internal partial struct Fraction {
         /// <summary>
         /// Returns the fraction as "numerator/denominator" or just "numerator" if the denominator has a value of 1.

--- a/src/KubernetesClient/Fractions/Fraction.cs
+++ b/src/KubernetesClient/Fractions/Fraction.cs
@@ -11,7 +11,7 @@ namespace Fractions {
     /// </summary>
     [TypeConverter(typeof (FractionTypeConverter))]
     [StructLayout(LayoutKind.Sequential)]
-    public partial struct Fraction : IEquatable<Fraction>, IComparable, IComparable<Fraction>, IFormattable {
+    internal partial struct Fraction : IEquatable<Fraction>, IComparable, IComparable<Fraction>, IFormattable {
         private static readonly BigInteger MIN_DECIMAL = new BigInteger(decimal.MinValue);
         private static readonly BigInteger MAX_DECIMAL = new BigInteger(decimal.MaxValue);
         private static readonly Fraction _zero = new Fraction(BigInteger.Zero, BigInteger.Zero, FractionState.IsNormalized);

--- a/src/KubernetesClient/Fractions/Fraction.cs
+++ b/src/KubernetesClient/Fractions/Fraction.cs
@@ -2,9 +2,9 @@ using System;
 using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.InteropServices;
-using Fractions.TypeConverters;
+using k8s.Internal.Fractions.TypeConverters;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     /// <summary>
     /// A mathematical fraction. A rational number written as a/b (a is the numerator and b the denominator).
     /// The data type is not capable to store NaN (not a number) or infinite.

--- a/src/KubernetesClient/Fractions/FractionState.cs
+++ b/src/KubernetesClient/Fractions/FractionState.cs
@@ -2,7 +2,7 @@ namespace Fractions {
     /// <summary>
     /// The fraction's state.
     /// </summary>
-    public enum FractionState
+    internal enum FractionState
     {
         /// <summary>
         /// Unknown state.

--- a/src/KubernetesClient/Fractions/FractionState.cs
+++ b/src/KubernetesClient/Fractions/FractionState.cs
@@ -1,4 +1,4 @@
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     /// <summary>
     /// The fraction's state.
     /// </summary>

--- a/src/KubernetesClient/Fractions/InvalidNumberException.cs
+++ b/src/KubernetesClient/Fractions/InvalidNumberException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Fractions {
+namespace k8s.Internal.Fractions {
     /// <summary>
     /// Exception that will be thrown if an argument contains not a number (NaN) or is infinite.
     /// </summary>

--- a/src/KubernetesClient/Fractions/InvalidNumberException.cs
+++ b/src/KubernetesClient/Fractions/InvalidNumberException.cs
@@ -4,7 +4,7 @@ namespace Fractions {
     /// <summary>
     /// Exception that will be thrown if an argument contains not a number (NaN) or is infinite.
     /// </summary>
-    public class InvalidNumberException : ArithmeticException {
+    internal class InvalidNumberException : ArithmeticException {
 #pragma warning disable 1591
         public InvalidNumberException() {}
         public InvalidNumberException(string message) : base(message) {}

--- a/src/KubernetesClient/Fractions/TypeConverters/FractionTypeConverter.cs
+++ b/src/KubernetesClient/Fractions/TypeConverters/FractionTypeConverter.cs
@@ -8,7 +8,7 @@ namespace Fractions.TypeConverters {
     /// <summary>
     /// Converts the <see cref="Fraction"/> from / to various data types.
     /// </summary>
-    public sealed class FractionTypeConverter : TypeConverter {
+    internal sealed class FractionTypeConverter : TypeConverter {
         private static readonly HashSet<Type> SUPPORTED_TYPES = new HashSet<Type> {
             typeof (string),
             typeof (int),

--- a/src/KubernetesClient/Fractions/TypeConverters/FractionTypeConverter.cs
+++ b/src/KubernetesClient/Fractions/TypeConverters/FractionTypeConverter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Numerics;
 
-namespace Fractions.TypeConverters {
+namespace k8s.Internal.Fractions.TypeConverters {
     /// <summary>
     /// Converts the <see cref="Fraction"/> from / to various data types.
     /// </summary>

--- a/src/KubernetesClient/ResourceQuantity.cs
+++ b/src/KubernetesClient/ResourceQuantity.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using Fractions;
+using k8s.Internal.Fractions;
 using Newtonsoft.Json;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;


### PR DESCRIPTION
#194 embedded the Fractions within the KubernetesClient.

Because most of the Fractions types are marked as `public`, any library referencing both KubernetesClient and the original Fractions library would be confused at compile time as there are two types with the same name in two different projects.

Hence, this PR makes all Fractions-related types `internal`, so they are not visible to any other library at compile time.

Libraries can also use reflection at runtime to find types. To guard against libraries being confused by finding two types with the same name in two different libraries, I've also renamed the `Fractions` to `k8s.Internal.Fractions`.
