### PR TITLE
Improve Watcher thread utilisation.

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -9,6 +9,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
+    <LangVersion>7.3</LangVersion>
     <TargetFrameworks>netstandard2.0;net452;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -29,9 +29,9 @@ namespace k8s
         public bool Watching { get; private set; }
 
         private readonly CancellationTokenSource _cts;
-        private readonly Func<Task<StreamReader>> _streamReaderCreator;
+        private readonly Func<Task<TextReader>> _streamReaderCreator;
 
-        private StreamReader _streamReader;
+        private TextReader _streamReader;
         private readonly Task _watcherLoop;
 
         /// <summary>
@@ -50,6 +50,28 @@ namespace k8s
         /// The action to invoke when the server closes the connection.
         /// </param>
         public Watcher(Func<Task<StreamReader>> streamReaderCreator, Action<WatchEventType, T> onEvent, Action<Exception> onError, Action onClosed = null)
+            : this(
+                async () => (TextReader)await streamReaderCreator().ConfigureAwait(false),
+                onEvent, onError, onClosed)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Watcher{T}"/> class.
+        /// </summary>
+        /// <param name="streamReader">
+        /// A <see cref="StreamReader"/> from which to read the events.
+        /// </param>
+        /// <param name="onEvent">
+        /// The action to invoke when the server sends a new event.
+        /// </param>
+        /// <param name="onError">
+        /// The action to invoke when an error occurs.
+        /// </param>
+        /// <param name="onClosed">
+        /// The action to invoke when the server closes the connection.
+        /// </param>
+        public Watcher(Func<Task<TextReader>> streamReaderCreator, Action<WatchEventType, T> onEvent, Action<Exception> onError, Action onClosed = null)
         {
             _streamReaderCreator = streamReaderCreator;
             OnEvent += onEvent;

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -105,16 +105,16 @@ namespace k8s
                 base.Dispose(disposing);
             }
 
-            private CancellationTokenSourceSlim CreateCancellationTokenSource(CancellationToken userCancellationToken)
+            private LinkedCancellationTokenSource CreateCancellationTokenSource(CancellationToken userCancellationToken)
             {
-                return new CancellationTokenSourceSlim(_cancellationToken, userCancellationToken);
+                return new LinkedCancellationTokenSource(_cancellationToken, userCancellationToken);
             }
 
-            private readonly struct CancellationTokenSourceSlim : IDisposable
+            private readonly struct LinkedCancellationTokenSource : IDisposable
             {
                 private readonly CancellationTokenSource _cancellationTokenSource;
 
-                public CancellationTokenSourceSlim(CancellationToken token1, CancellationToken token2)
+                public LinkedCancellationTokenSource(CancellationToken token1, CancellationToken token2)
                 {
                     if (token1.CanBeCanceled && token2.CanBeCanceled)
                     {

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -96,6 +96,15 @@ namespace k8s
                 set => _innerStream.Position = value;
             }
 
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _innerStream.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+
             private CancellationTokenSourceSlim CreateCancellationTokenSource(CancellationToken userCancellationToken)
             {
                 return new CancellationTokenSourceSlim(_cancellationToken, userCancellationToken);

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -172,24 +172,18 @@ namespace k8s
             }
         }
 
-        internal class PeekableStreamReader : StreamReader
+        internal class PeekableStreamReader : TextReader
         {
-            private Queue<string> _buffer;
+            private readonly Queue<string> _buffer;
+            private readonly StreamReader _inner;
 
-            public PeekableStreamReader(Stream stream) : base(stream)
+            public PeekableStreamReader(Stream stream)
             {
                 _buffer = new Queue<string>();
+                _inner = new StreamReader(stream);
             }
 
-            public override string ReadLine()
-            {
-                if (_buffer.Count > 0)
-                {
-                    return _buffer.Dequeue();
-                }
-
-                return base.ReadLine();
-            }
+            public override string ReadLine() => throw new NotImplementedException();
 
             public override Task<string> ReadLineAsync()
             {
@@ -198,7 +192,7 @@ namespace k8s
                     return Task.FromResult(_buffer.Dequeue());
                 }
 
-                return base.ReadLineAsync();
+                return _inner.ReadLineAsync();
             }
 
             public async Task<string> PeekLineAsync()
@@ -221,6 +215,15 @@ namespace k8s
             public override string ReadToEnd() => throw new NotImplementedException();
 
             public override Task<string> ReadToEndAsync() => throw new NotImplementedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _inner.Dispose();
+                }
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -45,7 +45,8 @@ namespace k8s
                 _cancellationToken = cancellationToken;
             }
 
-            public override void Flush() => _innerStream.Flush();
+            public override void Flush() =>
+                _innerStream.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
 
             public override async Task FlushAsync(CancellationToken cancellationToken)
             {


### PR DESCRIPTION
This PR fixes #381. We no longer observe any blocked threads:

![parallel stacks](https://user-images.githubusercontent.com/63398/77586224-b57e4300-6edd-11ea-9d18-4c1e9bda20c9.png)

Note that as `CancelableStream` is used exclusively by `PeekableStreamReader`, it could be made `private`. This would enable:
* It to be made read only (i.e. `CancelableReadStream`) and `{Flush, FlushAsync, Write, WriteAsync, SetLength}` made to throw.
* The simplification of the user supplied cancellation token support as `PeekableStreamReader` provides `None` to `ReadAsync`.

Please let me know your thoughts?
