### PR TITLE
Prevent NullReferenceException when using HttpClient to initialize Kubernetes client. Fixes #335

### DIFF
--- a/examples/httpClientFactory/Program.cs
+++ b/examples/httpClientFactory/Program.cs
@@ -31,7 +31,8 @@ namespace httpClientFactory
                             return new Kubernetes(
                                 serviceProvider.GetRequiredService<KubernetesClientConfiguration>(),
                                 httpClient);
-                        });
+                        })
+                        .ConfigurePrimaryHttpMessageHandler(config.CreateDefaultHttpClientHandler);
 
                     // Add the class that uses the client
                     services.AddHostedService<PodListHostedService>();

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -43,7 +43,7 @@ namespace k8s
             ValidateConfig(config);
             CaCerts = config.SslCaCerts;
             SkipTlsVerify = config.SkipTlsVerify;
-            InitializeFromConfig(config);
+            SetCredentials(config); 
         }
 
         /// <summary>
@@ -151,8 +151,9 @@ namespace k8s
                 }
             }
 
-            // set credentails for the kubernernet client
-            SetCredentials(config, HttpClientHandler);
+            // set credentails for the kubernetes client
+            SetCredentials(config);
+            config.AddCertificates(HttpClientHandler);
         }
 
         private X509Certificate2Collection CaCerts { get; }
@@ -195,9 +196,7 @@ namespace k8s
         ///     Set credentials for the Client
         /// </summary>
         /// <param name="config">k8s client configuration</param>
-        /// <param name="handler">http client handler for the rest client</param>
-        /// <returns>Task</returns>
-        private void SetCredentials(KubernetesClientConfiguration config, HttpClientHandler handler)
+        private void SetCredentials(KubernetesClientConfiguration config)
         {
             // set the Credentails for token based auth
             if (!string.IsNullOrWhiteSpace(config.AccessToken))
@@ -211,25 +210,6 @@ namespace k8s
                     UserName = config.Username,
                     Password = config.Password
                 };
-            }
-
-#if XAMARINIOS1_0 || MONOANDROID8_1
-            // handle.ClientCertificates is not implemented in Xamarin.
-            return;
-#endif
-
-            if ((!string.IsNullOrWhiteSpace(config.ClientCertificateData) ||
-                    !string.IsNullOrWhiteSpace(config.ClientCertificateFilePath)) &&
-                    (!string.IsNullOrWhiteSpace(config.ClientCertificateKeyData) ||
-                    !string.IsNullOrWhiteSpace(config.ClientKeyFilePath)))
-            {
-                var cert = CertUtils.GeneratePfx(config);
-
-#if NET452
-                ((WebRequestHandler) handler).ClientCertificates.Add(cert);
-#else
-                handler.ClientCertificates.Add(cert);
-#endif
             }
         }
 

--- a/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net.Http;
+
+namespace k8s
+{
+    public partial class KubernetesClientConfiguration {
+        public HttpClientHandler CreateDefaultHttpClientHandler() {
+            var httpClientHandler = new HttpClientHandler();
+
+#if !NET452
+            var uriScheme = new Uri(this.Host).Scheme;
+
+            if(uriScheme == "https")
+            {
+                if(this.SkipTlsVerify)
+                {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = 
+                        (sender, certificate, chain, sslPolicyErrors) => true;
+                }
+                else
+                {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
+                    {
+                        return Kubernetes.CertificateValidationCallBack(sender, this.SslCaCerts, certificate, chain, sslPolicyErrors);
+                    };
+                }
+            }
+#endif
+
+            AddCertificates(httpClientHandler);
+
+            return httpClientHandler;
+        }
+
+        public void AddCertificates(HttpClientHandler handler) {
+#if XAMARINIOS1_0 || MONOANDROID8_1
+            // handle.ClientCertificates is not implemented in Xamarin.
+            return;
+#endif
+
+            if ((!string.IsNullOrWhiteSpace(this.ClientCertificateData) ||
+                    !string.IsNullOrWhiteSpace(this.ClientCertificateFilePath)) &&
+                    (!string.IsNullOrWhiteSpace(this.ClientCertificateKeyData) ||
+                    !string.IsNullOrWhiteSpace(this.ClientKeyFilePath)))
+            {
+                var cert = CertUtils.GeneratePfx(this);
+
+#if NET452
+                ((WebRequestHandler) handler).ClientCertificates.Add(cert);
+#else
+                handler.ClientCertificates.Add(cert);
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
This should correct the NullReferenceException that occurs when passing in an HttpClient to the constructor of the Kubernetes client. This occurred because HttpClient objects are already initialized with an HttpClientHandler before being handed down to the Kubernetes client, and there's no way to retrieve that object from an HttpClient once initialized.

Because it's useful to set some values on an HttpClientHandler based on the Kubernetes configuration, I added a new file to the partial KubernetesClientConfiguration class that handles generation of a default HttpClientHandler based on the config. This replaced the need to call `InitializeFromConfig` in the Kubernetes.ConfigInit.cs class from the constructor that accepts an HttpClient. I've also updated the example named `httpClientFactory` to illustrate the use of this new function.

I also split the `SetCredentials` method in Kubernetes.ConfgInit.cs into two separate functions. Originally, this method was both setting credentials, and adding certificates to the HttpClientHandler. Because of the changes required to resolve this bug, it was necessary to pull the certificate related code out, and make it more generally usable, given an HttpClientHandler and a config object.

