### PR TITLE
Remove double "Usage" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 dotnet add package KubernetesClient
 ```
 
-# Usage
-
 ## Authentication/Configuration
 You should be able to use an standard KubeConfig file with this library,
 see the `BuildConfigFromConfigFile` function below. Most authentication


### PR DESCRIPTION
Remove double "Usage" in docs