### PR TITLE
fix gh action failed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ jobs:
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
Nerdbank.GitVersioning cannot read the obj id of master due to depth is only 1