### PR TITLE
Add MSBuild leg, for building NuGet package with Xamarin support

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -1,5 +1,26 @@
 jobs:
 
+- job: build_xamarin
+  pool:
+    vmImage: 'VS2017-Win2016'
+  steps:
+  - task: MSBuild@1
+    displayName: 'NuGet restore'
+    inputs:
+      solution: '$(Build.SourcesDirectory)/src/KubernetesClient/KubernetesClient.csproj'
+      msbuildArguments: '/restore /p:Configuration=Release'
+
+  - task: MSBuild@1
+    displayName: 'MSBuild Pack'
+    inputs:
+      solution: '$(Build.SourcesDirectory)/src/KubernetesClient/KubernetesClient.csproj'
+      msbuildArguments: '/t:pack /p:Configuration=Release /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)/nupkg/"'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/nupkg/'
+
 - job: Build
   pool:
     vmImage: 'VS2017-Win2016'

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>
@@ -9,9 +9,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
-    <TargetFrameworks>netstandard1.4;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TF_BUILD)' == 'True'">netstandard1.4;net452;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>kubernetes-client.snk</AssemblyOriginatorKeyFile>
@@ -25,17 +25,18 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.68" PrivateAssets="all" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.68" PrivateAssets="all" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.1.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net461'">
     <Reference Include="System.Net.Http.WebRequest" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'xamarinios10'">
     <Reference Include="System.Numerics" />


### PR DESCRIPTION
This PR adds another build leg to the Azure pipline, which uses `MSBuild.exe` instead of `dotnet.exe` to build the KubernetesClient. This way, you can build a NuGet package with Xamarin support, too.

It also:
- Adds a `netstandard2.0` and `net461` target. This puts the package in line with the [Open Source Library Guidance](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting), although they also recommend dropping `netstandard1.x` and `net452` alltogether.
- Disables cross-building for Xamarin alltogether when building using `dotnet build`.
- Removes redundant dependencies for the `netstandard`/`netcoreapp` targets