### PR TITLE
improved async support for watches

### DIFF
--- a/src/KubernetesClient/IAsyncLineReader.cs
+++ b/src/KubernetesClient/IAsyncLineReader.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    /// <summary>
+    /// Represents a line oriented stream used for watching server responses
+    /// </summary>
+    public interface IAsyncLineReader : IDisposable
+    {
+        /// <summary>
+        /// Read a line from the server
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used to cancel the read</param>
+        Task<string> ReadLineAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/KubernetesClient/Kubernetes.Watch.cs
+++ b/src/KubernetesClient/Kubernetes.Watch.cs
@@ -150,7 +150,7 @@ namespace k8s
             }
 
             var stream = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            StreamReader reader = new StreamReader(stream);
+            PeekableStreamReader reader = new PeekableStreamReader(stream);
 
             return new Watcher<T>(reader, onEvent, onError, onClosed);
         }

--- a/src/KubernetesClient/PeekableStreamReader.cs
+++ b/src/KubernetesClient/PeekableStreamReader.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    internal class PeekableStreamReader : IAsyncLineReader
+    {
+        private readonly Queue<string> _peek = new Queue<string>();
+        private Stream _stream;
+        private byte[] _buf = new byte[4096];
+        private int _bufPos = 0;
+        private int _bufLength = 0;
+        private bool _eof = false;
+
+        public PeekableStreamReader(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        private void ShuffleConsumedBytes(byte[] dst)
+        {
+            if (_bufPos < _bufLength)
+            {
+                Buffer.BlockCopy(_buf, _bufPos, dst, 0, _bufLength - _bufPos);
+            }
+            _bufLength -= _bufPos;
+            _bufPos = 0;
+        }
+
+        private void CheckDisposed()
+        {
+            if (_stream == null)
+            {
+                throw new ObjectDisposedException("PeekableStreamReader");
+            }
+        }
+
+        public async Task<string> ReadLineAsync(CancellationToken cancellationToken)
+        {
+            CheckDisposed();
+
+            if (_peek.Count > 0)
+            {
+                return _peek.Dequeue();
+            }
+
+            for (;;)
+            {
+                // read buffered data
+                if (_bufPos < _bufLength)
+                {
+                    int nlPos = _eof ? _bufLength - 1 : Array.IndexOf(_buf, (byte)'\n', _bufPos, _bufLength -_bufPos);
+                    if (nlPos >= 0)
+                    {
+                        string result = Encoding.UTF8.GetString(_buf, _bufPos, nlPos - _bufPos + 1);
+                        _bufPos = nlPos + 1;
+                        return result;
+                    }
+                }
+                if (_eof)
+                {
+                    return null;
+                }
+                // make the buffer bigger if needed
+                if (_buf.Length - _bufLength < 512)
+                {
+                    if (_buf.Length > Int32.MaxValue / 2)
+                    {
+                        throw new InvalidOperationException(
+                            "trying to read a line > 2Gb from the server");
+                    }
+                    byte[] newbuf = new byte[_buf.Length * 2];
+                    ShuffleConsumedBytes(newbuf);
+                }
+                // consume any previously read data
+                else if (_bufPos > 0)
+                {
+                    ShuffleConsumedBytes(_buf);
+                }
+
+                int read = await _stream.ReadAsync(_buf, _bufLength,
+                    _buf.Length - _bufLength, cancellationToken).ConfigureAwait(false);
+                _bufLength += read;
+                _eof = read == 0;
+            }
+        }
+
+        public async Task<string> PeekLineAsync(CancellationToken cancellationToken)
+        {
+            CheckDisposed();
+
+            var line = await ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            _peek.Enqueue(line);
+            return line;
+        }
+
+        public void Dispose()
+        {
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+            }
+        }
+    }
+}

--- a/src/KubernetesClient/PeekableStreamReader.cs
+++ b/src/KubernetesClient/PeekableStreamReader.cs
@@ -65,6 +65,11 @@ namespace k8s
                 {
                     return null;
                 }
+                // consume any previously read data
+                if (_bufPos > 0)
+                {
+                    ShuffleConsumedBytes(_buf);
+                }
                 // make the buffer bigger if needed
                 if (_buf.Length - _bufLength < 512)
                 {
@@ -75,11 +80,7 @@ namespace k8s
                     }
                     byte[] newbuf = new byte[_buf.Length * 2];
                     ShuffleConsumedBytes(newbuf);
-                }
-                // consume any previously read data
-                else if (_bufPos > 0)
-                {
-                    ShuffleConsumedBytes(_buf);
+                    _buf = newbuf;
                 }
 
                 int read = await _stream.ReadAsync(_buf, _bufLength,

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -163,7 +163,7 @@ namespace k8s
             Action<WatchEventType, T> onEvent,
             Action<Exception> onError = null,
             Action onClosed = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!(response.Response.Content is WatcherDelegatingHandler.LineSeparatedHttpContent content))
             {
@@ -189,7 +189,7 @@ namespace k8s
             Action<WatchEventType, T> onEvent,
             Action<Exception> onError = null,
             Action onClosed = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             return Watch((HttpOperationResponse)response, onEvent, onError, onClosed, cancellationToken);
         }

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -165,7 +165,7 @@ namespace k8s
             Action onClosed = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!(response.Response.Content is WatcherDelegatingHandler.LineSeparatedHttpContent content))
+            if (!(response.Response.Content is ILineSeparatedHttpContent content))
             {
                 throw new KubernetesClientException("not a watchable request or failed response");
             }
@@ -212,7 +212,7 @@ namespace k8s
             Func<CancellationToken, Exception, Task> onError = null,
             Func<CancellationToken, Task> onClosed = null)
         {
-            if (!(response.Response.Content is WatcherDelegatingHandler.LineSeparatedHttpContent content))
+            if (!(response.Response.Content is ILineSeparatedHttpContent content))
             {
                 throw new KubernetesClientException("not a watchable request or failed response");
             }

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -51,7 +51,7 @@ namespace k8s
         /// A token that can be used to cancel the read
         /// </param>
         public Watcher(IAsyncLineReader lineReader, Action<WatchEventType, T> onEvent, Action<Exception> onError,
-            Action onClosed = null, CancellationToken cancellationToken = default)
+            Action onClosed = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             _lineReader = lineReader;
             OnEvent += onEvent;

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -36,7 +36,7 @@ namespace k8s
         /// Initializes a new instance of the <see cref="Watcher{T}"/> class.
         /// </summary>
         /// <param name="lineReader">
-        /// A <see cref="ILineReader"/> from which to read the events.
+        /// An <see cref="IAsyncLineReader"/> from which to read the events.
         /// </param>
         /// <param name="onEvent">
         /// The action to invoke when the server sends a new event.
@@ -207,10 +207,10 @@ namespace k8s
         /// <param name="cancellationToken">A token that can be used to cancel the watch</param>
         /// <returns>a watch object</returns>
         public static async Task WatchAsync<T>(this HttpOperationResponse response,
-            CancellationToken cancellationToken,
             Func<CancellationToken, WatchEventType, T, Task> onEvent,
             Func<CancellationToken, Exception, Task> onError = null,
-            Func<CancellationToken, Task> onClosed = null)
+            Func<CancellationToken, Task> onClosed = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!(response.Response.Content is ILineSeparatedHttpContent content))
             {
@@ -290,12 +290,12 @@ namespace k8s
         /// <param name="cancellationToken">A token that can be used to cancel the watch</param>
         /// <returns>a watch object</returns>
         public static Task WatchAsync<T>(this HttpOperationResponse<T> response,
-            CancellationToken cancellationToken,
             Func<CancellationToken, WatchEventType, T, Task> onEvent,
             Func<CancellationToken, Exception, Task> onError = null,
-            Func<CancellationToken, Task> onClosed = null)
+            Func<CancellationToken, Task> onClosed = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WatchAsync((HttpOperationResponse)response, cancellationToken, onEvent, onError, onClosed);
+            return WatchAsync((HttpOperationResponse)response, onEvent, onError, onClosed, cancellationToken);
         }
     }
 }

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -56,9 +56,12 @@ namespace k8s
                 StreamReader = new PeekableStreamReader(_originStream);
 
                 var firstLine = await StreamReader.PeekLineAsync(_cancellationToken);
-                var lineBytes = Encoding.UTF8.GetBytes(firstLine);
-                await stream.WriteAsync(lineBytes, 0, lineBytes.Length, _cancellationToken);
-                await stream.FlushAsync(_cancellationToken);
+                if (!string.IsNullOrEmpty(firstLine))
+                {
+                    var lineBytes = Encoding.UTF8.GetBytes(firstLine);
+                    await stream.WriteAsync(lineBytes, 0, lineBytes.Length, _cancellationToken);
+                    await stream.FlushAsync(_cancellationToken);
+                }
             }
 
             protected override bool TryComputeLength(out long length)

--- a/tests/KubernetesClient.Tests/PeekableLineStreamReaderTests.cs
+++ b/tests/KubernetesClient.Tests/PeekableLineStreamReaderTests.cs
@@ -1,0 +1,107 @@
+using k8s.Models;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class PeekableLineStreamReaderTest
+    {
+        private PeekableStreamReader CreateStream(string input, int maxLineLength = Int32.MaxValue)
+        {
+            var memoryStream = new MemoryStream();
+            var bytes = Encoding.UTF8.GetBytes(input);
+            memoryStream.Write(bytes, 0, bytes.Length);
+            memoryStream.Position = 0;
+            return new PeekableStreamReader(memoryStream, maxLineLength);
+        }
+
+        [Fact]
+        public void PeekDisposedThrows()
+        {
+            using (var peekableStream = CreateStream("one\ntwo\nthree"))
+            {
+                peekableStream.Dispose();
+                Assert.ThrowsAsync<ObjectDisposedException>(
+                    async () => await peekableStream.PeekLineAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact]
+        public void ReadDisposedThrows()
+        {
+            using (var peekableStream = CreateStream("one\ntwo\nthree"))
+            {
+                peekableStream.Dispose();
+                peekableStream.Dispose();
+                Assert.ThrowsAsync<ObjectDisposedException>(
+                    async () => await peekableStream.ReadLineAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact]
+        public async Task PeekAllThenRead()
+        {
+            var ct = CancellationToken.None;
+            using (var peekableStream = CreateStream("one\ntwo\nthree\n"))
+            {
+                Assert.Equal("one\n", await peekableStream.PeekLineAsync(ct));
+                Assert.Equal("two\n", await peekableStream.PeekLineAsync(ct));
+                Assert.Equal("three\n", await peekableStream.PeekLineAsync(ct));
+                Assert.Null(await peekableStream.PeekLineAsync(ct));
+                Assert.Equal("one\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("two\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("three\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Null(await peekableStream.ReadLineAsync(ct));
+            }
+        }
+
+        [Fact]
+        public async Task ReadWithBigLines()
+        {
+            var sb = new StringBuilder();
+            sb.Append("one\n");
+            sb.Append("two\n");
+            sb.Append('9', 4500).Append('\n');
+            sb.Append("three\n");
+            sb.Append('6', 17432).Append('\n');
+            var ct = CancellationToken.None;
+            using (var peekableStream = CreateStream(sb.ToString()))
+            {
+                Assert.Equal("one\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("two\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal(new String('9', 4500) + "\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("three\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal(new String('6', 17432) + "\n", await peekableStream.ReadLineAsync(ct));
+            }
+        }
+
+        [Fact]
+        public async Task ReadLastLineWithNoNL()
+        {
+            var ct = CancellationToken.None;
+            using (var peekableStream = CreateStream("one\ntwo\nthree"))
+            {
+                Assert.Equal("one\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("two\n", await peekableStream.ReadLineAsync(ct));
+                Assert.Equal("three", await peekableStream.ReadLineAsync(ct));
+                Assert.Null(await peekableStream.ReadLineAsync(ct));
+                Assert.Null(await peekableStream.ReadLineAsync(ct));
+            }
+        }
+
+        [Fact]
+        public void ReadLineBiggerThanMaxThrows()
+        {
+            var ct = CancellationToken.None;
+            using (var peekableStream = CreateStream(new string('6', 8192), 4096))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await peekableStream.ReadLineAsync(ct));
+            }
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/WatchTests.cs
+++ b/tests/KubernetesClient.Tests/WatchTests.cs
@@ -794,7 +794,8 @@ namespace k8s.Tests
             };
             Assert.ThrowsAsync<KubernetesClientException>(
                 async () => await response.WatchAsync(
-                    ct, (ct_, evt, pod) => Task.CompletedTask));
+                    (ct_, evt, pod) => Task.CompletedTask,
+                    cancellationToken: ct));
         }
 
         private HttpOperationResponse<V1Pod> MakeResponse(MockLineStreamReader reader)
@@ -816,7 +817,8 @@ namespace k8s.Tests
             var reader = new MockLineStreamReader(new string[0], 0);
             var response = MakeResponse(reader);
             var cts = new CancellationTokenSource();
-            var task = response.WatchAsync(cts.Token, (ct, evt, pod) => Task.CompletedTask);
+            var task = response.WatchAsync((ct, evt, pod) => Task.CompletedTask,
+                cancellationToken: cts.Token);
             cts.Cancel();
             await task;
         }
@@ -830,7 +832,8 @@ namespace k8s.Tests
             }, 0);
             var response = MakeResponse(reader);
             var cts = new CancellationTokenSource();
-            var task = response.WatchAsync(cts.Token, (ct, evt, pod) => Task.CompletedTask);
+            var task = response.WatchAsync((ct, evt, pod) => Task.CompletedTask,
+                cancellationToken: cts.Token);
             cts.Cancel();
             await task;
         }
@@ -846,7 +849,7 @@ namespace k8s.Tests
             var exceptions = new List<Exception>();
             var onCloseCalled = false;
 
-            var task = response.WatchAsync(CancellationToken.None,
+            var task = response.WatchAsync(
                 (ct, evt, pod) => Task.CompletedTask,
                 (ct, ex) =>
                 {
@@ -857,7 +860,7 @@ namespace k8s.Tests
                 {
                     onCloseCalled = true;
                     return Task.CompletedTask;
-                });
+                }, CancellationToken.None);
             await task;
 
             Assert.True(onCloseCalled);
@@ -886,7 +889,7 @@ namespace k8s.Tests
             var events = new List<WatchEventType>();
             var exceptions = new List<Exception>();
             var onCloseCalled = false;
-            await response.WatchAsync(ct,
+            await response.WatchAsync(
                 (ct_, evt, pod) =>
                 {
                     events.Add(evt);
@@ -901,7 +904,7 @@ namespace k8s.Tests
                 {
                     onCloseCalled = true;
                     return Task.CompletedTask;
-                });
+                }, ct);
 
             Assert.True(onCloseCalled);
             Assert.Equal(new WatchEventType[]

--- a/tests/KubernetesClient.Tests/WatcherTests.cs
+++ b/tests/KubernetesClient.Tests/WatcherTests.cs
@@ -3,10 +3,31 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace k8s.Tests
 {
+    class LineStreamReader : IAsyncLineReader
+    {
+        private readonly StreamReader _stream;
+
+        public LineStreamReader(Stream stream)
+        {
+            _stream = new StreamReader(stream);
+        }
+
+        public async Task<string> ReadLineAsync(CancellationToken cancellationToken)
+        {
+            return await _stream.ReadLineAsync();
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+        }
+    }
+
     public class WatcherTests
     {
         [Fact]
@@ -15,7 +36,7 @@ namespace k8s.Tests
             byte[] data = Encoding.UTF8.GetBytes("{\"type\":\"ERROR\",\"object\":{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"too old resource version: 44982(53593)\",\"reason\":\"Gone\",\"code\":410}}");
 
             using (MemoryStream stream = new MemoryStream(data))
-            using (StreamReader reader = new StreamReader(stream))
+            using (LineStreamReader reader = new LineStreamReader(stream))
             {
                 Exception recordedException = null;
                 ManualResetEvent mre = new ManualResetEvent(false);


### PR DESCRIPTION
This improves cancellation support for watches.  Currently cancellation only works when data is returned from the server because the Watcher object ends up calling StreamReader.ReadLineAsync() to fetch data from the http response and that API does not actually support cancellation.

Although this can be worked around by closing the underlying stream from the http response, If the initial List* call does not receive a response from the server (because there are no events to report yet) then the response object is of course unavailable and there is no way to cancel the List* call.  To fix this I've just avoided using StreamReader and implemented a simple line stream class that is used during watching that does support cancellation.

I am also not really clear on why the List* calls fetch the first line of the response when watching -- it would seem reasonable to wait for the subsequent Watch call to return the data -- however with cancellation support added it's not a big deal either way.  (There's another open case about that: https://github.com/kubernetes-client/csharp/issues/263).

I've also added an asynchronous watch interface which can be used like this:

```csharp
var result = await _k8s.ListNamespacedPodWithHttpMessagesAsync(
    "default",
    watch: true,
    cancellationToken: cancellationToken
).ConfigureAwait(false);
// ... do stuff with result
await result.WatchAsync<V1Pod>(cancellationToken, (cancellationToken, type, pod) => {
    // ... do stuff asynchronously
    return Task.CompletedTask;
});
```

This propagates the async and cancellation support to the callbacks as well as being more 'natural' for async code by implementing watching simply as an asynchronous function.

Please let me know what you think!

Thanks,

Mark
