### PR TITLE
Out-of-tree client authentication providers (UserCredentials exec option) for asp.net core applications

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/ExecCredentialResponse.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExecCredentialResponse.cs
@@ -10,6 +10,6 @@ namespace k8s.KubeConfigModels
         [JsonProperty("kind")]
         public string Kind { get; set; }
         [JsonProperty("status")]
-        public Dictionary<string, string> Status { get; set; }
+        public IDictionary<string, string> Status { get; set; }
     }
 }

--- a/src/KubernetesClient/KubeConfigModels/ExecCredentialResponse.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExecCredentialResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace k8s.KubeConfigModels
+{
+    public class ExecCredentialResponse
+    {
+        [JsonProperty("apiVersion")]
+        public string ApiVersion { get; set; }
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+        [JsonProperty("status")]
+        public Dictionary<string, string> Status { get; set; }
+    }
+}

--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -16,11 +16,11 @@ namespace k8s.KubeConfigModels
         /// Environment variables to set when executing the plugin. Optional.
         /// </summary>
         [YamlMember(Alias = "env")]
-        public Dictionary<string, string> EnvironmentVariables { get; set; }
+        public IDictionary<string, string> EnvironmentVariables { get; set; }
         /// <summary>
         /// Arguments to pass when executing the plugin. Optional.
         /// </summary>
         [YamlMember(Alias = "args")]
-        public List<string> Arguments { get; set; }
+        public IList<string> Arguments { get; set; }
     }
 }

--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+
+namespace k8s.KubeConfigModels
+{
+    public class ExternalExecution
+    {
+        [YamlMember(Alias = "apiVersion")]
+        public string ApiVersion { get; set; }
+        /// <summary>
+        /// The command to execute. Required.
+        /// </summary>
+        [YamlMember(Alias = "command")]
+        public string Command { get; set; }
+        /// <summary>
+        /// Environment variables to set when executing the plugin. Optional.
+        /// </summary>
+        [YamlMember(Alias = "env")]
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
+        /// <summary>
+        /// Arguments to pass when executing the plugin. Optional.
+        /// </summary>
+        [YamlMember(Alias = "args")]
+        public List<string> Arguments { get; set; }
+    }
+}

--- a/src/KubernetesClient/KubeConfigModels/UserCredentials.cs
+++ b/src/KubernetesClient/KubeConfigModels/UserCredentials.cs
@@ -80,5 +80,11 @@ namespace k8s.KubeConfigModels
         /// </summary>
         [YamlMember(Alias = "extensions")]
         public IDictionary<string, dynamic> Extensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets external command and its arguments to receive user credentials
+        /// </summary>
+        [YamlMember(Alias = "exec")]
+        public ExternalExecution ExternalExecution { get; set; }
     }
 }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -1,5 +1,5 @@
 using System;
-#if NETSTANDARD
+#if NETSTANDARD2_0
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -362,7 +362,7 @@ namespace k8s
                 }
             }
 
-#if NETSTANDARD
+#if NETSTANDARD2_0
             if (userDetails.UserCredentials.ExternalExecution != null)
             {
                 if (string.IsNullOrWhiteSpace(userDetails.UserCredentials.ExternalExecution.Command))
@@ -390,7 +390,7 @@ namespace k8s
             throw new KubeConfigException("Refresh not supported.");
         }
 
-#if NETSTANDARD
+#if NETSTANDARD2_0
         /// <summary>
         /// Implementation of the proposal for out-of-tree client
         /// authentication providers as described here --

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -1,6 +1,9 @@
 using System;
+#if NETCOREAPP
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
+#endif
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -8,7 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using k8s.Exceptions;
 using k8s.KubeConfigModels;
-using Newtonsoft.Json;
+
 
 namespace k8s
 {
@@ -359,6 +362,7 @@ namespace k8s
                 }
             }
 
+#if NETCOREAPP
             if (userDetails.UserCredentials.ExternalExecution != null)
             {
                 if (string.IsNullOrWhiteSpace(userDetails.UserCredentials.ExternalExecution.Command))
@@ -372,6 +376,7 @@ namespace k8s
 
                 userCredentialsFound = true;
             }
+#endif
 
             if (!userCredentialsFound)
             {
@@ -385,6 +390,7 @@ namespace k8s
             throw new KubeConfigException("Refresh not supported.");
         }
 
+#if NETCOREAPP
         /// <summary>
         /// Implementation of the proposal for out-of-tree client
         /// authentication providers as described here --
@@ -458,6 +464,7 @@ namespace k8s
             
 
         }
+#endif
 
         /// <summary>
         ///     Loads entire Kube Config from default or explicit file path

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -1,5 +1,5 @@
 using System;
-#if NETCOREAPP
+#if NETSTANDARD
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -362,7 +362,7 @@ namespace k8s
                 }
             }
 
-#if NETCOREAPP2_1 
+#if NETSTANDARD
             if (userDetails.UserCredentials.ExternalExecution != null)
             {
                 if (string.IsNullOrWhiteSpace(userDetails.UserCredentials.ExternalExecution.Command))
@@ -390,7 +390,7 @@ namespace k8s
             throw new KubeConfigException("Refresh not supported.");
         }
 
-#if NETCOREAPP
+#if NETSTANDARD
         /// <summary>
         /// Implementation of the proposal for out-of-tree client
         /// authentication providers as described here --
@@ -443,7 +443,8 @@ namespace k8s
             if (string.IsNullOrWhiteSpace(stderr) == false)
                 throw new KubeConfigException($"external exec failed due to: {stderr}");
 
-            process.WaitForExit();
+            // Wait for a maximum of 5 seconds, if a response takes longer probably something went wrong...
+            process.WaitForExit(5);
 
             try
             {

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Mail;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -159,7 +159,7 @@ namespace k8s
             var k8SConfiguration = new KubernetesClientConfiguration();
 
             currentContext = currentContext ?? k8SConfig.CurrentContext;
-            // only init context if context if set
+            // only init context if context is set
             if (currentContext != null)
             {
                 k8SConfiguration.InitializeContext(k8SConfig, currentContext);
@@ -423,7 +423,8 @@ namespace k8s
                         value: config.EnvironmentVariables[configEnvironmentVariableKey]);
 
             process.StartInfo.FileName = config.Command;
-            process.StartInfo.Arguments = string.Join(" ", config.Arguments);
+            if (config.Arguments != null)
+                process.StartInfo.Arguments = string.Join(" ", config.Arguments);
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -362,7 +362,7 @@ namespace k8s
                 }
             }
 
-#if NETCOREAPP
+#if NETCOREAPP2_1 
             if (userDetails.UserCredentials.ExternalExecution != null)
             {
                 if (string.IsNullOrWhiteSpace(userDetails.UserCredentials.ExternalExecution.Command))

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -433,7 +433,7 @@ namespace k8s.Tests
 
                 var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "echo";
 
-                string[] arguments;
+                var arguments = new string[] { };
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     arguments = ($"/c echo {responseJson}").Split(" ");
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -15,7 +15,6 @@ using k8s.Tests.Mock;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Rest;
-using Newtonsoft.Json;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
@@ -420,10 +419,7 @@ namespace k8s.Tests
                 new Context {Name = name, ContextDetails = new ContextDetails {Cluster = name, User = username}}
             };
 
-            var responseObject = new ExecCredentialResponse
-            {
-                ApiVersion = "testingversion", Status = new Dictionary<string, string> {{"token", token}}
-            };
+            var responseJson = $"{{\"apiVersion\": \"testingversion\", \"status\": {{\"token\": \"{token}\"}}}}";
 
             {
                 var clusters = new List<Cluster>
@@ -437,8 +433,8 @@ namespace k8s.Tests
 
                 var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "echo";
                 var arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? ($"/c echo {JsonConvert.SerializeObject(responseObject)}").Split(" ")
-                    : new[] {JsonConvert.SerializeObject(responseObject)};
+                    ? ($"/c echo {responseJson}").Split(" ")
+                    : new[] {responseJson};
 
                 var users = new List<User>
                 {

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -279,7 +279,8 @@ namespace k8s.Tests
         }
 
 #endif // NETCOREAPP2_1
-#if NETSTANDARD
+
+#if NETSTANDARD2_0
         [Fact]
         public void ExternalToken()
         {
@@ -318,7 +319,7 @@ namespace k8s.Tests
                 }
             }
         }
-#endif // NETSTANDARD
+#endif // NETSTANDARD2_0
 
         [Fact]
         public void Token()

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -169,7 +169,7 @@ namespace k8s.Tests
             }
         }
 
-#if NETCOREAPP2_1 // The functionality under test, here, is dependent on managed HTTP / WebSocket & Diagnostics functionality in .NET Core 2.1 or newer.
+#if NETCOREAPP2_1 // The functionality under test, here, is dependent on managed HTTP / WebSocket in .NET Core 2.1 or newer.
         [Fact]
         public void Cert()
         {
@@ -278,6 +278,8 @@ namespace k8s.Tests
             }
         }
 
+#endif // NETCOREAPP2_1
+#if NETSTANDARD
         [Fact]
         public void ExternalToken()
         {
@@ -316,7 +318,7 @@ namespace k8s.Tests
                 }
             }
         }
-#endif // NETCOREAPP2_1
+#endif // NETSTANDARD
 
         [Fact]
         public void Token()
@@ -432,14 +434,14 @@ namespace k8s.Tests
                 };
 
                 var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "echo";
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    command = "printf";
 
                 var arguments = new string[] { };
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     arguments = ($"/c echo {responseJson}").Split(" ");
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     arguments = new[] {responseJson};
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    arguments = new[] {"-nE", responseJson};
 
 
                 var users = new List<User>

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -432,9 +432,15 @@ namespace k8s.Tests
                 };
 
                 var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "echo";
-                var arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? ($"/c echo {responseJson}").Split(" ")
-                    : new[] {responseJson};
+
+                string[] arguments;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    arguments = ($"/c echo {responseJson}").Split(" ");
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    arguments = new[] {responseJson};
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    arguments = new[] {"-nE", responseJson};
+
 
                 var users = new List<User>
                 {

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -170,8 +170,7 @@ namespace k8s.Tests
             }
         }
 
-#if NETCOREAPP2_1 // The functionality under test, here, is dependent on managed HTTP / WebSocket functionality in .NET Core 2.1 or newer.
-
+#if NETCOREAPP2_1 // The functionality under test, here, is dependent on managed HTTP / WebSocket & Diagnostics functionality in .NET Core 2.1 or newer.
         [Fact]
         public void Cert()
         {
@@ -279,9 +278,7 @@ namespace k8s.Tests
                 }
             }
         }
-#endif // NETCOREAPP2_1
 
-#if NETCOREAPP // Requires NET Core Process (Diagnostics) Functionality
         [Fact]
         public void ExternalToken()
         {
@@ -320,7 +317,7 @@ namespace k8s.Tests
                 }
             }
         }
-#endif // NETCOREAPP
+#endif // NETCOREAPP2_1
 
         [Fact]
         public void Token()


### PR DESCRIPTION
after facing the same problem described in: https://github.com/kubernetes-client/csharp/issues/340
I've tried to create a version that will allow me to receive the token using an external command execution (as kubeconfig supports).

Implemented according to:
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/kubectl-exec-plugins.md
and with inspiration from the kubernetes python implementation (https://github.com/kubernetes-client/python-base/blob/master/config/exec_provider.py)

**1. I haven't written tests
2. Token refreshment hasn't been implemented meaning that once the token is expired a new token has to be generated, I am currently using my kubernetes "access layer" from the DI with a scoped life time cycle.
3. I've tested it running on Linux (_Amazon Linux 2_) only, not sure if it works properly on Windows/any other creature ;)**

Would appreciate help finishing and wrapping this up for usage.