### PR TITLE
Add repository location to NuGet package information

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -8,6 +8,8 @@
     <PackageProjectUrl>https://github.com/kubernetes-client/csharp</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/kubernetes-client/csharp.git</RepositoryUrl>
 
     <TargetFrameworks>netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1</TargetFrameworks>


### PR DESCRIPTION
Nuget provides elements to specify where the source code repository is for a nuget package, by specifying [repository information](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd#L78).

It would be great if we had this information straight into the .nuspec, which would allow tooling such as [renovate](https://renovatebot.com/) to fetch detailed information about releases (what specifically has been fixed [sample](https://github.com/tomkerkhove/promitor/pull/75)).

This adds the repository location to the nuspec.