### PR TITLE
Fix nuget's "Setup SxS dotnet" not being run.

### DIFF
--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -26,7 +26,6 @@ jobs:
       with:
         dotnet-version: 3.1.201
     - name: Setup SxS dotnet
-      if: matrix.os == 'windows-latest'
       run: |
         (robocopy %DOTNET_ROOT:3.1.201=2.1.805% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%
         (robocopy %DOTNET_ROOT:3.1.201=2.1.202% %DOTNET_ROOT% /E /XC /XN /XO /NFL /NDL /NJH /NJS /NP) ^& if %ERRORLEVEL% geq 8 exit /B %ERRORLEVEL%


### PR DESCRIPTION
The step's condition will always evaluate false ([see](https://github.com/kubernetes-client/csharp/runs/563856087?check_suite_focus=true)) as the workflow does not use a matrix strategy.

