### PR TITLE
add websocket auth support for .net standard 2.0 support

### DIFF
--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
 using System.Net.Security;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -281,7 +281,7 @@ namespace k8s
                 }
             }
 
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
             if (this.CaCerts != null)
             {
                 webSocketBuilder.SetServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
@@ -368,7 +368,7 @@ namespace k8s
                 {
                     ServiceClientTracing.Exit(invocationId, null);
                 }
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
                 if (this.CaCerts != null)
                 {
                     webSocketBuilder.CleanupServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
@@ -378,7 +378,7 @@ namespace k8s
             return webSocket;
         }
 
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
         internal bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
             return Kubernetes.CertificateValidationCallBack(sender, this.CaCerts, certificate, chain, sslPolicyErrors);

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -368,6 +368,7 @@ namespace k8s
                 {
                     ServiceClientTracing.Exit(invocationId, null);
                 }
+
 #if (NET452 || NETSTANDARD2_0)
                 if (this.CaCerts != null)
                 {

--- a/src/KubernetesClient/WebSocketBuilder.cs
+++ b/src/KubernetesClient/WebSocketBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
 using System.Net.Security;
 #endif
 using System.Security.Cryptography.X509Certificates;
@@ -39,7 +39,7 @@ namespace k8s
             return this;
         }
 
-#if NET452
+#if (NET452 || NETSTANDARD2_0)
         public WebSocketBuilder SetServerCertificateValidationCallback(RemoteCertificateValidationCallback validationCallback)
         {
             System.Net.ServicePointManager.ServerCertificateValidationCallback += validationCallback;


### PR DESCRIPTION
WebSocket certificate validation is not implemented for NETSTANDARD2_0. This means, when KubernetesClient.dll is consumed by a process running such as Visual Studio, WebSocket will not work. This change enables it.