### PR TITLE
Temporarily disable the Resharper checks

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -49,12 +49,12 @@ jobs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
 
-  - task: alanwales.resharper-code-analysis.custom-build-task.ResharperCli@1
-    displayName: 'Automated code quality checks'
-    inputs:
-      SolutionOrProjectPath: 'kubernetes-client.sln'
-      FailBuildOnCodeIssues: false
-    continueOnError: true
+#  - task: alanwales.resharper-code-analysis.custom-build-task.ResharperCli@1
+#    displayName: 'Automated code quality checks'
+#    inputs:
+#      SolutionOrProjectPath: 'kubernetes-client.sln'
+#      FailBuildOnCodeIssues: false
+#    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet pack'


### PR DESCRIPTION
Workaround for #272 . This should get the CI signal green again.