### PR TITLE
Use value from ContextDetails to populate Namespace

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/Context.cs
+++ b/src/KubernetesClient/KubeConfigModels/Context.cs
@@ -1,5 +1,6 @@
 namespace k8s.KubeConfigModels
 {
+    using System;
     using YamlDotNet.Serialization;
 
     /// <summary>
@@ -19,6 +20,7 @@ namespace k8s.KubeConfigModels
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
 
+        [Obsolete("This property is not set by the YAML config. Use ContextDetails.Namespace instead.")]
         [YamlMember(Alias = "namespace")]
         public string Namespace { get; set; }
     }

--- a/src/KubernetesClient/KubeConfigModels/ContextDetails.cs
+++ b/src/KubernetesClient/KubeConfigModels/ContextDetails.cs
@@ -16,7 +16,7 @@ namespace k8s.KubeConfigModels
         public string Cluster { get; set; }
 
         /// <summary>
-        /// Gets or sets the anem of the user for this context.
+        /// Gets or sets the name of the user for this context.
         /// </summary>
         [YamlMember(Alias = "user")]
         public string User { get; set; }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -209,7 +209,7 @@ namespace k8s
             SetUserDetails(k8SConfig, activeContext);
 
             // namespace
-            Namespace = activeContext.Namespace ?? activeContext.ContextDetails?.Namespace;
+            Namespace = activeContext.ContextDetails?.Namespace;
         }
 
         private void SetClusterDetails(K8SConfiguration k8SConfig, Context activeContext)

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -193,6 +193,13 @@ namespace k8s
                 throw new KubeConfigException($"CurrentContext: {currentContext} not found in contexts in kubeconfig");
             }
 
+            if (string.IsNullOrEmpty(activeContext.ContextDetails?.Cluster))
+            {
+                // This serves as validation for any of the properties of ContextDetails being set.
+                // Other locations in code assume that ContextDetails is non-null.
+                throw new KubeConfigException($"Cluster not set for context `{currentContext}` in kubeconfig");
+            }
+
             CurrentContext = activeContext.Name;
 
             // cluster
@@ -202,7 +209,7 @@ namespace k8s
             SetUserDetails(k8SConfig, activeContext);
 
             // namespace
-            Namespace = activeContext.Namespace;
+            Namespace = activeContext.Namespace ?? activeContext.ContextDetails?.Namespace;
         }
 
         private void SetClusterDetails(K8SConfiguration k8SConfig, Context activeContext)
@@ -254,7 +261,7 @@ namespace k8s
 
             if (userDetails == null)
             {
-                throw new KubeConfigException("User not found for context {activeContext.Name} in kubeconfig");
+                throw new KubeConfigException($"User not found for context {activeContext.Name} in kubeconfig");
             }
 
             if (userDetails.UserCredentials == null)

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -436,7 +436,6 @@ namespace k8s.Tests
         private void AssertContextEqual(Context expected, Context actual)
         {
             Assert.Equal(expected.Name, actual.Name);
-            Assert.Equal(expected.Namespace, actual.Namespace);
             Assert.Equal(expected.ContextDetails.Cluster, actual.ContextDetails.Cluster);
             Assert.Equal(expected.ContextDetails.User, actual.ContextDetails.User);
             Assert.Equal(expected.ContextDetails.Namespace, actual.ContextDetails.Namespace);

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -22,6 +22,19 @@ namespace k8s.Tests
         }
 
         /// <summary>
+        ///     Check if namespace is properly loaded, per context
+        /// </summary>
+        [Theory]
+        [InlineData("federal-context", "chisel-ns")]
+        [InlineData("queen-anne-context", "saw-ns")]
+        public void ContextNamespace(string context, string @namespace)
+        {
+            var fi = new FileInfo("assets/kubeconfig.yml");
+            var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, context, useRelativePaths: false);
+            Assert.Equal(@namespace, cfg.Namespace);
+        }
+
+        /// <summary>
         ///     Checks if user-based token is loaded properly from the config file, per context
         /// </summary>
         /// <param name="context"></param>
@@ -188,6 +201,16 @@ namespace k8s.Tests
             var fi = new FileInfo("assets/kubeconfig-no-context.yml");
             Assert.Throws<KubeConfigException>(() =>
                 KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, "context"));
+        }
+
+        /// <summary>
+        ///     Checks that a KubeConfigException is thrown when the current context exists but has no details specified
+        /// </summary>
+        [Fact]
+        public void ContextNoDetails()
+        {
+            var fi = new FileInfo("assets/kubeconfig.no-context-details.yml");
+            Assert.Throws<KubeConfigException>(() => KubernetesClientConfiguration.BuildConfigFromConfigFile(fi));
         }
 
         /// <summary>

--- a/tests/KubernetesClient.Tests/assets/kubeconfig.no-context-details.yml
+++ b/tests/KubernetesClient.Tests/assets/kubeconfig.no-context-details.yml
@@ -1,0 +1,31 @@
+# Sample file based on https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/
+# WARNING: File includes minor fixes
+---
+current-context: federal-context
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://cow.org:8080
+  name: cow-cluster
+- cluster:
+    certificate-authority: assets/ca.crt
+    server: https://horse.org:4443
+  name: horse-cluster
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://pig.org:443
+  name: pig-cluster
+contexts:
+ - name: federal-context
+kind: Config
+users:
+- name: blue-user
+  user:
+    token: blue-token
+- name: green-user
+  user:
+    client-certificate: assets/client.crt
+    client-key: assets/client.key
+- name: black-user
+  user:
+    token: black-token    


### PR DESCRIPTION
**Use value from ContextDetails to populate Namespace**

Fixes: #372

This change uses the value from ContextDetails.Namespace to populate
KubernetesClientConfiguration.Namespace.

The issue is there's a Namespace property on both Context and ContextDetails
 - The property on Context is used today
 - The property on ContextDetails is not
 - The property on ContextDetails maps to the actual yaml config

---

**Obsolete Context.Namespace**

*I did a separate commit for this so we can skip it if you don't want it. Reasonable people disagree on whether its good semver to obsolete something in a patch/minor release. I'd like some confirmation as well about whether this property is supposed to be there for some reason*

This property doesn't map to anything in the YAML and thus will never be
set. Other clients I checked (java, golang) don't look for a property
at this level.

I think this was likely a mistake, and it should be obsoleted because
it will never be populated.

Example:

```yaml
contexts:
- context:
    cluster: ...
    namespace: ... # this is ContextDetails.Namespace
    user: ...
  name: foo
```

```yaml
contexts:
- context:
    cluster: ...
    namespace: ...
    user: ...
  name: foo
  namespace: ... # this is Context.Namespace
```

---