### PR TITLE
Upgrade to .NET Core SDK 3.1.

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -33,8 +33,9 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           rsync --archive --ignore-existing ${DOTNET_ROOT/3.1.201/2.1.805}/ ${DOTNET_ROOT/3.1.201/2.1.202}/ $DOTNET_ROOT
-      - run: dotnet build --configuration Release
-      - name: test with dotnet
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Test
         run: dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"**/KubernetesClient/generated/**/*.cs\" /p:CoverletOutputFormat="cobertura"
       # - uses: 5monkeys/cobertura-action@master
       #   with:

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -8,7 +8,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     name: Dotnet build
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           fetch-depth: 0
       - name: Setup dotnet runtime 2.0.9

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup SxS dotnet
         if: matrix.os == 'windows-latest'
         run: |
-          (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
-          (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+          (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+          (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
           exit /B 0
         shell: cmd
       - name: Setup SxS dotnet

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -11,10 +11,18 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - name: Setup dotnet
+      - name: Setup dotnet runtime 2.0.9
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.2.108
+          dotnet-version: 2.1.202
+      - name: Setup dotnet runtime 2.1.17
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.805
+      - name: Setup dotnet SDK 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.201
       - run: dotnet build --configuration Release
       - name: test with dotnet
         run: dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"**/KubernetesClient/generated/**/*.cs\" /p:CoverletOutputFormat="cobertura"

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -26,8 +26,9 @@ jobs:
       - name: Setup SxS dotnet
         if: matrix.os == 'windows-latest'
         run: |
-          robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO
-          robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO
+          (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+          (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+          exit /B 0
         shell: cmd
       - name: Setup SxS dotnet
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -23,6 +23,16 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.201
+      - name: Setup SxS dotnet
+        if: matrix.os == 'windows-latest'
+        run: |
+          robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO
+          robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO
+        shell: cmd
+      - name: Setup SxS dotnet
+        if: matrix.os != 'windows-latest'
+        run: |
+          rsync --archive --ignore-existing ${DOTNET_ROOT/3.1.201/2.1.805}/ ${DOTNET_ROOT/3.1.201/2.1.202}/ $DOTNET_ROOT
       - run: dotnet build --configuration Release
       - name: test with dotnet
         run: dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"**/KubernetesClient/generated/**/*.cs\" /p:CoverletOutputFormat="cobertura"

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -28,8 +28,9 @@ jobs:
     - name: Setup SxS dotnet
       if: matrix.os == 'windows-latest'
       run: |
-        robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO
-        robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO
+        (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+        (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+        exit /B 0
       shell: cmd
     - name: Test
       run: dotnet test

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -11,10 +11,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Setup dotnet runtime 2.0.9
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.202
+    - name: Setup dotnet runtime 2.1.17
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.805
     - name: Setup dotnet SDK 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.201
+    - name: Setup SxS dotnet
+      if: matrix.os == 'windows-latest'
+      run: |
+        robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO
+        robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO
+      shell: cmd
     - name: test with dotnet
       run: dotnet test
     - name: pack

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
     - name: Setup dotnet runtime 2.0.9
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -28,8 +28,8 @@ jobs:
     - name: Setup SxS dotnet
       if: matrix.os == 'windows-latest'
       run: |
-        (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
-        (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+        (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
+        (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
         exit /B 0
       shell: cmd
     - name: Test

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup dotnet SDK 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 3.1.201
     - name: test with dotnet
       run: dotnet test
     - name: pack

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -31,9 +31,9 @@ jobs:
         robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO
         robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO
       shell: cmd
-    - name: test with dotnet
+    - name: Test
       run: dotnet test
-    - name: pack
+    - name: Pack
       run: dotnet pack --configuration Release src/KubernetesClient -o pkg
-    - name: push
-      run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }} 
+    - name: Push
+      run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -5,7 +5,9 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-get -qq update
-sudo apt-get install -y dotnet-sdk-2.2
+sudo apt-get install -y dotnet-runtime-2.0.9
+sudo apt-get install -y dotnet-runtime-2.1
+sudo apt-get install -y dotnet-sdk-3.1
 
 echo 'Installing kubectl'
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 echo 'Installing .NET Core...'
 
-wget https://download.visualstudio.microsoft.com/download/pr/4850aa8f-44a9-4c4a-9961-f18aa4d90ceb/07d790444f3ba6b412a76d6f1aced338/dotnet-sdk-2.2.105-osx-x64.pkg -O ~/dotnet-sdk-2.2.105-osx-x64.pkg
+wget https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.pkg -O ~/dotnet-runtime-2.0.9-osx-x64.pkg
+wget https://download.visualstudio.microsoft.com/download/pr/9d3edcf8-2da1-42eb-a30f-54d629c8f13f/2e967304f8f3543c7329fd53d292d076/dotnet-runtime-2.1.17-osx-x64.pkg -O ~/dotnet-runtime-2.1.17-osx-x64.pkg
+wget https://download.visualstudio.microsoft.com/download/pr/905598d0-17a3-4b42-bf13-c5a69d7aac87/853aff73920dcb013c09a74f05da7f6a/dotnet-sdk-3.1.201-osx-x64.pkg -O ~/dotnet-sdk-3.1.201-osx-x64.pkg
 
-sudo installer -pkg ~/dotnet-sdk-2.2.105-osx-x64.pkg -target /
+sudo installer -pkg ~/dotnet-runtime-2.0.9-osx-x64.pkg -target /
+sudo installer -pkg ~/dotnet-runtime-2.1.17-osx-x64.pkg -target /
+sudo installer -pkg ~/dotnet-sdk-3.1.201-osx-x64.pkg -target /
 
 # https://github.com/dotnet/cli/issues/2544
 ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/


### PR DESCRIPTION
As discussed in #386 and #389, this PR upgrades to .NET Core SDK 3.1. It also installs the requisite 2.0.9 & 2.1.17 runtimes:
* The GitHub actions specify the SDK version and SDK 2.1.202 / 2.1.805 include runtime 2.0.9 / 2.1.17 respectively.
* The Travis linux and osx scripts install the runtimes directly as there is no APT package for SDK 2.1.805; I thought it best to keep those environments as similar as possible.