### PR TITLE
Create watch handle for http client factory

### DIFF
--- a/examples/httpClientFactory/Program.cs
+++ b/examples/httpClientFactory/Program.cs
@@ -32,7 +32,8 @@ namespace httpClientFactory
                                 serviceProvider.GetRequiredService<KubernetesClientConfiguration>(),
                                 httpClient);
                         })
-                        .ConfigurePrimaryHttpMessageHandler(config.CreateDefaultHttpClientHandler);
+                        .ConfigurePrimaryHttpMessageHandler(config.CreateDefaultHttpClientHandler)
+                        .AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);
 
                     // Add the class that uses the client
                     services.AddHostedService<PodListHostedService>();

--- a/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
@@ -14,7 +14,7 @@ namespace k8s
             {
                 if(this.SkipTlsVerify)
                 {
-                    httpClientHandler.ServerCertificateCustomValidationCallback = 
+                    httpClientHandler.ServerCertificateCustomValidationCallback =
                         (sender, certificate, chain, sslPolicyErrors) => true;
                 }
                 else
@@ -47,5 +47,7 @@ namespace k8s
 #endif
             }
         }
+
+        public static DelegatingHandler CreateWatchHandler() => new WatcherDelegatingHandler();
     }
 }


### PR DESCRIPTION
Resolves #374 

Introduce a new static Method on the KubernetesClientConfiguration class for use with HttpClientFactory and AddTypedClient.

The addition of using `.AddHttpMessageHandler(KubernetesClientConfiguration.CreateWatchHandler);` allows `List...Async().Watch` to work.
