### PR TITLE
[breaking changes] cleanup targets

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -31,7 +31,7 @@ echo Generating Code Coverage reports
 export PATH="$PATH:$HOME/.dotnet/tools"
 export DOTNET_ROOT=$(dirname $(realpath $(which dotnet))) # https://github.com/dotnet/cli/issues/9114#issuecomment-401670622
 dotnet tool install --global dotnet-reportgenerator-globaltool --version 4.0.15
-reportgenerator "-reports:**/*.opencover.xml" "-targetdir:coveragereport" "-reporttypes:HTMLInline;Cobertura"
+reportgenerator "-reports:**/*.opencover*.xml" "-targetdir:coveragereport" "-reporttypes:HTMLInline;Cobertura"
 
 ls coveragereport
 ls coveragereport/Cobertura.xml

--- a/gen/KubernetesWatchGenerator/KubernetesWatchGenerator.csproj
+++ b/gen/KubernetesWatchGenerator/KubernetesWatchGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSwag.Core" Version="11.17.2" />
-    <PackageReference Include="Nustache" Version="1.16.0.8" />
+    <PackageReference Include="Nustache" Version="1.16.0.8" NoWarn="NU1701" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -56,11 +56,7 @@ namespace k8s
         ///     Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
         public Kubernetes(KubernetesClientConfiguration config, params DelegatingHandler[] handlers)
-#if MONOANDROID8_1
-            : this(new Xamarin.Android.Net.AndroidClientHandler(), handlers)
-#else
             : this(handlers)
-#endif
         {
             ValidateConfig(config);
             CaCerts = config.SslCaCerts;
@@ -162,7 +158,7 @@ namespace k8s
 
         partial void CustomInitialize()
         {
-#if NET452 || XAMARINIOS1_0 || MONOANDROID8_1
+#if NET452 
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 #endif
             AppendDelegatingHandler<WatcherDelegatingHandler>();

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>The Kubernetes Project Authors</Authors>
     <Copyright>2017 The Kubernetes Project Authors</Copyright>
@@ -9,8 +9,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
-    <TargetFrameworks>netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>
@@ -34,30 +33,13 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.68" PrivateAssets="all" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Net.Http.WebRequest" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'xamarinios10'">
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="Xamarin.iOS" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'monoandroid81'">
-    <Reference Include="Mono.Android" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -10,7 +10,7 @@
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
     <TargetFrameworks>netstandard2.0;net452;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>kubernetes-client.snk</AssemblyOriginatorKeyFile>

--- a/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
@@ -33,11 +33,6 @@ namespace k8s
         }
 
         public void AddCertificates(HttpClientHandler handler) {
-#if XAMARINIOS1_0 || MONOANDROID8_1
-            // handle.ClientCertificates is not implemented in Xamarin.
-            return;
-#endif
-
             if ((!string.IsNullOrWhiteSpace(this.ClientCertificateData) ||
                     !string.IsNullOrWhiteSpace(this.ClientCertificateFilePath)) &&
                     (!string.IsNullOrWhiteSpace(this.ClientCertificateKeyData) ||

--- a/src/KubernetesClient/KubernetesException.cs
+++ b/src/KubernetesClient/KubernetesException.cs
@@ -1,8 +1,6 @@
 using k8s.Models;
 using System;
-#if !NETSTANDARD1_4
 using System.Runtime.Serialization;
-#endif
 
 namespace k8s
 {
@@ -58,7 +56,6 @@ namespace k8s
         {
         }
 
-#if !NETSTANDARD1_4
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesException"/> class with serialized data.
         /// </summary>
@@ -74,7 +71,6 @@ namespace k8s
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// Gets, when this exception was raised because of a Kubernetes status message, the underlying

--- a/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
+++ b/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>k8s.tests</RootNamespace>

--- a/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
+++ b/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>k8s.tests</RootNamespace>
@@ -6,10 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+      <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9">
+          <!-- this is due to aspnet core 2.1 is not compatible with our code -->
+          <AllowExplicitVersion>true</AllowExplicitVersion>
+      </PackageReference>
+
       <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-      <PackageReference Include="System.Reactive" Version="4.1.3" />
-      <PackageReference Include="Nito.AsyncEx" Version="4.0.1" />
+      <PackageReference Include="System.Reactive" Version="4.3.2" />
+      <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
@@ -21,15 +25,15 @@
 
   <ItemGroup>
 
-    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" NoWarn="NU1701" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.13.1" />
 
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/tests/KubernetesClient.Tests/Mock/MockKubeApiServer.cs
+++ b/tests/KubernetesClient.Tests/Mock/MockKubeApiServer.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace k8s.Tests.Mock
 {
-    public class MockKubeApiServer : IDisposable
+    public sealed class MockKubeApiServer : IDisposable
     {
         // paste from minikube /api/v1/namespaces/default/pods
         public const string MockPodResponse =

--- a/tests/KubernetesClient.Tests/YamlTests.cs
+++ b/tests/KubernetesClient.Tests/YamlTests.cs
@@ -28,11 +28,11 @@ metadata:
             types.Add("v1/Namespace", typeof(V1Namespace));
 
             var objs = Yaml.LoadAllFromString(content, types);
-            Assert.Equal(objs.Count, 2);
+            Assert.Equal(2, objs.Count);
             Assert.IsType<V1Pod>(objs[0]);
             Assert.IsType<V1Namespace>(objs[1]);
-            Assert.Equal(((V1Pod) objs[0]).Metadata.Name, "foo");
-            Assert.Equal(((V1Namespace) objs[1]).Metadata.Name, "ns");
+            Assert.Equal("foo", ((V1Pod) objs[0]).Metadata.Name);
+            Assert.Equal("ns", ((V1Namespace) objs[1]).Metadata.Name);
         }
 
         [Fact]


### PR DESCRIPTION
This is to cleanup targets to ensure the quality of code

<https://docs.microsoft.com/en-us/dotnet/standard/net-standard>
remove xamarin ios and android as they can reference netstandard2 directly (confirmed here #140)

removing those targets would also help building issues (#357)
and this is the first step to build nuget on gh action (cannot target xaramin). #239 #317 

here is the matrix after this patch

- [ ] netstandard1.4;
- [X] netstandard2.0;
- [X] net452;
- [ ] net461;
- [X] netcoreapp2.1;
- [ ] xamarinios10;
- [ ] monoandroid81

some comments for why other platforms are kept/removed:
`net452` it is still [supported by MS until 2023](https://stackoverflow.com/questions/58732338/when-is-end-of-life-for-dotnet-framework-4-5-2)
`netstandard1.4` [since `netcore1.0` is no longer support](https://devblogs.microsoft.com/dotnet/net-core-1-0-and-1-1-will-reach-end-of-life-on-june-27-2019/), netcore app should migrate to netcore2, we drop support for `netstandard1` there
`netcoreapp2.1`, I am working on to migrated those certificates code to pure `netstandard2.0`  will send another PR after this is merged
`net461`, included in `netstandard2.0`


see aslo
#303 #345
