### PR TITLE
Add interfaces for generated Kubernetes objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ bin/
 *.user
 *.userosscache
 *.sln.docstates
+
+# JetBrains Rider
+.idea/
+*.sln.iml

--- a/gen/KubernetesWatchGenerator/ModelExtensions.cs.template
+++ b/gen/KubernetesWatchGenerator/ModelExtensions.cs.template
@@ -1,7 +1,7 @@
 namespace k8s.Models
 {
 {{#.}}
-    [KubernetesEntity(Group="{{GetGroup . }}", Kind="{{GetKind . }}", ApiVersion="{{GetApiVersion . }}")]
+    [KubernetesEntity(Group="{{GetGroup . }}", Kind="{{GetKind . }}", ApiVersion="{{GetApiVersion . }}", PluralName={{GetPlural .}})]
     public partial class {{GetClassName . }} : {{GetInterfaceName . }}
     {
         public const string KubeApiVersion = "{{GetApiVersion . }}";

--- a/gen/KubernetesWatchGenerator/ModelExtensions.cs.template
+++ b/gen/KubernetesWatchGenerator/ModelExtensions.cs.template
@@ -1,7 +1,8 @@
 namespace k8s.Models
 {
 {{#.}}
-    public partial class {{GetClassName . }} : IKubernetesObject
+    [KubernetesEntity(Group="{{GetGroup . }}", Kind="{{GetKind . }}", ApiVersion="{{GetApiVersion . }}")]
+    public partial class {{GetClassName . }} : {{GetInterfaceName . }}
     {
         public const string KubeApiVersion = "{{GetApiVersion . }}";
         public const string KubeKind = "{{GetKind . }}";

--- a/gen/KubernetesWatchGenerator/Program.cs
+++ b/gen/KubernetesWatchGenerator/Program.cs
@@ -4,6 +4,7 @@ using Nustache.Core;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -13,7 +14,10 @@ namespace KubernetesWatchGenerator
 {
     class Program
     {
+        private static HashSet<string> _classesWithValidation;
         static readonly Dictionary<string, string> ClassNameMap = new Dictionary<string, string>();
+        private static Dictionary<JsonSchema4, string> _schemaToNameMap;
+        private static HashSet<string> _schemaDefinitionsInMultipleGroups;
 
         static async Task Main(string[] args)
         {
@@ -45,10 +49,21 @@ namespace KubernetesWatchGenerator
 
             // gen project removed all watch operations, so here we switch back to unprocessed version
             swagger = await SwaggerDocument.FromFileAsync(Path.Combine(args[1], "swagger.json.unprocessed"));
-
+            _schemaToNameMap = swagger.Definitions.ToDictionary(x => x.Value, x => x.Key);
+            _schemaDefinitionsInMultipleGroups = _schemaToNameMap.Values.Select(x =>
+            {
+                var parts = x.Split(".");
+                return new {FullName = x, Name = parts[parts.Length - 1], Version = parts[parts.Length - 2], Group = parts[parts.Length - 3]};
+            })
+                .GroupBy(x => new {x.Name, x.Version})
+                .Where(x => x.Count() > 1)
+                .SelectMany(x => x)
+                .Select(x => x.FullName)
+                .ToHashSet();
             // Register helpers used in the templating.
             Helpers.Register(nameof(ToXmlDoc), ToXmlDoc);
             Helpers.Register(nameof(GetClassName), GetClassName);
+            Helpers.Register(nameof(GetInterfaceName), GetInterfaceName);
             Helpers.Register(nameof(GetMethodName), GetMethodName);
             Helpers.Register(nameof(GetDotNetName), GetDotNetName);
             Helpers.Register(nameof(GetDotNetType), GetDotNetType);
@@ -84,6 +99,13 @@ namespace KubernetesWatchGenerator
                     d => d.ExtensionData != null
                     && d.ExtensionData.ContainsKey("x-kubernetes-group-version-kind")
                     && !skippedTypes.Contains(GetClassName(d)));
+
+            var modelsDir = Path.Combine(outputDirectory, "Models");
+            _classesWithValidation = Directory.EnumerateFiles(modelsDir)
+                .Select(x => new {Class = Path.GetFileNameWithoutExtension(x), Content = File.ReadAllText(x)})
+                .Where(x => x.Content.Contains("public virtual void Validate()"))
+                .Select(x => x.Class)
+                .ToHashSet();
 
             Render.FileToFile("ModelExtensions.cs.template", definitions, Path.Combine(outputDirectory, "ModelExtensions.cs"));
         }
@@ -148,6 +170,66 @@ namespace KubernetesWatchGenerator
 
             return GetClassName(groupVersionKind);
         }
+        private static void GetInterfaceName(RenderContext context, IList<object> arguments, IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
+        {
+
+            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema4)
+            {
+                context.Write(GetInterfaceName(arguments[0] as JsonSchema4));
+            }
+
+        }
+
+        static string GetClassNameForSchemaDefinition(JsonSchema4 definition)
+        {
+            if (definition.ExtensionData != null && definition.ExtensionData.ContainsKey("x-kubernetes-group-version-kind"))
+                return GetClassName(definition);
+
+            var schemaName = _schemaToNameMap[definition];
+
+            var parts = schemaName.Split(".");
+            var group = parts[parts.Length - 3];
+            var version = parts[parts.Length - 2];
+            var entityName = parts[parts.Length - 1];
+            if (!_schemaDefinitionsInMultipleGroups.Contains(schemaName))
+                group = null;
+            var className = ToPascalCase($"{group}{version}{entityName}");
+            return className;
+
+        }
+        static string GetInterfaceName(JsonSchema4 definition)
+        {
+            var groupVersionKindElements = (object[])definition.ExtensionData["x-kubernetes-group-version-kind"];
+            var groupVersionKind = (Dictionary<string, object>)groupVersionKindElements[0];
+
+            var group = groupVersionKind["group"] as string;
+            var version = groupVersionKind["version"] as string;
+            var kind = groupVersionKind["kind"] as string;
+            var className = GetClassName(definition);
+            var interfaces = new List<string>();
+            interfaces.Add("IKubernetesObject");
+            if (definition.Properties.TryGetValue("metadata", out var metadataProperty))
+            {
+                interfaces.Add($"IMetadata<{GetClassNameForSchemaDefinition(metadataProperty.Reference)}>");
+            }
+
+            if (definition.Properties.TryGetValue("items", out var itemsProperty))
+            {
+                var schema = itemsProperty.Type == JsonObjectType.Object ? itemsProperty.Reference : itemsProperty.Item.Reference;
+                interfaces.Add($"IItems<{GetClassNameForSchemaDefinition(schema)}>");
+            }
+
+            if (definition.Properties.TryGetValue("spec", out var specProperty))
+            {
+                interfaces.Add($"ISpec<{GetClassNameForSchemaDefinition(specProperty.Reference)}>");
+            }
+
+            if(_classesWithValidation.Contains(className))
+                interfaces.Add("IValidate");
+            var result = string.Join(", ", interfaces);
+            return result;
+        }
+
 
         static void GetKind(RenderContext context, IList<object> arguments, IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
         {

--- a/src/KubernetesClient/IItems.cs
+++ b/src/KubernetesClient/IItems.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace k8s
+{
+    /// <summary>
+    /// Kubernetes object that exposes list of objects
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IItems<T>
+    {
+        /// <summary>
+        /// Gets or sets list of objects. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+        /// </summary>
+        IList<T> Items { get; set; }
+    }
+}

--- a/src/KubernetesClient/IMetadata.cs
+++ b/src/KubernetesClient/IMetadata.cs
@@ -1,0 +1,18 @@
+using k8s.Models;
+
+namespace k8s
+{
+    /// <summary>
+    /// Kubernetes object that exposes metadata
+    /// </summary>
+    /// <typeparam name="T">Type of metadata exposed. Usually this will be either
+    /// <see cref="V1ListMeta"/> for lists or <see cref="V1ObjectMeta"/> for objects</typeparam>
+    public interface IMetadata<T>
+    {
+        /// <summary>
+        /// Gets or sets standard object's metadata. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        /// </summary>
+        T Metadata { get; set; }
+    }
+}

--- a/src/KubernetesClient/ISpec.cs
+++ b/src/KubernetesClient/ISpec.cs
@@ -1,0 +1,17 @@
+namespace k8s
+{
+    /// <summary>
+    /// Represents a Kubernetes object that has a spec
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ISpec<T>
+    {
+        /// <summary>
+        /// Gets or sets specification of the desired behavior of the entity. More
+        /// info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        /// </summary>
+        /// </summary>
+        T Spec { get; set; }
+    }
+}

--- a/src/KubernetesClient/IStatus.cs
+++ b/src/KubernetesClient/IStatus.cs
@@ -1,0 +1,17 @@
+namespace k8s
+{
+    /// <summary>
+    /// Kubernetes object that exposes status
+    /// </summary>
+    /// <typeparam name="T">The type of status object</typeparam>
+    public interface IStatus<T>
+    {
+        /// <summary>
+        /// Gets or sets most recently observed status of the object. This data
+        /// may not be up to date. Populated by the system. Read-only. More
+        /// info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        /// </summary>
+        T Status { get; set; }
+    }
+}

--- a/src/KubernetesClient/IValidate.cs
+++ b/src/KubernetesClient/IValidate.cs
@@ -1,0 +1,14 @@
+namespace k8s
+{
+    /// <summary>
+    /// Object that allows self validation
+    /// </summary>
+    public interface IValidate
+    {
+        /// <summary>
+        /// Validate the object.
+        /// </summary>
+        void Validate();
+
+    }
+}

--- a/src/KubernetesClient/KubernetesEntityAttribute.cs
+++ b/src/KubernetesClient/KubernetesEntityAttribute.cs
@@ -19,5 +19,9 @@ namespace k8s.Models
         /// The API Version this Kubernetes type belongs to
         /// </summary>
         public string ApiVersion { get; set; }
+        /// <summary>
+        /// The plural name of the entity
+        /// </summary>
+        public string PluralName { get; set; }
     }
 }

--- a/src/KubernetesClient/KubernetesEntityAttribute.cs
+++ b/src/KubernetesClient/KubernetesEntityAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace k8s.Models
+{
+    /// <summary>
+    /// Describes object type in Kubernetes
+    /// </summary>
+    public class KubernetesEntityAttribute : Attribute
+    {
+        /// <summary>
+        /// The Kubernetes named schema this object is based on
+        /// </summary>
+        public string Kind { get; set; }
+        /// <summary>
+        /// The Group this Kubernetes type belongs to
+        /// </summary>
+        public string Group { get; set; }
+        /// <summary>
+        /// The API Version this Kubernetes type belongs to
+        /// </summary>
+        public string ApiVersion { get; set; }
+    }
+}

--- a/src/KubernetesClient/KubernetesList.cs
+++ b/src/KubernetesClient/KubernetesList.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using k8s.Models;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+
+namespace k8s.Models
+{
+
+    public class KubernetesList<T> : IMetadata<V1ListMeta>, IItems<T> where T : IKubernetesObject
+    {
+
+        public KubernetesList(IList<T> items, string apiVersion = default(string), string kind = default(string), V1ListMeta metadata = default(V1ListMeta))
+        {
+            ApiVersion = apiVersion;
+            Items = items;
+            Kind = kind;
+            Metadata = metadata;
+        }
+
+
+        /// <summary>
+        /// Gets or sets aPIVersion defines the versioned schema of this
+        /// representation of an object. Servers should convert recognized
+        /// schemas to the latest internal value, and may reject unrecognized
+        /// values. More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        /// </summary>
+        [JsonProperty(PropertyName = "apiVersion")]
+        public string ApiVersion { get; set; }
+
+        [JsonProperty(PropertyName = "items")]
+        public IList<T> Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets kind is a string value representing the REST resource
+        /// this object represents. Servers may infer this from the endpoint
+        /// the client submits requests to. Cannot be updated. In CamelCase.
+        /// More info:
+        /// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        /// </summary>
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+
+        /// <summary>
+        /// Gets or sets standard object's metadata.
+        /// </summary>
+        [JsonProperty(PropertyName = "metadata")]
+        public V1ListMeta Metadata { get; set; }
+
+        /// <summary>
+        /// Validate the object.
+        /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
+        public void Validate()
+        {
+            if (Items == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Items");
+            }
+            if (Items != null)
+            {
+                foreach (var element in Items.OfType<IValidate>())
+                {
+                    element.Validate();
+                }
+            }
+        }
+    }
+}

--- a/src/KubernetesClient/generated/ModelExtensions.cs
+++ b/src/KubernetesClient/generated/ModelExtensions.cs
@@ -1,1314 +1,1502 @@
 namespace k8s.Models
 {
-    public partial class V1MutatingWebhookConfiguration : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1")]
+    public partial class V1MutatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "MutatingWebhookConfiguration";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1MutatingWebhookConfigurationList : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1")]
+    public partial class V1MutatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1MutatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "MutatingWebhookConfigurationList";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1ValidatingWebhookConfiguration : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1")]
+    public partial class V1ValidatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ValidatingWebhookConfiguration";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1ValidatingWebhookConfigurationList : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1")]
+    public partial class V1ValidatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ValidatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ValidatingWebhookConfigurationList";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1beta1MutatingWebhookConfiguration : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1beta1")]
+    public partial class V1beta1MutatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "MutatingWebhookConfiguration";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1beta1MutatingWebhookConfigurationList : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1beta1")]
+    public partial class V1beta1MutatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1MutatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "MutatingWebhookConfigurationList";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1beta1ValidatingWebhookConfiguration : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1beta1")]
+    public partial class V1beta1ValidatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ValidatingWebhookConfiguration";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1beta1ValidatingWebhookConfigurationList : IKubernetesObject
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1beta1")]
+    public partial class V1beta1ValidatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ValidatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ValidatingWebhookConfigurationList";
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    public partial class V1ControllerRevision : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1")]
+    public partial class V1ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ControllerRevision";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1ControllerRevisionList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1")]
+    public partial class V1ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ControllerRevisionList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1DaemonSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1")]
+    public partial class V1DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "DaemonSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1DaemonSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1")]
+    public partial class V1DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "DaemonSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1Deployment : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1")]
+    public partial class V1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Deployment";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1DeploymentList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1")]
+    public partial class V1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "DeploymentList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1ReplicaSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1")]
+    public partial class V1ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ReplicaSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1ReplicaSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1")]
+    public partial class V1ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ReplicaSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1StatefulSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1")]
+    public partial class V1StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "StatefulSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1StatefulSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1")]
+    public partial class V1StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "StatefulSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta1ControllerRevision : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta1")]
+    public partial class V1beta1ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ControllerRevision";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta1ControllerRevisionList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta1")]
+    public partial class V1beta1ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ControllerRevisionList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class Appsv1beta1Deployment : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta1")]
+    public partial class Appsv1beta1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Appsv1beta1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Deployment";
         public const string KubeGroup = "apps";
     }
 
-    public partial class Appsv1beta1DeploymentList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta1")]
+    public partial class Appsv1beta1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Appsv1beta1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DeploymentList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class Appsv1beta1DeploymentRollback : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DeploymentRollback", ApiVersion="v1beta1")]
+    public partial class Appsv1beta1DeploymentRollback : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DeploymentRollback";
         public const string KubeGroup = "apps";
     }
 
-    public partial class Appsv1beta1Scale : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta1")]
+    public partial class Appsv1beta1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Appsv1beta1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Scale";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta1StatefulSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta1")]
+    public partial class V1beta1StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "StatefulSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta1StatefulSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta1")]
+    public partial class V1beta1StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "StatefulSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2ControllerRevision : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta2")]
+    public partial class V1beta2ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "ControllerRevision";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2ControllerRevisionList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta2")]
+    public partial class V1beta2ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "ControllerRevisionList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2DaemonSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1beta2")]
+    public partial class V1beta2DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "DaemonSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2DaemonSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1beta2")]
+    public partial class V1beta2DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "DaemonSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2Deployment : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta2")]
+    public partial class V1beta2Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "Deployment";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2DeploymentList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta2")]
+    public partial class V1beta2DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "DeploymentList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2ReplicaSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1beta2")]
+    public partial class V1beta2ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "ReplicaSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2ReplicaSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1beta2")]
+    public partial class V1beta2ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "ReplicaSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2Scale : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta2")]
+    public partial class V1beta2Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "Scale";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2StatefulSet : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta2")]
+    public partial class V1beta2StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "StatefulSet";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1beta2StatefulSetList : IKubernetesObject
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta2")]
+    public partial class V1beta2StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
         public const string KubeKind = "StatefulSetList";
         public const string KubeGroup = "apps";
     }
 
-    public partial class V1alpha1AuditSink : IKubernetesObject
+    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSink", ApiVersion="v1alpha1")]
+    public partial class V1alpha1AuditSink : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1AuditSinkSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "AuditSink";
         public const string KubeGroup = "auditregistration.k8s.io";
     }
 
-    public partial class V1alpha1AuditSinkList : IKubernetesObject
+    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSinkList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1AuditSinkList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1AuditSink>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "AuditSinkList";
         public const string KubeGroup = "auditregistration.k8s.io";
     }
 
-    public partial class V1TokenRequest : IKubernetesObject
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenRequest", ApiVersion="v1")]
+    public partial class V1TokenRequest : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1TokenRequestSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "TokenRequest";
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    public partial class V1TokenReview : IKubernetesObject
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1")]
+    public partial class V1TokenReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1TokenReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "TokenReview";
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    public partial class V1beta1TokenReview : IKubernetesObject
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1beta1")]
+    public partial class V1beta1TokenReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1TokenReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "TokenReview";
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    public partial class V1LocalSubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1")]
+    public partial class V1LocalSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "LocalSubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1SelfSubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1")]
+    public partial class V1SelfSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SelfSubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "SelfSubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1SelfSubjectRulesReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1")]
+    public partial class V1SelfSubjectRulesReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SelfSubjectRulesReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "SelfSubjectRulesReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1SubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1")]
+    public partial class V1SubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "SubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1beta1LocalSubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1beta1")]
+    public partial class V1beta1LocalSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "LocalSubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1beta1SelfSubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1beta1")]
+    public partial class V1beta1SelfSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SelfSubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "SelfSubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1beta1SelfSubjectRulesReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1beta1")]
+    public partial class V1beta1SelfSubjectRulesReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SelfSubjectRulesReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "SelfSubjectRulesReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1beta1SubjectAccessReview : IKubernetesObject
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1beta1")]
+    public partial class V1beta1SubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "SubjectAccessReview";
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    public partial class V1HorizontalPodAutoscaler : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v1")]
+    public partial class V1HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "HorizontalPodAutoscaler";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V1HorizontalPodAutoscalerList : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v1")]
+    public partial class V1HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "HorizontalPodAutoscalerList";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V1Scale : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="Scale", ApiVersion="v1")]
+    public partial class V1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Scale";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V2beta1HorizontalPodAutoscaler : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta1")]
+    public partial class V2beta1HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2beta1HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v2beta1";
         public const string KubeKind = "HorizontalPodAutoscaler";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V2beta1HorizontalPodAutoscalerList : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta1")]
+    public partial class V2beta1HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2beta1HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v2beta1";
         public const string KubeKind = "HorizontalPodAutoscalerList";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V2beta2HorizontalPodAutoscaler : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta2")]
+    public partial class V2beta2HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2beta2HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v2beta2";
         public const string KubeKind = "HorizontalPodAutoscaler";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V2beta2HorizontalPodAutoscalerList : IKubernetesObject
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta2")]
+    public partial class V2beta2HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2beta2HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v2beta2";
         public const string KubeKind = "HorizontalPodAutoscalerList";
         public const string KubeGroup = "autoscaling";
     }
 
-    public partial class V1Job : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="Job", ApiVersion="v1")]
+    public partial class V1Job : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1JobSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Job";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V1JobList : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="JobList", ApiVersion="v1")]
+    public partial class V1JobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Job>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "JobList";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V1beta1CronJob : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v1beta1")]
+    public partial class V1beta1CronJob : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CronJobSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CronJob";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V1beta1CronJobList : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v1beta1")]
+    public partial class V1beta1CronJobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CronJob>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CronJobList";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V2alpha1CronJob : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v2alpha1")]
+    public partial class V2alpha1CronJob : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2alpha1CronJobSpec>, IValidate
     {
         public const string KubeApiVersion = "v2alpha1";
         public const string KubeKind = "CronJob";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V2alpha1CronJobList : IKubernetesObject
+    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v2alpha1")]
+    public partial class V2alpha1CronJobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2alpha1CronJob>, IValidate
     {
         public const string KubeApiVersion = "v2alpha1";
         public const string KubeKind = "CronJobList";
         public const string KubeGroup = "batch";
     }
 
-    public partial class V1beta1CertificateSigningRequest : IKubernetesObject
+    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequest", ApiVersion="v1beta1")]
+    public partial class V1beta1CertificateSigningRequest : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CertificateSigningRequestSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CertificateSigningRequest";
         public const string KubeGroup = "certificates.k8s.io";
     }
 
-    public partial class V1beta1CertificateSigningRequestList : IKubernetesObject
+    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequestList", ApiVersion="v1beta1")]
+    public partial class V1beta1CertificateSigningRequestList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CertificateSigningRequest>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CertificateSigningRequestList";
         public const string KubeGroup = "certificates.k8s.io";
     }
 
-    public partial class V1Lease : IKubernetesObject
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1")]
+    public partial class V1Lease : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1LeaseSpec>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Lease";
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    public partial class V1LeaseList : IKubernetesObject
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1")]
+    public partial class V1LeaseList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Lease>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "LeaseList";
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    public partial class V1beta1Lease : IKubernetesObject
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1beta1")]
+    public partial class V1beta1Lease : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1LeaseSpec>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Lease";
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    public partial class V1beta1LeaseList : IKubernetesObject
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1beta1")]
+    public partial class V1beta1LeaseList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Lease>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "LeaseList";
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    public partial class V1Binding : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Binding", ApiVersion="v1")]
+    public partial class V1Binding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Binding";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ComponentStatus : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ComponentStatus", ApiVersion="v1")]
+    public partial class V1ComponentStatus : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ComponentStatus";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ComponentStatusList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ComponentStatusList", ApiVersion="v1")]
+    public partial class V1ComponentStatusList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ComponentStatus>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ComponentStatusList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ConfigMap : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ConfigMap", ApiVersion="v1")]
+    public partial class V1ConfigMap : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ConfigMap";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ConfigMapList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ConfigMapList", ApiVersion="v1")]
+    public partial class V1ConfigMapList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ConfigMap>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ConfigMapList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Endpoints : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Endpoints", ApiVersion="v1")]
+    public partial class V1Endpoints : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Endpoints";
         public const string KubeGroup = "";
     }
 
-    public partial class V1EndpointsList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="EndpointsList", ApiVersion="v1")]
+    public partial class V1EndpointsList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Endpoints>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "EndpointsList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Event : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Event", ApiVersion="v1")]
+    public partial class V1Event : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Event";
         public const string KubeGroup = "";
     }
 
-    public partial class V1EventList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="EventList", ApiVersion="v1")]
+    public partial class V1EventList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Event>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "EventList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1LimitRange : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="LimitRange", ApiVersion="v1")]
+    public partial class V1LimitRange : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1LimitRangeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "LimitRange";
         public const string KubeGroup = "";
     }
 
-    public partial class V1LimitRangeList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="LimitRangeList", ApiVersion="v1")]
+    public partial class V1LimitRangeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1LimitRange>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "LimitRangeList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Namespace : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Namespace", ApiVersion="v1")]
+    public partial class V1Namespace : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NamespaceSpec>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Namespace";
         public const string KubeGroup = "";
     }
 
-    public partial class V1NamespaceList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="NamespaceList", ApiVersion="v1")]
+    public partial class V1NamespaceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Namespace>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "NamespaceList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Node : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Node", ApiVersion="v1")]
+    public partial class V1Node : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NodeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Node";
         public const string KubeGroup = "";
     }
 
-    public partial class V1NodeList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="NodeList", ApiVersion="v1")]
+    public partial class V1NodeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Node>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "NodeList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PersistentVolume : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PersistentVolume", ApiVersion="v1")]
+    public partial class V1PersistentVolume : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PersistentVolumeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PersistentVolume";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PersistentVolumeClaim : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PersistentVolumeClaim", ApiVersion="v1")]
+    public partial class V1PersistentVolumeClaim : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PersistentVolumeClaimSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PersistentVolumeClaim";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PersistentVolumeClaimList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PersistentVolumeClaimList", ApiVersion="v1")]
+    public partial class V1PersistentVolumeClaimList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PersistentVolumeClaim>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PersistentVolumeClaimList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PersistentVolumeList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PersistentVolumeList", ApiVersion="v1")]
+    public partial class V1PersistentVolumeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PersistentVolume>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PersistentVolumeList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Pod : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Pod", ApiVersion="v1")]
+    public partial class V1Pod : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PodSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Pod";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PodList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PodList", ApiVersion="v1")]
+    public partial class V1PodList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Pod>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PodList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PodTemplate : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PodTemplate", ApiVersion="v1")]
+    public partial class V1PodTemplate : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PodTemplate";
         public const string KubeGroup = "";
     }
 
-    public partial class V1PodTemplateList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="PodTemplateList", ApiVersion="v1")]
+    public partial class V1PodTemplateList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PodTemplate>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PodTemplateList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ReplicationController : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ReplicationController", ApiVersion="v1")]
+    public partial class V1ReplicationController : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ReplicationControllerSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ReplicationController";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ReplicationControllerList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ReplicationControllerList", ApiVersion="v1")]
+    public partial class V1ReplicationControllerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ReplicationController>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ReplicationControllerList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ResourceQuota : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ResourceQuota", ApiVersion="v1")]
+    public partial class V1ResourceQuota : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ResourceQuotaSpec>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ResourceQuota";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ResourceQuotaList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ResourceQuotaList", ApiVersion="v1")]
+    public partial class V1ResourceQuotaList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ResourceQuota>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ResourceQuotaList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Secret : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Secret", ApiVersion="v1")]
+    public partial class V1Secret : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Secret";
         public const string KubeGroup = "";
     }
 
-    public partial class V1SecretList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="SecretList", ApiVersion="v1")]
+    public partial class V1SecretList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Secret>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "SecretList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1Service : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Service", ApiVersion="v1")]
+    public partial class V1Service : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ServiceSpec>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Service";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ServiceAccount : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ServiceAccount", ApiVersion="v1")]
+    public partial class V1ServiceAccount : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ServiceAccount";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ServiceAccountList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ServiceAccountList", ApiVersion="v1")]
+    public partial class V1ServiceAccountList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ServiceAccount>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ServiceAccountList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1ServiceList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="ServiceList", ApiVersion="v1")]
+    public partial class V1ServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Service>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ServiceList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1alpha1EndpointSlice : IKubernetesObject
+    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSlice", ApiVersion="v1alpha1")]
+    public partial class V1alpha1EndpointSlice : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "EndpointSlice";
         public const string KubeGroup = "discovery.k8s.io";
     }
 
-    public partial class V1alpha1EndpointSliceList : IKubernetesObject
+    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSliceList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1EndpointSliceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1EndpointSlice>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "EndpointSliceList";
         public const string KubeGroup = "discovery.k8s.io";
     }
 
-    public partial class V1beta1Event : IKubernetesObject
+    [KubernetesEntity(Group="events.k8s.io", Kind="Event", ApiVersion="v1beta1")]
+    public partial class V1beta1Event : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Event";
         public const string KubeGroup = "events.k8s.io";
     }
 
-    public partial class V1beta1EventList : IKubernetesObject
+    [KubernetesEntity(Group="events.k8s.io", Kind="EventList", ApiVersion="v1beta1")]
+    public partial class V1beta1EventList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Event>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "EventList";
         public const string KubeGroup = "events.k8s.io";
     }
 
-    public partial class V1beta1DaemonSet : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="DaemonSet", ApiVersion="v1beta1")]
+    public partial class V1beta1DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DaemonSet";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1beta1DaemonSetList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="DaemonSetList", ApiVersion="v1beta1")]
+    public partial class V1beta1DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DaemonSetList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1Deployment : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="Deployment", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Deployment";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1DeploymentList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="DeploymentList", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DeploymentList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1DeploymentRollback : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="DeploymentRollback", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1DeploymentRollback : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "DeploymentRollback";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1Ingress : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="Ingress", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1Ingress : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1IngressSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Ingress";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1IngressList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="IngressList", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1IngressList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1Ingress>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "IngressList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1beta1NetworkPolicy : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="NetworkPolicy", ApiVersion="v1beta1")]
+    public partial class V1beta1NetworkPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1NetworkPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "NetworkPolicy";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1beta1NetworkPolicyList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="NetworkPolicyList", ApiVersion="v1beta1")]
+    public partial class V1beta1NetworkPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1NetworkPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "NetworkPolicyList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1PodSecurityPolicy : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicy", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1PodSecurityPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1PodSecurityPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodSecurityPolicy";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1PodSecurityPolicyList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicyList", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1PodSecurityPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1PodSecurityPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodSecurityPolicyList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1beta1ReplicaSet : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="ReplicaSet", ApiVersion="v1beta1")]
+    public partial class V1beta1ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ReplicaSet";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1beta1ReplicaSetList : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="ReplicaSetList", ApiVersion="v1beta1")]
+    public partial class V1beta1ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ReplicaSetList";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class Extensionsv1beta1Scale : IKubernetesObject
+    [KubernetesEntity(Group="extensions", Kind="Scale", ApiVersion="v1beta1")]
+    public partial class Extensionsv1beta1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Scale";
         public const string KubeGroup = "extensions";
     }
 
-    public partial class V1NetworkPolicy : IKubernetesObject
+    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicy", ApiVersion="v1")]
+    public partial class V1NetworkPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NetworkPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "NetworkPolicy";
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    public partial class V1NetworkPolicyList : IKubernetesObject
+    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicyList", ApiVersion="v1")]
+    public partial class V1NetworkPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1NetworkPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "NetworkPolicyList";
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    public partial class Networkingv1beta1Ingress : IKubernetesObject
+    [KubernetesEntity(Group="networking.k8s.io", Kind="Ingress", ApiVersion="v1beta1")]
+    public partial class Networkingv1beta1Ingress : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Networkingv1beta1IngressSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Ingress";
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    public partial class Networkingv1beta1IngressList : IKubernetesObject
+    [KubernetesEntity(Group="networking.k8s.io", Kind="IngressList", ApiVersion="v1beta1")]
+    public partial class Networkingv1beta1IngressList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Networkingv1beta1Ingress>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "IngressList";
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    public partial class V1alpha1RuntimeClass : IKubernetesObject
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1alpha1")]
+    public partial class V1alpha1RuntimeClass : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1RuntimeClassSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "RuntimeClass";
         public const string KubeGroup = "node.k8s.io";
     }
 
-    public partial class V1alpha1RuntimeClassList : IKubernetesObject
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1RuntimeClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1RuntimeClass>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "RuntimeClassList";
         public const string KubeGroup = "node.k8s.io";
     }
 
-    public partial class V1beta1RuntimeClass : IKubernetesObject
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1beta1")]
+    public partial class V1beta1RuntimeClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "RuntimeClass";
         public const string KubeGroup = "node.k8s.io";
     }
 
-    public partial class V1beta1RuntimeClassList : IKubernetesObject
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1beta1")]
+    public partial class V1beta1RuntimeClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1RuntimeClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "RuntimeClassList";
         public const string KubeGroup = "node.k8s.io";
     }
 
-    public partial class V1beta1Eviction : IKubernetesObject
+    [KubernetesEntity(Group="policy", Kind="Eviction", ApiVersion="v1beta1")]
+    public partial class V1beta1Eviction : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Eviction";
         public const string KubeGroup = "policy";
     }
 
-    public partial class V1beta1PodDisruptionBudget : IKubernetesObject
+    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudget", ApiVersion="v1beta1")]
+    public partial class V1beta1PodDisruptionBudget : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1PodDisruptionBudgetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodDisruptionBudget";
         public const string KubeGroup = "policy";
     }
 
-    public partial class V1beta1PodDisruptionBudgetList : IKubernetesObject
+    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudgetList", ApiVersion="v1beta1")]
+    public partial class V1beta1PodDisruptionBudgetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1PodDisruptionBudget>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodDisruptionBudgetList";
         public const string KubeGroup = "policy";
     }
 
-    public partial class Policyv1beta1PodSecurityPolicy : IKubernetesObject
+    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicy", ApiVersion="v1beta1")]
+    public partial class Policyv1beta1PodSecurityPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Policyv1beta1PodSecurityPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodSecurityPolicy";
         public const string KubeGroup = "policy";
     }
 
-    public partial class Policyv1beta1PodSecurityPolicyList : IKubernetesObject
+    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicyList", ApiVersion="v1beta1")]
+    public partial class Policyv1beta1PodSecurityPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Policyv1beta1PodSecurityPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PodSecurityPolicyList";
         public const string KubeGroup = "policy";
     }
 
-    public partial class V1ClusterRole : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1")]
+    public partial class V1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ClusterRole";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1ClusterRoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1")]
+    public partial class V1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ClusterRoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1ClusterRoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1")]
+    public partial class V1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ClusterRoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1ClusterRoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1")]
+    public partial class V1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "ClusterRoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1Role : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1")]
+    public partial class V1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Role";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1RoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1")]
+    public partial class V1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "RoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1RoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1")]
+    public partial class V1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "RoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1RoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1")]
+    public partial class V1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Role>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "RoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1ClusterRole : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1alpha1")]
+    public partial class V1alpha1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "ClusterRole";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1ClusterRoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1alpha1")]
+    public partial class V1alpha1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "ClusterRoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1ClusterRoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "ClusterRoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1ClusterRoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "ClusterRoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1Role : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1alpha1")]
+    public partial class V1alpha1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "Role";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1RoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1alpha1")]
+    public partial class V1alpha1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "RoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1RoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "RoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1alpha1RoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1Role>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "RoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1ClusterRole : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1beta1")]
+    public partial class V1beta1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ClusterRole";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1ClusterRoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1beta1")]
+    public partial class V1beta1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ClusterRoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1ClusterRoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1beta1")]
+    public partial class V1beta1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ClusterRoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1ClusterRoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1beta1")]
+    public partial class V1beta1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "ClusterRoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1Role : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1beta1")]
+    public partial class V1beta1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "Role";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1RoleBinding : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1beta1")]
+    public partial class V1beta1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "RoleBinding";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1RoleBindingList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1beta1")]
+    public partial class V1beta1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "RoleBindingList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1beta1RoleList : IKubernetesObject
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1beta1")]
+    public partial class V1beta1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Role>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "RoleList";
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    public partial class V1PriorityClass : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1")]
+    public partial class V1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PriorityClass";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1PriorityClassList : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1")]
+    public partial class V1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "PriorityClassList";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1alpha1PriorityClass : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1alpha1")]
+    public partial class V1alpha1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "PriorityClass";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1alpha1PriorityClassList : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "PriorityClassList";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1beta1PriorityClass : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1beta1")]
+    public partial class V1beta1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PriorityClass";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1beta1PriorityClassList : IKubernetesObject
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1beta1")]
+    public partial class V1beta1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "PriorityClassList";
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    public partial class V1alpha1PodPreset : IKubernetesObject
+    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPreset", ApiVersion="v1alpha1")]
+    public partial class V1alpha1PodPreset : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1PodPresetSpec>
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "PodPreset";
         public const string KubeGroup = "settings.k8s.io";
     }
 
-    public partial class V1alpha1PodPresetList : IKubernetesObject
+    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPresetList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1PodPresetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1PodPreset>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "PodPresetList";
         public const string KubeGroup = "settings.k8s.io";
     }
 
-    public partial class V1StorageClass : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1")]
+    public partial class V1StorageClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "StorageClass";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1StorageClassList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1")]
+    public partial class V1StorageClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1StorageClass>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "StorageClassList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1VolumeAttachment : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1")]
+    public partial class V1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "VolumeAttachment";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1VolumeAttachmentList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1")]
+    public partial class V1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "VolumeAttachmentList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1alpha1VolumeAttachment : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1alpha1")]
+    public partial class V1alpha1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "VolumeAttachment";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1alpha1VolumeAttachmentList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1alpha1")]
+    public partial class V1alpha1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
         public const string KubeKind = "VolumeAttachmentList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1CSIDriver : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriver", ApiVersion="v1beta1")]
+    public partial class V1beta1CSIDriver : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CSIDriverSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CSIDriver";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1CSIDriverList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriverList", ApiVersion="v1beta1")]
+    public partial class V1beta1CSIDriverList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CSIDriver>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CSIDriverList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1CSINode : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINode", ApiVersion="v1beta1")]
+    public partial class V1beta1CSINode : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CSINodeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CSINode";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1CSINodeList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINodeList", ApiVersion="v1beta1")]
+    public partial class V1beta1CSINodeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CSINode>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CSINodeList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1StorageClass : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1beta1")]
+    public partial class V1beta1StorageClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "StorageClass";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1StorageClassList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1beta1")]
+    public partial class V1beta1StorageClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1StorageClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "StorageClassList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1VolumeAttachment : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1beta1")]
+    public partial class V1beta1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "VolumeAttachment";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1beta1VolumeAttachmentList : IKubernetesObject
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1beta1")]
+    public partial class V1beta1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "VolumeAttachmentList";
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    public partial class V1CustomResourceDefinition : IKubernetesObject
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1")]
+    public partial class V1CustomResourceDefinition : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1CustomResourceDefinitionSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "CustomResourceDefinition";
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    public partial class V1CustomResourceDefinitionList : IKubernetesObject
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1")]
+    public partial class V1CustomResourceDefinitionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1CustomResourceDefinition>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "CustomResourceDefinitionList";
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    public partial class V1beta1CustomResourceDefinition : IKubernetesObject
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1beta1")]
+    public partial class V1beta1CustomResourceDefinition : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CustomResourceDefinitionSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CustomResourceDefinition";
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    public partial class V1beta1CustomResourceDefinitionList : IKubernetesObject
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1beta1")]
+    public partial class V1beta1CustomResourceDefinitionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CustomResourceDefinition>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "CustomResourceDefinitionList";
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    public partial class V1APIGroup : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="APIGroup", ApiVersion="v1")]
+    public partial class V1APIGroup : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIGroup";
         public const string KubeGroup = "";
     }
 
-    public partial class V1APIGroupList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="APIGroupList", ApiVersion="v1")]
+    public partial class V1APIGroupList : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIGroupList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1APIResourceList : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="APIResourceList", ApiVersion="v1")]
+    public partial class V1APIResourceList : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIResourceList";
         public const string KubeGroup = "";
     }
 
-    public partial class V1APIVersions : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="APIVersions", ApiVersion="v1")]
+    public partial class V1APIVersions : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIVersions";
         public const string KubeGroup = "";
     }
 
+    [KubernetesEntity(Group="", Kind="DeleteOptions", ApiVersion="v1")]
     public partial class V1DeleteOptions : IKubernetesObject
     {
         public const string KubeApiVersion = "v1";
@@ -1316,35 +1504,40 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    public partial class V1Status : IKubernetesObject
+    [KubernetesEntity(Group="", Kind="Status", ApiVersion="v1")]
+    public partial class V1Status : IKubernetesObject, IMetadata<V1ListMeta>
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "Status";
         public const string KubeGroup = "";
     }
 
-    public partial class V1APIService : IKubernetesObject
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1")]
+    public partial class V1APIService : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1APIServiceSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIService";
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    public partial class V1APIServiceList : IKubernetesObject
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1")]
+    public partial class V1APIServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1APIService>, IValidate
     {
         public const string KubeApiVersion = "v1";
         public const string KubeKind = "APIServiceList";
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    public partial class V1beta1APIService : IKubernetesObject
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1beta1")]
+    public partial class V1beta1APIService : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1APIServiceSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "APIService";
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    public partial class V1beta1APIServiceList : IKubernetesObject
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1beta1")]
+    public partial class V1beta1APIServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1APIService>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
         public const string KubeKind = "APIServiceList";

--- a/src/KubernetesClient/generated/ModelExtensions.cs
+++ b/src/KubernetesClient/generated/ModelExtensions.cs
@@ -1,6 +1,6 @@
 namespace k8s.Models
 {
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1", PluralName="mutatingwebhookconfigurations")]
     public partial class V1MutatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -8,7 +8,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1", PluralName="mutatingwebhookconfigurations")]
     public partial class V1MutatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1MutatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -16,7 +16,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1", PluralName="validatingwebhookconfigurations")]
     public partial class V1ValidatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -24,7 +24,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1", PluralName="validatingwebhookconfigurations")]
     public partial class V1ValidatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ValidatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -32,7 +32,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfiguration", ApiVersion="v1beta1", PluralName="mutatingwebhookconfigurations")]
     public partial class V1beta1MutatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -40,7 +40,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="MutatingWebhookConfigurationList", ApiVersion="v1beta1", PluralName="mutatingwebhookconfigurations")]
     public partial class V1beta1MutatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1MutatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -48,7 +48,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfiguration", ApiVersion="v1beta1", PluralName="validatingwebhookconfigurations")]
     public partial class V1beta1ValidatingWebhookConfiguration : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -56,7 +56,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="admissionregistration.k8s.io", Kind="ValidatingWebhookConfigurationList", ApiVersion="v1beta1", PluralName="validatingwebhookconfigurations")]
     public partial class V1beta1ValidatingWebhookConfigurationList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ValidatingWebhookConfiguration>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -64,7 +64,7 @@ namespace k8s.Models
         public const string KubeGroup = "admissionregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1", PluralName="controllerrevisions")]
     public partial class V1ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -72,7 +72,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1", PluralName="controllerrevisions")]
     public partial class V1ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -80,7 +80,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1", PluralName="daemonsets")]
     public partial class V1DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -88,7 +88,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1", PluralName="daemonsets")]
     public partial class V1DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -96,7 +96,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1", PluralName="deployments")]
     public partial class V1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -104,7 +104,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1", PluralName="deployments")]
     public partial class V1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -112,7 +112,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1", PluralName="replicasets")]
     public partial class V1ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -120,7 +120,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1", PluralName="replicasets")]
     public partial class V1ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -128,7 +128,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1", PluralName="statefulsets")]
     public partial class V1StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -136,7 +136,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1", PluralName="statefulsets")]
     public partial class V1StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -144,7 +144,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta1", PluralName="controllerrevisions")]
     public partial class V1beta1ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -152,7 +152,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta1", PluralName="controllerrevisions")]
     public partial class V1beta1ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -160,7 +160,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta1", PluralName="deployments")]
     public partial class Appsv1beta1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Appsv1beta1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -168,7 +168,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta1", PluralName="deployments")]
     public partial class Appsv1beta1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Appsv1beta1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -176,7 +176,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DeploymentRollback", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="DeploymentRollback", ApiVersion="v1beta1", PluralName=null)]
     public partial class Appsv1beta1DeploymentRollback : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -184,7 +184,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta1", PluralName=null)]
     public partial class Appsv1beta1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Appsv1beta1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -192,7 +192,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta1", PluralName="statefulsets")]
     public partial class V1beta1StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -200,7 +200,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta1", PluralName="statefulsets")]
     public partial class V1beta1StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -208,7 +208,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevision", ApiVersion="v1beta2", PluralName="controllerrevisions")]
     public partial class V1beta2ControllerRevision : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -216,7 +216,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="ControllerRevisionList", ApiVersion="v1beta2", PluralName="controllerrevisions")]
     public partial class V1beta2ControllerRevisionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2ControllerRevision>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -224,7 +224,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="DaemonSet", ApiVersion="v1beta2", PluralName="daemonsets")]
     public partial class V1beta2DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -232,7 +232,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="DaemonSetList", ApiVersion="v1beta2", PluralName="daemonsets")]
     public partial class V1beta2DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -240,7 +240,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="Deployment", ApiVersion="v1beta2", PluralName="deployments")]
     public partial class V1beta2Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -248,7 +248,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="DeploymentList", ApiVersion="v1beta2", PluralName="deployments")]
     public partial class V1beta2DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -256,7 +256,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="ReplicaSet", ApiVersion="v1beta2", PluralName="replicasets")]
     public partial class V1beta2ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -264,7 +264,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="ReplicaSetList", ApiVersion="v1beta2", PluralName="replicasets")]
     public partial class V1beta2ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -272,7 +272,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="Scale", ApiVersion="v1beta2", PluralName=null)]
     public partial class V1beta2Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -280,7 +280,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSet", ApiVersion="v1beta2", PluralName="statefulsets")]
     public partial class V1beta2StatefulSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta2StatefulSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -288,7 +288,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta2")]
+    [KubernetesEntity(Group="apps", Kind="StatefulSetList", ApiVersion="v1beta2", PluralName="statefulsets")]
     public partial class V1beta2StatefulSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta2StatefulSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta2";
@@ -296,7 +296,7 @@ namespace k8s.Models
         public const string KubeGroup = "apps";
     }
 
-    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSink", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSink", ApiVersion="v1alpha1", PluralName="auditsinks")]
     public partial class V1alpha1AuditSink : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1AuditSinkSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -304,7 +304,7 @@ namespace k8s.Models
         public const string KubeGroup = "auditregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSinkList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="auditregistration.k8s.io", Kind="AuditSinkList", ApiVersion="v1alpha1", PluralName="auditsinks")]
     public partial class V1alpha1AuditSinkList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1AuditSink>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -312,7 +312,7 @@ namespace k8s.Models
         public const string KubeGroup = "auditregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenRequest", ApiVersion="v1")]
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenRequest", ApiVersion="v1", PluralName=null)]
     public partial class V1TokenRequest : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1TokenRequestSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -320,7 +320,7 @@ namespace k8s.Models
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1")]
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1", PluralName=null)]
     public partial class V1TokenReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1TokenReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -328,7 +328,7 @@ namespace k8s.Models
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="authentication.k8s.io", Kind="TokenReview", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1TokenReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1TokenReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -336,7 +336,7 @@ namespace k8s.Models
         public const string KubeGroup = "authentication.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1", PluralName=null)]
     public partial class V1LocalSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -344,7 +344,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1", PluralName=null)]
     public partial class V1SelfSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SelfSubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -352,7 +352,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1", PluralName=null)]
     public partial class V1SelfSubjectRulesReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SelfSubjectRulesReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -360,7 +360,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1", PluralName=null)]
     public partial class V1SubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -368,7 +368,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="LocalSubjectAccessReview", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1LocalSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -376,7 +376,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectAccessReview", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1SelfSubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SelfSubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -384,7 +384,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SelfSubjectRulesReview", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1SelfSubjectRulesReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SelfSubjectRulesReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -392,7 +392,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="authorization.k8s.io", Kind="SubjectAccessReview", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1SubjectAccessReview : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1SubjectAccessReviewSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -400,7 +400,7 @@ namespace k8s.Models
         public const string KubeGroup = "authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v1")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v1", PluralName="horizontalpodautoscalers")]
     public partial class V1HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -408,7 +408,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v1")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v1", PluralName="horizontalpodautoscalers")]
     public partial class V1HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -416,7 +416,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="Scale", ApiVersion="v1")]
+    [KubernetesEntity(Group="autoscaling", Kind="Scale", ApiVersion="v1", PluralName=null)]
     public partial class V1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -424,7 +424,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta1")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta1", PluralName="horizontalpodautoscalers")]
     public partial class V2beta1HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2beta1HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v2beta1";
@@ -432,7 +432,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta1")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta1", PluralName="horizontalpodautoscalers")]
     public partial class V2beta1HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2beta1HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v2beta1";
@@ -440,7 +440,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta2")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscaler", ApiVersion="v2beta2", PluralName="horizontalpodautoscalers")]
     public partial class V2beta2HorizontalPodAutoscaler : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2beta2HorizontalPodAutoscalerSpec>, IValidate
     {
         public const string KubeApiVersion = "v2beta2";
@@ -448,7 +448,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta2")]
+    [KubernetesEntity(Group="autoscaling", Kind="HorizontalPodAutoscalerList", ApiVersion="v2beta2", PluralName="horizontalpodautoscalers")]
     public partial class V2beta2HorizontalPodAutoscalerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2beta2HorizontalPodAutoscaler>, IValidate
     {
         public const string KubeApiVersion = "v2beta2";
@@ -456,7 +456,7 @@ namespace k8s.Models
         public const string KubeGroup = "autoscaling";
     }
 
-    [KubernetesEntity(Group="batch", Kind="Job", ApiVersion="v1")]
+    [KubernetesEntity(Group="batch", Kind="Job", ApiVersion="v1", PluralName="jobs")]
     public partial class V1Job : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1JobSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -464,7 +464,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="batch", Kind="JobList", ApiVersion="v1")]
+    [KubernetesEntity(Group="batch", Kind="JobList", ApiVersion="v1", PluralName="jobs")]
     public partial class V1JobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Job>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -472,7 +472,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v1beta1", PluralName="cronjobs")]
     public partial class V1beta1CronJob : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CronJobSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -480,7 +480,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v1beta1", PluralName="cronjobs")]
     public partial class V1beta1CronJobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CronJob>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -488,7 +488,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v2alpha1")]
+    [KubernetesEntity(Group="batch", Kind="CronJob", ApiVersion="v2alpha1", PluralName="cronjobs")]
     public partial class V2alpha1CronJob : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V2alpha1CronJobSpec>, IValidate
     {
         public const string KubeApiVersion = "v2alpha1";
@@ -496,7 +496,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v2alpha1")]
+    [KubernetesEntity(Group="batch", Kind="CronJobList", ApiVersion="v2alpha1", PluralName="cronjobs")]
     public partial class V2alpha1CronJobList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V2alpha1CronJob>, IValidate
     {
         public const string KubeApiVersion = "v2alpha1";
@@ -504,7 +504,7 @@ namespace k8s.Models
         public const string KubeGroup = "batch";
     }
 
-    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequest", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequest", ApiVersion="v1beta1", PluralName="certificatesigningrequests")]
     public partial class V1beta1CertificateSigningRequest : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CertificateSigningRequestSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -512,7 +512,7 @@ namespace k8s.Models
         public const string KubeGroup = "certificates.k8s.io";
     }
 
-    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequestList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="certificates.k8s.io", Kind="CertificateSigningRequestList", ApiVersion="v1beta1", PluralName="certificatesigningrequests")]
     public partial class V1beta1CertificateSigningRequestList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CertificateSigningRequest>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -520,7 +520,7 @@ namespace k8s.Models
         public const string KubeGroup = "certificates.k8s.io";
     }
 
-    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1")]
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1", PluralName="leases")]
     public partial class V1Lease : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1LeaseSpec>
     {
         public const string KubeApiVersion = "v1";
@@ -528,7 +528,7 @@ namespace k8s.Models
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1")]
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1", PluralName="leases")]
     public partial class V1LeaseList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Lease>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -536,7 +536,7 @@ namespace k8s.Models
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="Lease", ApiVersion="v1beta1", PluralName="leases")]
     public partial class V1beta1Lease : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1LeaseSpec>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -544,7 +544,7 @@ namespace k8s.Models
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="coordination.k8s.io", Kind="LeaseList", ApiVersion="v1beta1", PluralName="leases")]
     public partial class V1beta1LeaseList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Lease>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -552,7 +552,7 @@ namespace k8s.Models
         public const string KubeGroup = "coordination.k8s.io";
     }
 
-    [KubernetesEntity(Group="", Kind="Binding", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Binding", ApiVersion="v1", PluralName=null)]
     public partial class V1Binding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -560,7 +560,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ComponentStatus", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ComponentStatus", ApiVersion="v1", PluralName="componentstatuses")]
     public partial class V1ComponentStatus : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -568,7 +568,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ComponentStatusList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ComponentStatusList", ApiVersion="v1", PluralName="componentstatuses")]
     public partial class V1ComponentStatusList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ComponentStatus>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -576,7 +576,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ConfigMap", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ConfigMap", ApiVersion="v1", PluralName="configmaps")]
     public partial class V1ConfigMap : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -584,7 +584,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ConfigMapList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ConfigMapList", ApiVersion="v1", PluralName="configmaps")]
     public partial class V1ConfigMapList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ConfigMap>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -592,7 +592,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Endpoints", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Endpoints", ApiVersion="v1", PluralName="endpoints")]
     public partial class V1Endpoints : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -600,7 +600,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="EndpointsList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="EndpointsList", ApiVersion="v1", PluralName="endpoints")]
     public partial class V1EndpointsList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Endpoints>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -608,7 +608,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Event", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Event", ApiVersion="v1", PluralName="events")]
     public partial class V1Event : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -616,7 +616,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="EventList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="EventList", ApiVersion="v1", PluralName="events")]
     public partial class V1EventList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Event>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -624,7 +624,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="LimitRange", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="LimitRange", ApiVersion="v1", PluralName="limitranges")]
     public partial class V1LimitRange : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1LimitRangeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -632,7 +632,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="LimitRangeList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="LimitRangeList", ApiVersion="v1", PluralName="limitranges")]
     public partial class V1LimitRangeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1LimitRange>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -640,7 +640,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Namespace", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Namespace", ApiVersion="v1", PluralName="namespaces")]
     public partial class V1Namespace : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NamespaceSpec>
     {
         public const string KubeApiVersion = "v1";
@@ -648,7 +648,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="NamespaceList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="NamespaceList", ApiVersion="v1", PluralName="namespaces")]
     public partial class V1NamespaceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Namespace>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -656,7 +656,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Node", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Node", ApiVersion="v1", PluralName="nodes")]
     public partial class V1Node : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NodeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -664,7 +664,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="NodeList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="NodeList", ApiVersion="v1", PluralName="nodes")]
     public partial class V1NodeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Node>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -672,7 +672,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PersistentVolume", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PersistentVolume", ApiVersion="v1", PluralName="persistentvolumes")]
     public partial class V1PersistentVolume : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PersistentVolumeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -680,7 +680,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PersistentVolumeClaim", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PersistentVolumeClaim", ApiVersion="v1", PluralName="persistentvolumeclaims")]
     public partial class V1PersistentVolumeClaim : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PersistentVolumeClaimSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -688,7 +688,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PersistentVolumeClaimList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PersistentVolumeClaimList", ApiVersion="v1", PluralName="persistentvolumeclaims")]
     public partial class V1PersistentVolumeClaimList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PersistentVolumeClaim>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -696,7 +696,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PersistentVolumeList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PersistentVolumeList", ApiVersion="v1", PluralName="persistentvolumes")]
     public partial class V1PersistentVolumeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PersistentVolume>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -704,7 +704,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Pod", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Pod", ApiVersion="v1", PluralName="pods")]
     public partial class V1Pod : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1PodSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -712,7 +712,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PodList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PodList", ApiVersion="v1", PluralName="pods")]
     public partial class V1PodList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Pod>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -720,7 +720,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PodTemplate", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PodTemplate", ApiVersion="v1", PluralName="podtemplates")]
     public partial class V1PodTemplate : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -728,7 +728,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="PodTemplateList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="PodTemplateList", ApiVersion="v1", PluralName="podtemplates")]
     public partial class V1PodTemplateList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PodTemplate>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -736,7 +736,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ReplicationController", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ReplicationController", ApiVersion="v1", PluralName="replicationcontrollers")]
     public partial class V1ReplicationController : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ReplicationControllerSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -744,7 +744,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ReplicationControllerList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ReplicationControllerList", ApiVersion="v1", PluralName="replicationcontrollers")]
     public partial class V1ReplicationControllerList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ReplicationController>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -752,7 +752,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ResourceQuota", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ResourceQuota", ApiVersion="v1", PluralName="resourcequotas")]
     public partial class V1ResourceQuota : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ResourceQuotaSpec>
     {
         public const string KubeApiVersion = "v1";
@@ -760,7 +760,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ResourceQuotaList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ResourceQuotaList", ApiVersion="v1", PluralName="resourcequotas")]
     public partial class V1ResourceQuotaList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ResourceQuota>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -768,7 +768,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Secret", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Secret", ApiVersion="v1", PluralName="secrets")]
     public partial class V1Secret : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -776,7 +776,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="SecretList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="SecretList", ApiVersion="v1", PluralName="secrets")]
     public partial class V1SecretList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Secret>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -784,7 +784,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Service", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Service", ApiVersion="v1", PluralName="services")]
     public partial class V1Service : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1ServiceSpec>
     {
         public const string KubeApiVersion = "v1";
@@ -792,7 +792,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ServiceAccount", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ServiceAccount", ApiVersion="v1", PluralName="serviceaccounts")]
     public partial class V1ServiceAccount : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -800,7 +800,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ServiceAccountList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ServiceAccountList", ApiVersion="v1", PluralName="serviceaccounts")]
     public partial class V1ServiceAccountList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ServiceAccount>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -808,7 +808,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="ServiceList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="ServiceList", ApiVersion="v1", PluralName="services")]
     public partial class V1ServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Service>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -816,7 +816,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSlice", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSlice", ApiVersion="v1alpha1", PluralName="endpointslices")]
     public partial class V1alpha1EndpointSlice : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -824,7 +824,7 @@ namespace k8s.Models
         public const string KubeGroup = "discovery.k8s.io";
     }
 
-    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSliceList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="discovery.k8s.io", Kind="EndpointSliceList", ApiVersion="v1alpha1", PluralName="endpointslices")]
     public partial class V1alpha1EndpointSliceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1EndpointSlice>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -832,7 +832,7 @@ namespace k8s.Models
         public const string KubeGroup = "discovery.k8s.io";
     }
 
-    [KubernetesEntity(Group="events.k8s.io", Kind="Event", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="events.k8s.io", Kind="Event", ApiVersion="v1beta1", PluralName="events")]
     public partial class V1beta1Event : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -840,7 +840,7 @@ namespace k8s.Models
         public const string KubeGroup = "events.k8s.io";
     }
 
-    [KubernetesEntity(Group="events.k8s.io", Kind="EventList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="events.k8s.io", Kind="EventList", ApiVersion="v1beta1", PluralName="events")]
     public partial class V1beta1EventList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Event>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -848,7 +848,7 @@ namespace k8s.Models
         public const string KubeGroup = "events.k8s.io";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="DaemonSet", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="DaemonSet", ApiVersion="v1beta1", PluralName="daemonsets")]
     public partial class V1beta1DaemonSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1DaemonSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -856,7 +856,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="DaemonSetList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="DaemonSetList", ApiVersion="v1beta1", PluralName="daemonsets")]
     public partial class V1beta1DaemonSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1DaemonSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -864,7 +864,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="Deployment", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="Deployment", ApiVersion="v1beta1", PluralName="deployments")]
     public partial class Extensionsv1beta1Deployment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1DeploymentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -872,7 +872,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="DeploymentList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="DeploymentList", ApiVersion="v1beta1", PluralName="deployments")]
     public partial class Extensionsv1beta1DeploymentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1Deployment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -880,7 +880,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="DeploymentRollback", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="DeploymentRollback", ApiVersion="v1beta1", PluralName=null)]
     public partial class Extensionsv1beta1DeploymentRollback : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -888,7 +888,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="Ingress", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="Ingress", ApiVersion="v1beta1", PluralName="ingresses")]
     public partial class Extensionsv1beta1Ingress : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1IngressSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -896,7 +896,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="IngressList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="IngressList", ApiVersion="v1beta1", PluralName="ingresses")]
     public partial class Extensionsv1beta1IngressList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1Ingress>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -904,7 +904,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="NetworkPolicy", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="NetworkPolicy", ApiVersion="v1beta1", PluralName="networkpolicies")]
     public partial class V1beta1NetworkPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1NetworkPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -912,7 +912,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="NetworkPolicyList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="NetworkPolicyList", ApiVersion="v1beta1", PluralName="networkpolicies")]
     public partial class V1beta1NetworkPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1NetworkPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -920,7 +920,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicy", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicy", ApiVersion="v1beta1", PluralName="podsecuritypolicies")]
     public partial class Extensionsv1beta1PodSecurityPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1PodSecurityPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -928,7 +928,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicyList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="PodSecurityPolicyList", ApiVersion="v1beta1", PluralName="podsecuritypolicies")]
     public partial class Extensionsv1beta1PodSecurityPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Extensionsv1beta1PodSecurityPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -936,7 +936,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="ReplicaSet", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="ReplicaSet", ApiVersion="v1beta1", PluralName="replicasets")]
     public partial class V1beta1ReplicaSet : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1ReplicaSetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -944,7 +944,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="ReplicaSetList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="ReplicaSetList", ApiVersion="v1beta1", PluralName="replicasets")]
     public partial class V1beta1ReplicaSetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ReplicaSet>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -952,7 +952,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="extensions", Kind="Scale", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="extensions", Kind="Scale", ApiVersion="v1beta1", PluralName=null)]
     public partial class Extensionsv1beta1Scale : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Extensionsv1beta1ScaleSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -960,7 +960,7 @@ namespace k8s.Models
         public const string KubeGroup = "extensions";
     }
 
-    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicy", ApiVersion="v1")]
+    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicy", ApiVersion="v1", PluralName="networkpolicies")]
     public partial class V1NetworkPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1NetworkPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -968,7 +968,7 @@ namespace k8s.Models
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicyList", ApiVersion="v1")]
+    [KubernetesEntity(Group="networking.k8s.io", Kind="NetworkPolicyList", ApiVersion="v1", PluralName="networkpolicies")]
     public partial class V1NetworkPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1NetworkPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -976,7 +976,7 @@ namespace k8s.Models
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    [KubernetesEntity(Group="networking.k8s.io", Kind="Ingress", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="networking.k8s.io", Kind="Ingress", ApiVersion="v1beta1", PluralName="ingresses")]
     public partial class Networkingv1beta1Ingress : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Networkingv1beta1IngressSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -984,7 +984,7 @@ namespace k8s.Models
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    [KubernetesEntity(Group="networking.k8s.io", Kind="IngressList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="networking.k8s.io", Kind="IngressList", ApiVersion="v1beta1", PluralName="ingresses")]
     public partial class Networkingv1beta1IngressList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Networkingv1beta1Ingress>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -992,7 +992,7 @@ namespace k8s.Models
         public const string KubeGroup = "networking.k8s.io";
     }
 
-    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1alpha1", PluralName="runtimeclasses")]
     public partial class V1alpha1RuntimeClass : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1RuntimeClassSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1000,7 +1000,7 @@ namespace k8s.Models
         public const string KubeGroup = "node.k8s.io";
     }
 
-    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1alpha1", PluralName="runtimeclasses")]
     public partial class V1alpha1RuntimeClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1RuntimeClass>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1008,7 +1008,7 @@ namespace k8s.Models
         public const string KubeGroup = "node.k8s.io";
     }
 
-    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClass", ApiVersion="v1beta1", PluralName="runtimeclasses")]
     public partial class V1beta1RuntimeClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1016,7 +1016,7 @@ namespace k8s.Models
         public const string KubeGroup = "node.k8s.io";
     }
 
-    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="node.k8s.io", Kind="RuntimeClassList", ApiVersion="v1beta1", PluralName="runtimeclasses")]
     public partial class V1beta1RuntimeClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1RuntimeClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1024,7 +1024,7 @@ namespace k8s.Models
         public const string KubeGroup = "node.k8s.io";
     }
 
-    [KubernetesEntity(Group="policy", Kind="Eviction", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="policy", Kind="Eviction", ApiVersion="v1beta1", PluralName=null)]
     public partial class V1beta1Eviction : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1032,7 +1032,7 @@ namespace k8s.Models
         public const string KubeGroup = "policy";
     }
 
-    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudget", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudget", ApiVersion="v1beta1", PluralName="poddisruptionbudgets")]
     public partial class V1beta1PodDisruptionBudget : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1PodDisruptionBudgetSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1040,7 +1040,7 @@ namespace k8s.Models
         public const string KubeGroup = "policy";
     }
 
-    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudgetList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="policy", Kind="PodDisruptionBudgetList", ApiVersion="v1beta1", PluralName="poddisruptionbudgets")]
     public partial class V1beta1PodDisruptionBudgetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1PodDisruptionBudget>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1048,7 +1048,7 @@ namespace k8s.Models
         public const string KubeGroup = "policy";
     }
 
-    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicy", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicy", ApiVersion="v1beta1", PluralName="podsecuritypolicies")]
     public partial class Policyv1beta1PodSecurityPolicy : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<Policyv1beta1PodSecurityPolicySpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1056,7 +1056,7 @@ namespace k8s.Models
         public const string KubeGroup = "policy";
     }
 
-    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicyList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="policy", Kind="PodSecurityPolicyList", ApiVersion="v1beta1", PluralName="podsecuritypolicies")]
     public partial class Policyv1beta1PodSecurityPolicyList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<Policyv1beta1PodSecurityPolicy>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1064,7 +1064,7 @@ namespace k8s.Models
         public const string KubeGroup = "policy";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1", PluralName="clusterroles")]
     public partial class V1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -1072,7 +1072,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1", PluralName="clusterrolebindings")]
     public partial class V1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1080,7 +1080,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1", PluralName="clusterrolebindings")]
     public partial class V1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1088,7 +1088,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1", PluralName="clusterroles")]
     public partial class V1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1096,7 +1096,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1", PluralName="roles")]
     public partial class V1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -1104,7 +1104,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1", PluralName="rolebindings")]
     public partial class V1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1112,7 +1112,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1", PluralName="rolebindings")]
     public partial class V1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1120,7 +1120,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1", PluralName="roles")]
     public partial class V1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1Role>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1128,7 +1128,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1alpha1", PluralName="clusterroles")]
     public partial class V1alpha1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1136,7 +1136,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1alpha1", PluralName="clusterrolebindings")]
     public partial class V1alpha1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1144,7 +1144,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1alpha1", PluralName="clusterrolebindings")]
     public partial class V1alpha1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1152,7 +1152,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1alpha1", PluralName="clusterroles")]
     public partial class V1alpha1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1160,7 +1160,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1alpha1", PluralName="roles")]
     public partial class V1alpha1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1168,7 +1168,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1alpha1", PluralName="rolebindings")]
     public partial class V1alpha1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1176,7 +1176,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1alpha1", PluralName="rolebindings")]
     public partial class V1alpha1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1184,7 +1184,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1alpha1", PluralName="roles")]
     public partial class V1alpha1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1Role>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1192,7 +1192,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRole", ApiVersion="v1beta1", PluralName="clusterroles")]
     public partial class V1beta1ClusterRole : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1200,7 +1200,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBinding", ApiVersion="v1beta1", PluralName="clusterrolebindings")]
     public partial class V1beta1ClusterRoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1208,7 +1208,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleBindingList", ApiVersion="v1beta1", PluralName="clusterrolebindings")]
     public partial class V1beta1ClusterRoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ClusterRoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1216,7 +1216,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="ClusterRoleList", ApiVersion="v1beta1", PluralName="clusterroles")]
     public partial class V1beta1ClusterRoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1ClusterRole>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1224,7 +1224,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="Role", ApiVersion="v1beta1", PluralName="roles")]
     public partial class V1beta1Role : IKubernetesObject, IMetadata<V1ObjectMeta>
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1232,7 +1232,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBinding", ApiVersion="v1beta1", PluralName="rolebindings")]
     public partial class V1beta1RoleBinding : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1240,7 +1240,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleBindingList", ApiVersion="v1beta1", PluralName="rolebindings")]
     public partial class V1beta1RoleBindingList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1RoleBinding>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1248,7 +1248,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="rbac.authorization.k8s.io", Kind="RoleList", ApiVersion="v1beta1", PluralName="roles")]
     public partial class V1beta1RoleList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1Role>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1256,7 +1256,7 @@ namespace k8s.Models
         public const string KubeGroup = "rbac.authorization.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1", PluralName="priorityclasses")]
     public partial class V1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1264,7 +1264,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1", PluralName="priorityclasses")]
     public partial class V1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1272,7 +1272,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1alpha1", PluralName="priorityclasses")]
     public partial class V1alpha1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1280,7 +1280,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1alpha1", PluralName="priorityclasses")]
     public partial class V1alpha1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1288,7 +1288,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClass", ApiVersion="v1beta1", PluralName="priorityclasses")]
     public partial class V1beta1PriorityClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1296,7 +1296,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="scheduling.k8s.io", Kind="PriorityClassList", ApiVersion="v1beta1", PluralName="priorityclasses")]
     public partial class V1beta1PriorityClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1PriorityClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1304,7 +1304,7 @@ namespace k8s.Models
         public const string KubeGroup = "scheduling.k8s.io";
     }
 
-    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPreset", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPreset", ApiVersion="v1alpha1", PluralName="podpresets")]
     public partial class V1alpha1PodPreset : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1PodPresetSpec>
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1312,7 +1312,7 @@ namespace k8s.Models
         public const string KubeGroup = "settings.k8s.io";
     }
 
-    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPresetList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="settings.k8s.io", Kind="PodPresetList", ApiVersion="v1alpha1", PluralName="podpresets")]
     public partial class V1alpha1PodPresetList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1PodPreset>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1320,7 +1320,7 @@ namespace k8s.Models
         public const string KubeGroup = "settings.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1", PluralName="storageclasses")]
     public partial class V1StorageClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1328,7 +1328,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1", PluralName="storageclasses")]
     public partial class V1StorageClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1StorageClass>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1336,7 +1336,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1", PluralName="volumeattachments")]
     public partial class V1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1344,7 +1344,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1", PluralName="volumeattachments")]
     public partial class V1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1352,7 +1352,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1alpha1", PluralName="volumeattachments")]
     public partial class V1alpha1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1alpha1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1360,7 +1360,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1alpha1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1alpha1", PluralName="volumeattachments")]
     public partial class V1alpha1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1alpha1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1alpha1";
@@ -1368,7 +1368,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriver", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriver", ApiVersion="v1beta1", PluralName="csidrivers")]
     public partial class V1beta1CSIDriver : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CSIDriverSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1376,7 +1376,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriverList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSIDriverList", ApiVersion="v1beta1", PluralName="csidrivers")]
     public partial class V1beta1CSIDriverList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CSIDriver>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1384,7 +1384,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINode", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINode", ApiVersion="v1beta1", PluralName="csinodes")]
     public partial class V1beta1CSINode : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CSINodeSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1392,7 +1392,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINodeList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="CSINodeList", ApiVersion="v1beta1", PluralName="csinodes")]
     public partial class V1beta1CSINodeList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CSINode>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1400,7 +1400,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClass", ApiVersion="v1beta1", PluralName="storageclasses")]
     public partial class V1beta1StorageClass : IKubernetesObject, IMetadata<V1ObjectMeta>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1408,7 +1408,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="StorageClassList", ApiVersion="v1beta1", PluralName="storageclasses")]
     public partial class V1beta1StorageClassList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1StorageClass>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1416,7 +1416,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachment", ApiVersion="v1beta1", PluralName="volumeattachments")]
     public partial class V1beta1VolumeAttachment : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1VolumeAttachmentSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1424,7 +1424,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="storage.k8s.io", Kind="VolumeAttachmentList", ApiVersion="v1beta1", PluralName="volumeattachments")]
     public partial class V1beta1VolumeAttachmentList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1VolumeAttachment>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1432,7 +1432,7 @@ namespace k8s.Models
         public const string KubeGroup = "storage.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1")]
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1", PluralName="customresourcedefinitions")]
     public partial class V1CustomResourceDefinition : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1CustomResourceDefinitionSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1440,7 +1440,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1", PluralName="customresourcedefinitions")]
     public partial class V1CustomResourceDefinitionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1CustomResourceDefinition>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1448,7 +1448,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinition", ApiVersion="v1beta1", PluralName="customresourcedefinitions")]
     public partial class V1beta1CustomResourceDefinition : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1CustomResourceDefinitionSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1456,7 +1456,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apiextensions.k8s.io", Kind="CustomResourceDefinitionList", ApiVersion="v1beta1", PluralName="customresourcedefinitions")]
     public partial class V1beta1CustomResourceDefinitionList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1CustomResourceDefinition>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1464,7 +1464,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiextensions.k8s.io";
     }
 
-    [KubernetesEntity(Group="", Kind="APIGroup", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="APIGroup", ApiVersion="v1", PluralName=null)]
     public partial class V1APIGroup : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1472,7 +1472,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="APIGroupList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="APIGroupList", ApiVersion="v1", PluralName=null)]
     public partial class V1APIGroupList : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1480,7 +1480,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="APIResourceList", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="APIResourceList", ApiVersion="v1", PluralName=null)]
     public partial class V1APIResourceList : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1488,7 +1488,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="APIVersions", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="APIVersions", ApiVersion="v1", PluralName=null)]
     public partial class V1APIVersions : IKubernetesObject, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1496,7 +1496,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="DeleteOptions", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="DeleteOptions", ApiVersion="v1", PluralName=null)]
     public partial class V1DeleteOptions : IKubernetesObject
     {
         public const string KubeApiVersion = "v1";
@@ -1504,7 +1504,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="", Kind="Status", ApiVersion="v1")]
+    [KubernetesEntity(Group="", Kind="Status", ApiVersion="v1", PluralName=null)]
     public partial class V1Status : IKubernetesObject, IMetadata<V1ListMeta>
     {
         public const string KubeApiVersion = "v1";
@@ -1512,7 +1512,7 @@ namespace k8s.Models
         public const string KubeGroup = "";
     }
 
-    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1")]
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1", PluralName="apiservices")]
     public partial class V1APIService : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1APIServiceSpec>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1520,7 +1520,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1")]
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1", PluralName="apiservices")]
     public partial class V1APIServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1APIService>, IValidate
     {
         public const string KubeApiVersion = "v1";
@@ -1528,7 +1528,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIService", ApiVersion="v1beta1", PluralName="apiservices")]
     public partial class V1beta1APIService : IKubernetesObject, IMetadata<V1ObjectMeta>, ISpec<V1beta1APIServiceSpec>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";
@@ -1536,7 +1536,7 @@ namespace k8s.Models
         public const string KubeGroup = "apiregistration.k8s.io";
     }
 
-    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1beta1")]
+    [KubernetesEntity(Group="apiregistration.k8s.io", Kind="APIServiceList", ApiVersion="v1beta1", PluralName="apiservices")]
     public partial class V1beta1APIServiceList : IKubernetesObject, IMetadata<V1ListMeta>, IItems<V1beta1APIService>, IValidate
     {
         public const string KubeApiVersion = "v1beta1";


### PR DESCRIPTION
Add interfaces for generated Kubernetes objects that can allow working with them without using concrete types. This work is needed for future shared informers / controllers components being developed