### PR TITLE
Use `Path.DirectorySeparatorChar` to have ServiceAccountPath start from root

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.InCluster.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.InCluster.cs
@@ -8,7 +8,7 @@ namespace k8s
     {
         private static string ServiceAccountPath =
             Path.Combine(new string[] {
-                "var", "run", "secrets", "kubernetes.io", "serviceaccount/"
+                $"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount"
             });
         private const string ServiceAccountTokenKeyFileName = "token";
         private const string ServiceAccountRootCAKeyFileName = "ca.crt";


### PR DESCRIPTION
The path constructed in `KubernetesClientConfiguration::ServiceAccountPath` is a relative path, and this works fine as long as CWD is the root directory.

This PR uses `Path.DirectorySeparatorChar` to have `ServiceAccountPath` start from root, instead of a relative path.

This should work fine on Linux containers, but it still assumes the Windows container working drive is "C:"