### PR TITLE
Add convenient model extensions

### DIFF
--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace k8s.Models
+{
+    public static class ModelExtensions
+    {
+        /// <summary>Extracts the Kubernetes API group from the <see cref="IKubernetesObject.ApiVersion"/>.</summary>
+        public static string ApiGroup(this IKubernetesObject obj)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null) return null;
+            int slash = obj.ApiVersion.IndexOf('/');
+            return slash < 0 ? string.Empty : obj.ApiVersion.Substring(0, slash);
+        }
+
+        /// <summary>Extracts the Kubernetes API version (excluding the group) from the <see cref="IKubernetesObject.ApiVersion"/>.</summary>
+        public static string ApiGroupVersion(this IKubernetesObject obj)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null) return null;
+            int slash = obj.ApiVersion.IndexOf('/');
+            return slash < 0 ? obj.ApiVersion : obj.ApiVersion.Substring(slash+1);
+        }
+
+        /// <summary>Splits the Kubernetes API version into the group and version.</summary>
+        public static (string, string) ApiGroupAndVersion(this IKubernetesObject obj)
+        {
+            string group, version;
+            obj.GetApiGroupAndVersion(out group, out version);
+            return (group, version);
+        }
+
+        /// <summary>Splits the Kubernetes API version into the group and version.</summary>
+        public static void GetApiGroupAndVersion(this IKubernetesObject obj, out string group, out string version)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null)
+            {
+                group = version = null;
+            }
+            else
+            {
+                int slash = obj.ApiVersion.IndexOf('/');
+                if(slash < 0) (group, version) = (string.Empty, obj.ApiVersion);
+                else (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash+1));
+            }
+        }
+
+        /// <summary>Gets the continuation token version of a Kubernetes list.</summary>
+        public static string Continue(this IMetadata<V1ListMeta> list) => list.Metadata?.ContinueProperty;
+
+        /// <summary>Ensures that the <see cref="V1ListMeta"/> metadata field is set, and returns it.</summary>
+        public static V1ListMeta EnsureMetadata(this IMetadata<V1ListMeta> obj)
+        {
+            if(obj.Metadata == null) obj.Metadata = new V1ListMeta();
+            return obj.Metadata;
+        }
+
+        /// <summary>Gets the resource version of a Kubernetes list.</summary>
+        public static string ResourceVersion(this IMetadata<V1ListMeta> list) => list.Metadata?.ResourceVersion;
+
+        /// <summary>Adds an owner reference to the object. No attempt is made to ensure the reference is correct or fits with the
+        /// other references.
+        /// </summary>
+        public static void AddOwnerReference(this IMetadata<V1ObjectMeta> obj, V1OwnerReference ownerRef)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(ownerRef == null) throw new ArgumentNullException(nameof(ownerRef));
+            if(obj.EnsureMetadata().OwnerReferences == null) obj.Metadata.OwnerReferences = new List<V1OwnerReference>();
+            obj.Metadata.OwnerReferences.Add(ownerRef);
+        }
+
+        /// <summary>Gets the annotations of a Kubernetes object.</summary>
+        public static IDictionary<string, string> Annotations(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Annotations;
+
+        /// <summary>Gets the creation time of a Kubernetes object, or null if it hasn't been created yet.</summary>
+        public static DateTime? CreationTimestamp(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.CreationTimestamp;
+
+        /// <summary>Gets the deletion time of a Kubernetes object, or null if it hasn't been scheduled for deletion.</summary>
+        public static DateTime? DeletionTimestamp(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.DeletionTimestamp;
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta"/> metadata field is set, and returns it.</summary>
+        public static V1ObjectMeta EnsureMetadata(this IMetadata<V1ObjectMeta> obj)
+        {
+            if(obj.Metadata == null) obj.Metadata = new V1ObjectMeta();
+            return obj.Metadata;
+        }
+
+        /// <summary>Gets the index of the <see cref="V1OwnerReference"/> that matches the given object, or -1 if no such
+        /// reference could be found.
+        /// </summary>
+        public static int FindOwnerRef(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
+        {
+            var ownerRefs = obj.OwnerReferences();
+            if(ownerRefs != null)
+            {
+                for(int i = 0; i < ownerRefs.Count; i++)
+                {
+                    if(ownerRefs[i].Matches(owner)) return i;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>Gets the generation a Kubernetes object.</summary>
+        public static long? Generation(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Generation;
+
+        /// <summary>Returns the given annotation from a Kubernetes object or null if the annotation was not found.</summary>
+        public static string GetAnnotation(this IMetadata<V1ObjectMeta> obj, string key)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            IDictionary<string, string> annotations = obj.Annotations();
+            return annotations != null && annotations.TryGetValue(key, out string value) ? value : null;
+        }
+
+        /// <summary>Gets the <see cref="V1OwnerReference"/> for the controller of this object, or null if it couldn't be found.</summary>
+        public static V1OwnerReference GetController(this IMetadata<V1ObjectMeta> obj) =>
+            obj.OwnerReferences()?.FirstOrDefault(r => r.Controller.GetValueOrDefault());
+
+        /// <summary>Returns the given label from a Kubernetes object or null if the label was not found.</summary>
+        public static string GetLabel(this IMetadata<V1ObjectMeta> obj, string key)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            IDictionary<string, string> labels = obj.Labels();
+            return labels != null && labels.TryGetValue(key, out string value) ? value : null;
+        }
+
+        /// <summary>Creates a <see cref="V1ObjectReference"/> that refers to the given object.</summary>
+        public static V1ObjectReference GetObjectReference<T>(this T obj) where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
+            if(string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
+            {
+                object[] attrs = typeof(T).GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
+                if(attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
+                var attr = (KubernetesEntityAttribute)attrs[0];
+                (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);
+            }
+            return new V1ObjectReference()
+            {
+                ApiVersion = apiVersion, Kind = kind, Name = obj.Name(), NamespaceProperty = obj.Namespace(), Uid = obj.Uid(),
+                ResourceVersion = obj.ResourceVersion()
+            };
+        }
+
+        /// <summary>Gets the labels of a Kubernetes object.</summary>
+        public static IDictionary<string, string> Labels(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Labels;
+
+        /// <summary>Gets the name of a Kubernetes object.</summary>
+        public static string Name(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Name;
+
+        /// <summary>Gets the namespace of a Kubernetes object.</summary>
+        public static string Namespace(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.NamespaceProperty;
+
+        /// <summary>Gets the owner references of a Kubernetes object.</summary>
+        public static IList<V1OwnerReference> OwnerReferences(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.OwnerReferences;
+
+        /// <summary>Gets the resource version of a Kubernetes object.</summary>
+        public static string ResourceVersion(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.ResourceVersion;
+
+        /// <summary>Sets or removes an annotation on a Kubernetes object.</summary>
+        public static void SetAnnotation(this IMetadata<V1ObjectMeta> obj, string key, string value)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            if(value != null) obj.EnsureMetadata().EnsureAnnotations()[key] = value;
+            else obj.Metadata?.Annotations?.Remove(key);
+        }
+
+        /// <summary>Sets or removes a label on a Kubernetes object.</summary>
+        public static void SetLabel(this IMetadata<V1ObjectMeta> obj, string key, string value)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            if(value != null) obj.EnsureMetadata().EnsureLabels()[key] = value;
+            else obj.Metadata?.Labels?.Remove(key);
+        }
+
+        /// <summary>Gets the unique ID of a Kubernetes object.</summary>
+        public static string Uid(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Uid;
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta.Annotations"/> field is not null, and returns it.</summary>
+        public static IDictionary<string, string> EnsureAnnotations(this V1ObjectMeta meta)
+        {
+            if(meta.Annotations == null) meta.Annotations = new Dictionary<string, string>();
+            return meta.Annotations;
+        }
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta.Labels"/> field is not null, and returns it.</summary>
+        public static IDictionary<string, string> EnsureLabels(this V1ObjectMeta meta)
+        {
+            if(meta.Labels == null) meta.Labels = new Dictionary<string, string>();
+            return meta.Labels;
+        }
+
+        /// <summary>Gets the namespace from Kubernetes metadata.</summary>
+        public static string Namespace(this V1ObjectMeta meta) => meta.NamespaceProperty;
+
+        /// <summary>Sets the namespace from Kubernetes metadata.</summary>
+        public static void SetNamespace(this V1ObjectMeta meta, string ns) => meta.NamespaceProperty = ns;
+
+        /// <summary>Determines whether an object reference references the given object.</summary>
+        public static bool Matches(this V1ObjectReference objref, IKubernetesObject<V1ObjectMeta> obj)
+        {
+            if(objref == null) throw new ArgumentNullException(nameof(objref));
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            return objref.ApiVersion == obj.ApiVersion && objref.Kind == obj.Kind && objref.Name == obj.Name() && objref.Uid == obj.Uid() &&
+                   objref.NamespaceProperty == obj.Namespace();
+        }
+
+        /// <summary>Determines whether an owner reference references the given object.</summary>
+        public static bool Matches(this V1OwnerReference owner, IKubernetesObject<V1ObjectMeta> obj)
+        {
+            if(owner == null) throw new ArgumentNullException(nameof(owner));
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            return owner.ApiVersion == obj.ApiVersion && owner.Kind == obj.Kind && owner.Name == obj.Name() && owner.Uid == obj.Uid();
+        }
+    }
+
+    public partial class V1Status
+    {
+        /// <summary>Converts a <see cref="V1Status"/> object representing an error into a short description of the error.</summary>
+        public override string ToString()
+        {
+            string reason = Reason;
+            if(string.IsNullOrEmpty(reason) && Code.GetValueOrDefault() != 0)
+            {
+                reason = ((HttpStatusCode)Code.Value).ToString();
+            }
+            return string.IsNullOrEmpty(Message) ? reason : string.IsNullOrEmpty(reason) ? Message : $"{reason} - {Message}";
+        }
+    }
+}

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -92,7 +92,7 @@ namespace k8s.Models
         /// <summary>Gets the index of the <see cref="V1OwnerReference"/> that matches the given object, or -1 if no such
         /// reference could be found.
         /// </summary>
-        public static int FindOwnerRef(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
+        public static int FindOwnerReference(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
         {
             var ownerRefs = obj.OwnerReferences();
             if(ownerRefs != null)
@@ -131,13 +131,13 @@ namespace k8s.Models
         }
 
         /// <summary>Creates a <see cref="V1ObjectReference"/> that refers to the given object.</summary>
-        public static V1ObjectReference GetObjectReference<T>(this T obj) where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+        public static V1ObjectReference GetObjectReference(this IKubernetesObject<V1ObjectMeta> obj)
         {
             if(obj == null) throw new ArgumentNullException(nameof(obj));
             string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
             if(string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
             {
-                object[] attrs = typeof(T).GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
+                object[] attrs = obj.GetType().GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
                 if(attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
                 var attr = (KubernetesEntityAttribute)attrs[0];
                 (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -353,18 +353,4 @@ namespace k8s.Models
             return owner.ApiVersion == obj.ApiVersion && owner.Kind == obj.Kind && owner.Name == obj.Name() && owner.Uid == obj.Uid();
         }
     }
-
-    public partial class V1Status
-    {
-        /// <summary>Converts a <see cref="V1Status"/> object representing an error into a short description of the error.</summary>
-        public override string ToString()
-        {
-            string reason = Reason;
-            if (string.IsNullOrEmpty(reason) && Code.GetValueOrDefault() != 0)
-            {
-                reason = ((HttpStatusCode)Code.Value).ToString();
-            }
-            return string.IsNullOrEmpty(Message) ? reason : string.IsNullOrEmpty(reason) ? Message : $"{reason} - {Message}";
-        }
-    }
 }

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 
 namespace k8s.Models
 {

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -1,0 +1,171 @@
+using System;
+using k8s.Models;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class ModelExtensionTests
+    {
+        [Fact]
+        public void TestMetadata()
+        {
+            // test getters on null metadata
+            var pod = new V1Pod();
+            Assert.Null(pod.Annotations());
+            Assert.Null(pod.ApiGroup());
+            var (g, v) = pod.ApiGroupAndVersion();
+            Assert.Null(g);
+            Assert.Null(v);
+            Assert.Null(pod.ApiGroupVersion());
+            Assert.Null(pod.CreationTimestamp());
+            Assert.Null(pod.DeletionTimestamp());
+            Assert.Null(pod.Finalizers());
+            Assert.Null(pod.Generation());
+            Assert.Null(pod.GetAnnotation("x"));
+            Assert.Null(pod.GetController());
+            Assert.Null(pod.GetLabel("x"));
+            Assert.False(pod.HasFinalizer("x"));
+            Assert.Null(pod.Labels());
+            Assert.Null(pod.Name());
+            Assert.Null(pod.Namespace());
+            Assert.Null(pod.OwnerReferences());
+            Assert.Null(pod.ResourceVersion());
+            Assert.Null(pod.Uid());
+            Assert.Null(pod.Metadata);
+
+            // test API version stuff
+            pod = new V1Pod() { ApiVersion = "v1" };
+            Assert.Equal("", pod.ApiGroup());
+            (g, v) = pod.ApiGroupAndVersion();
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("v1", pod.ApiGroupVersion());
+            pod.ApiVersion = "abc/v2";
+            Assert.Equal("abc", pod.ApiGroup());
+            (g, v) = pod.ApiGroupAndVersion();
+            Assert.Equal("abc", g);
+            Assert.Equal("v2", v);
+            Assert.Equal("v2", pod.ApiGroupVersion());
+
+            // test the Ensure*() functions
+            Assert.NotNull(pod.EnsureMetadata());
+            Assert.NotNull(pod.Metadata);
+            Assert.NotNull(pod.Metadata.EnsureAnnotations());
+            Assert.NotNull(pod.Metadata.Annotations);
+            Assert.NotNull(pod.Metadata.EnsureFinalizers());
+            Assert.NotNull(pod.Metadata.Finalizers);
+            Assert.NotNull(pod.Metadata.EnsureLabels());
+            Assert.NotNull(pod.Metadata.Labels);
+
+            // test getters with non-null values
+            DateTime ts = DateTime.UtcNow, ts2 = DateTime.Now;
+            pod.Metadata = new V1ObjectMeta()
+            {
+                CreationTimestamp = ts, DeletionTimestamp = ts2, Generation = 1, Name = "name", NamespaceProperty = "ns", ResourceVersion = "42", Uid = "id"
+            };
+            Assert.Equal(ts, pod.CreationTimestamp().Value);
+            Assert.Equal(ts2, pod.DeletionTimestamp().Value);
+            Assert.Equal(1, pod.Generation().Value);
+            Assert.Equal("name", pod.Name());
+            Assert.Equal("ns", pod.Namespace());
+            Assert.Equal("42", pod.ResourceVersion());
+            Assert.Equal("id", pod.Uid());
+
+            // test annotations and labels
+            pod.SetAnnotation("x", "y");
+            pod.SetLabel("a", "b");
+            Assert.Equal(1, pod.Annotations().Count);
+            Assert.Equal(1, pod.Labels().Count);
+            Assert.Equal("y", pod.GetAnnotation("x"));
+            Assert.Equal("y", pod.Metadata.Annotations["x"]);
+            Assert.Null(pod.GetAnnotation("a"));
+            Assert.Equal("b", pod.GetLabel("a"));
+            Assert.Equal("b", pod.Metadata.Labels["a"]);
+            Assert.Null(pod.GetLabel("x"));
+            pod.SetAnnotation("x", null);
+            Assert.Equal(0, pod.Annotations().Count);
+            pod.SetLabel("a", null);
+            Assert.Equal(0, pod.Labels().Count);
+
+            // test finalizers
+            Assert.False(pod.HasFinalizer("abc"));
+            Assert.True(pod.AddFinalizer("abc"));
+            Assert.True(pod.HasFinalizer("abc"));
+            Assert.False(pod.AddFinalizer("abc"));
+            Assert.False(pod.HasFinalizer("xyz"));
+            Assert.False(pod.RemoveFinalizer("xyz"));
+            Assert.True(pod.RemoveFinalizer("abc"));
+            Assert.False(pod.HasFinalizer("abc"));
+            Assert.False(pod.RemoveFinalizer("abc"));
+        }
+
+        [Fact]
+        public void TestReferences()
+        {
+            // test object references
+            var pod = new V1Pod() { ApiVersion = "abc/xyz", Kind = "sometimes" };
+            pod.Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns", ResourceVersion = "ver", Uid = "id" };
+            var objr = pod.GetObjectReference();
+            Assert.Equal(pod.ApiVersion, objr.ApiVersion);
+            Assert.Equal(pod.Kind, objr.Kind);
+            Assert.Equal(pod.Name(), objr.Name);
+            Assert.Equal(pod.Namespace(), objr.NamespaceProperty);
+            Assert.Equal(pod.ResourceVersion(), objr.ResourceVersion);
+            Assert.Equal(pod.Uid(), objr.Uid);
+            Assert.True(objr.Matches(pod));
+
+            (pod.ApiVersion, pod.Kind) = (null, null);
+            objr = pod.GetObjectReference();
+            Assert.Equal("v1", objr.ApiVersion);
+            Assert.Equal("Pod", objr.Kind);
+            Assert.False(objr.Matches(pod));
+            (pod.ApiVersion, pod.Kind) = (objr.ApiVersion, objr.Kind);
+            Assert.True(objr.Matches(pod));
+            pod.Metadata.Name = "nome";
+            Assert.False(objr.Matches(pod));
+
+            // test owner references
+            (pod.ApiVersion, pod.Kind) = ("abc/xyz", "sometimes");
+            var ownr = pod.CreateOwnerReference(true, false);
+            Assert.Equal(pod.ApiVersion, ownr.ApiVersion);
+            Assert.Equal(pod.Kind, ownr.Kind);
+            Assert.Equal(pod.Name(), ownr.Name);
+            Assert.Equal(pod.Uid(), ownr.Uid);
+            Assert.True(ownr.Controller.Value);
+            Assert.False(ownr.BlockOwnerDeletion.Value);
+            Assert.True(ownr.Matches(pod));
+
+            (pod.ApiVersion, pod.Kind) = (null, null);
+            Assert.False(ownr.Matches(pod));
+            ownr = pod.CreateOwnerReference();
+            Assert.Equal("v1", ownr.ApiVersion);
+            Assert.Equal("Pod", ownr.Kind);
+            Assert.Null(ownr.Controller);
+            Assert.Null(ownr.BlockOwnerDeletion);
+            Assert.False(ownr.Matches(pod));
+            (pod.ApiVersion, pod.Kind) = (ownr.ApiVersion, ownr.Kind);
+            Assert.True(ownr.Matches(pod));
+            ownr.Name = "nim";
+            Assert.False(ownr.Matches(pod));
+            ownr.Name = pod.Name();
+
+            var svc = new V1Service();
+            svc.AddOwnerReference(ownr);
+            Assert.Equal(0, svc.FindOwnerReference(pod));
+            Assert.Equal(-1, svc.FindOwnerReference(svc));
+            Assert.Null(svc.GetController());
+            svc.OwnerReferences()[0].Controller = true;
+            Assert.Same(ownr, svc.GetController());
+            Assert.Same(ownr, svc.RemoveOwnerReference(pod));
+            Assert.Equal(0, svc.OwnerReferences().Count);
+            svc.AddOwnerReference(pod.CreateOwnerReference(true));
+            svc.AddOwnerReference(pod.CreateOwnerReference(false));
+            svc.AddOwnerReference(pod.CreateOwnerReference());
+            Assert.Equal(3, svc.OwnerReferences().Count);
+            Assert.NotNull(svc.RemoveOwnerReference(pod));
+            Assert.Equal(2, svc.OwnerReferences().Count);
+            Assert.True(svc.RemoveOwnerReferences(pod));
+            Assert.Equal(0, svc.OwnerReferences().Count);
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -20,10 +20,12 @@ namespace k8s.Tests
             Assert.Null(pod.CreationTimestamp());
             Assert.Null(pod.DeletionTimestamp());
             Assert.Null(pod.Finalizers());
+            Assert.Equal(-1, pod.FindOwnerReference(r => true));
             Assert.Null(pod.Generation());
             Assert.Null(pod.GetAnnotation("x"));
             Assert.Null(pod.GetController());
             Assert.Null(pod.GetLabel("x"));
+            Assert.Null(pod.GetOwnerReference(r => true));
             Assert.False(pod.HasFinalizer("x"));
             Assert.Null(pod.Labels());
             Assert.Null(pod.Name());
@@ -105,7 +107,7 @@ namespace k8s.Tests
             // test object references
             var pod = new V1Pod() { ApiVersion = "abc/xyz", Kind = "sometimes" };
             pod.Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns", ResourceVersion = "ver", Uid = "id" };
-            var objr = pod.GetObjectReference();
+            var objr = pod.CreateObjectReference();
             Assert.Equal(pod.ApiVersion, objr.ApiVersion);
             Assert.Equal(pod.Kind, objr.Kind);
             Assert.Equal(pod.Name(), objr.Name);
@@ -115,7 +117,7 @@ namespace k8s.Tests
             Assert.True(objr.Matches(pod));
 
             (pod.ApiVersion, pod.Kind) = (null, null);
-            objr = pod.GetObjectReference();
+            objr = pod.CreateObjectReference();
             Assert.Equal("v1", objr.ApiVersion);
             Assert.Equal("Pod", objr.Kind);
             Assert.False(objr.Matches(pod));
@@ -153,6 +155,8 @@ namespace k8s.Tests
             svc.AddOwnerReference(ownr);
             Assert.Equal(0, svc.FindOwnerReference(pod));
             Assert.Equal(-1, svc.FindOwnerReference(svc));
+            Assert.Same(ownr, svc.GetOwnerReference(pod));
+            Assert.Null(svc.GetOwnerReference(svc));
             Assert.Null(svc.GetController());
             svc.OwnerReferences()[0].Controller = true;
             Assert.Same(ownr, svc.GetController());


### PR DESCRIPTION
This change adds a many useful model extension methods that make the Kubernetes client smoother and more concise to use. This change helps address issue #390 .

* Metadata is inlined, so instead of o.Metadata.X, you can use o.X(). Examples:

      o.Metadata?.Name -> o.Name()
      o.Metadata?.NamespaceProperty -> o.Namespace()
      ... etc ...

* Managing labels and annotations. Examples for labels:

      string value = null;
      if(o.Metadata.Labels != null) o.Metadata.Labels.TryGetValue(key, out value)
  
  becomes
  
      o.GetLabel(key)
  
  Similarly,

      if(o.Metadata == null) o.Metadata = new V1ObjectMeta();
      if(o.Metadata.Labels == null) o.Metadata.Labels = new Dictionary<string,string>();
      o.Metadata.Labels[key] = value;
  
  becomes
  
      o.SetLabel(key, value)

* Managing owner and object references
  * o.AddOwnerReference(ownerRef) // adds an owner reference
  * o.CreateOwnerReference(...) // create an owner reference to o
  * o.FindOwnerReference(owner) // finds and returns the reference to 'owner', if any
  * o.GetController() // gets the reference to the owner that controls the resource
  * o.GetObjectReference() // creates an object reference to o
  * ownerRef.Matches(o) // does ownerRef refer to o?
  * objRef.Matches(o) // does objRef refer to o?
  * ...
* And some other small things.

The pull request depends on (and includes) the IKubernetesObject\<T\> PR I submitted earlier: https://github.com/kubernetes-client/csharp/pull/404  **The only changes in this PR specifically belong to the ModelExtensions.cs file.** (I'm not sure how best to represent that in a PR...)