### PR TITLE
Add an improved watch

### DIFF
--- a/src/KubernetesClient/Fluent/Kubernetes.Fluent.cs
+++ b/src/KubernetesClient/Fluent/Kubernetes.Fluent.cs
@@ -2,48 +2,48 @@ using System;
 using System.Net.Http;
 using k8s.Models;
 
-namespace k8s
+namespace k8s.Fluent
 {
-    public partial class Kubernetes
+    public static class KubernetesFluent
     {
         /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/> and
         /// <see cref="IKubernetesObject.Kind"/>.
         /// </summary>
-        public T New<T>() where T : IKubernetesObject, new() => Scheme.New<T>();
+        public static T New<T>(this Kubernetes client) where T : IKubernetesObject, new() => client.Scheme.New<T>();
 
         /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
         /// <see cref="IKubernetesObject.Kind"/>, and <see cref="V1ObjectMeta.Name"/>.
         /// </summary>
-        public T New<T>(string name) where T : IKubernetesObject<V1ObjectMeta>, new() => Scheme.New<T>(name);
+        public static T New<T>(this Kubernetes client, string name) where T : IKubernetesObject<V1ObjectMeta>, new() => client.Scheme.New<T>(name);
 
         /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
         /// <see cref="IKubernetesObject.Kind"/>, <see cref="V1ObjectMeta.Namespace"/>, and <see cref="V1ObjectMeta.Name"/>.
         /// </summary>
-        public T New<T>(string ns, string name) where T : IKubernetesObject<V1ObjectMeta>, new() => Scheme.New<T>(ns, name);
+        public static T New<T>(this Kubernetes client, string ns, string name) where T : IKubernetesObject<V1ObjectMeta>, new() => client.Scheme.New<T>(ns, name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
         /// (<see cref="HttpMethod.Get"/> by default).
         /// </summary>
-        public KubernetesRequest Request(HttpMethod method = null) => new KubernetesRequest(this).Method(method);
+        public static KubernetesRequest Request(this Kubernetes client, HttpMethod method = null) => new KubernetesRequest(client).Method(method);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
         /// and resource URI components.
         /// </summary>
-        public KubernetesRequest Request(
+        public static KubernetesRequest Request(this Kubernetes client, 
             HttpMethod method, string type = null, string ns = null, string name = null, string group = null, string version = null) =>
-            new KubernetesRequest(this).Method(method).Group(group).Version(version).Type(type).Namespace(ns).Name(name);
+            new KubernetesRequest(client).Method(method).Group(group).Version(version).Type(type).Namespace(ns).Name(name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object.</summary>
-        public KubernetesRequest Request(Type type) => new KubernetesRequest(this).GVK(type);
+        public static KubernetesRequest Request(this Kubernetes client, Type type) => new KubernetesRequest(client).GVK(type);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
-        public KubernetesRequest Request(HttpMethod method, Type type, string ns = null, string name = null) =>
-            Request(method).GVK(type).Namespace(ns).Name(name);
+        public static KubernetesRequest Request(this Kubernetes client, HttpMethod method, Type type, string ns = null, string name = null) =>
+            Request(client, method).GVK(type).Namespace(ns).Name(name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
-        public KubernetesRequest Request<T>(string ns = null, string name = null) => Request(null, typeof(T), ns, name);
+        public static KubernetesRequest Request<T>(this Kubernetes client, string ns = null, string name = null) => Request(client, null, typeof(T), ns, name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
-        public KubernetesRequest Request(IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(this).Set(obj, setBody);
+        public static KubernetesRequest Request(this Kubernetes client, IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(client).Set(obj, setBody);
     }
 }

--- a/src/KubernetesClient/Fluent/KubernetesRequest.cs
+++ b/src/KubernetesClient/Fluent/KubernetesRequest.cs
@@ -12,9 +12,8 @@ using k8s.Models;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 
-namespace k8s
+namespace k8s.Fluent
 {
-    #region KubernetesRequest
     /// <summary>Represents a single request to Kubernetes.</summary>
     public sealed class KubernetesRequest : ICloneable
     {
@@ -687,91 +686,4 @@ namespace k8s
 
         static string NormalizeEmpty(string value) => string.IsNullOrEmpty(value) ? null : value; // normalizes empty strings to null
     }
-#endregion
-
-#region KubernetesResponse
-    /// <summary>Represents a response to a <see cref="KubernetesRequest"/>.</summary>
-    public sealed class KubernetesResponse : IDisposable
-    {
-        /// <summary>Initializes a new <see cref="KubernetesResponse"/> from an <see cref="HttpResponseMessage"/>.</summary>
-        public KubernetesResponse(HttpResponseMessage message) => Message = message ?? throw new ArgumentNullException(nameof(message));
-
-        /// <summary>Indicates whether the server returned an error response.</summary>
-        public bool IsError => (int)StatusCode >= 400;
-
-        /// <summary>Indicates whether the server returned a 404 Not Found response.</summary>
-        public bool IsNotFound => StatusCode == HttpStatusCode.NotFound;
-
-        /// <summary>Gets the underlying <see cref="HttpResponseMessage"/>.</summary>
-        public HttpResponseMessage Message { get; }
-
-        /// <summary>Gets the <see cref="HttpStatusCode"/> of the response.</summary>
-        public HttpStatusCode StatusCode => Message.StatusCode;
-
-        /// <inheritdoc/>
-        public void Dispose() => Message.Dispose();
-
-        /// <summary>Returns the response body as a string.</summary>
-        public async Task<string> GetBodyAsync()
-        {
-            if (body == null)
-            {
-                body = Message.Content != null ? await Message.Content.ReadAsStringAsync().ConfigureAwait(false) : string.Empty;
-            }
-            return body;
-        }
-
-        /// <summary>Deserializes the response body from JSON as a value of the given type, or null if the response body is empty.</summary>
-        /// <param name="type">The type of object to return</param>
-        /// <param name="failIfEmpty">If false, an empty response body will be returned as null. If true, an exception will be thrown if
-        /// the body is empty. The default is false.
-        /// </param>
-        public async Task<object> GetBodyAsync(Type type, bool failIfEmpty = false)
-        {
-            string body = await GetBodyAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(body))
-            {
-                if (!failIfEmpty) throw new InvalidOperationException("The response body was empty.");
-                return null;
-            }
-            return JsonConvert.DeserializeObject(body, type, Kubernetes.DefaultJsonSettings);
-        }
-
-        /// <summary>Deserializes the response body from JSON as a value of type <typeparamref name="T"/>, or the default value of
-        /// type <typeparamref name="T"/> if the response body is empty.
-        /// </summary>
-        /// <param name="failIfEmpty">If false, an empty response body will be returned as the default value of type
-        /// <typeparamref name="T"/>. If true, an exception will be thrown if the body is empty. The default is false.
-        /// </param>
-        public async Task<T> GetBodyAsync<T>(bool failIfEmpty = false)
-        {
-            string body = await GetBodyAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(body))
-            {
-                if (failIfEmpty) throw new InvalidOperationException("The response body was empty.");
-                return default(T);
-            }
-            return JsonConvert.DeserializeObject<T>(body, Kubernetes.DefaultJsonSettings);
-        }
-
-        /// <summary>Deserializes the response body as a <see cref="V1Status"/> object, or creates one from the status code if the
-        /// response body is not a JSON object.
-        /// </summary>
-        public async Task<V1Status> GetStatusAsync()
-        {
-            try
-            {
-                var status = await GetBodyAsync<V1Status>().ConfigureAwait(false);
-                if (status != null && (status.Status == "Success" || status.Status == "Failure")) return status;
-            }
-            catch (JsonException) { }
-            return new V1Status()
-            {
-                Status = IsError ? "Failure" : "Success", Code = (int)StatusCode, Reason = StatusCode.ToString(), Message = body
-            };
-        }
-
-        string body;
-    }
-#endregion
 }

--- a/src/KubernetesClient/Fluent/KubernetesResponse.cs
+++ b/src/KubernetesClient/Fluent/KubernetesResponse.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using k8s.Models;
+using Newtonsoft.Json;
+
+namespace k8s.Fluent
+{
+    /// <summary>Represents a response to a <see cref="KubernetesRequest"/>.</summary>
+    public sealed class KubernetesResponse : IDisposable
+    {
+        /// <summary>Initializes a new <see cref="KubernetesResponse"/> from an <see cref="HttpResponseMessage"/>.</summary>
+        public KubernetesResponse(HttpResponseMessage message) => Message = message ?? throw new ArgumentNullException(nameof(message));
+
+        /// <summary>Indicates whether the server returned an error response.</summary>
+        public bool IsError => (int)StatusCode >= 400;
+
+        /// <summary>Indicates whether the server returned a 404 Not Found response.</summary>
+        public bool IsNotFound => StatusCode == HttpStatusCode.NotFound;
+
+        /// <summary>Gets the underlying <see cref="HttpResponseMessage"/>.</summary>
+        public HttpResponseMessage Message { get; }
+
+        /// <summary>Gets the <see cref="HttpStatusCode"/> of the response.</summary>
+        public HttpStatusCode StatusCode => Message.StatusCode;
+
+        /// <inheritdoc/>
+        public void Dispose() => Message.Dispose();
+
+        /// <summary>Returns the response body as a string.</summary>
+        public async Task<string> GetBodyAsync()
+        {
+            if (body == null)
+            {
+                body = Message.Content != null ? await Message.Content.ReadAsStringAsync().ConfigureAwait(false) : string.Empty;
+            }
+            return body;
+        }
+
+        /// <summary>Deserializes the response body from JSON as a value of the given type, or null if the response body is empty.</summary>
+        /// <param name="type">The type of object to return</param>
+        /// <param name="failIfEmpty">If false, an empty response body will be returned as null. If true, an exception will be thrown if
+        /// the body is empty. The default is false.
+        /// </param>
+        public async Task<object> GetBodyAsync(Type type, bool failIfEmpty = false)
+        {
+            string body = await GetBodyAsync().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                if (!failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                return null;
+            }
+            return JsonConvert.DeserializeObject(body, type, Kubernetes.DefaultJsonSettings);
+        }
+
+        /// <summary>Deserializes the response body from JSON as a value of type <typeparamref name="T"/>, or the default value of
+        /// type <typeparamref name="T"/> if the response body is empty.
+        /// </summary>
+        /// <param name="failIfEmpty">If false, an empty response body will be returned as the default value of type
+        /// <typeparamref name="T"/>. If true, an exception will be thrown if the body is empty. The default is false.
+        /// </param>
+        public async Task<T> GetBodyAsync<T>(bool failIfEmpty = false)
+        {
+            string body = await GetBodyAsync().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                if (failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                return default(T);
+            }
+            return JsonConvert.DeserializeObject<T>(body, Kubernetes.DefaultJsonSettings);
+        }
+
+        /// <summary>Deserializes the response body as a <see cref="V1Status"/> object, or creates one from the status code if the
+        /// response body is not a JSON object.
+        /// </summary>
+        public async Task<V1Status> GetStatusAsync()
+        {
+            try
+            {
+                var status = await GetBodyAsync<V1Status>().ConfigureAwait(false);
+                if (status != null && (status.Status == "Success" || status.Status == "Failure")) return status;
+            }
+            catch (JsonException) { }
+            return new V1Status()
+            {
+                Status = IsError ? "Failure" : "Success", Code = (int)StatusCode, Reason = StatusCode.ToString(), Message = body
+            };
+        }
+
+        string body;
+    }
+}

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -203,19 +203,7 @@ namespace k8s
         /// </summary>
         private void SetCredentials()
         {
-            // set the Credentails for token based auth
-            if (!string.IsNullOrWhiteSpace(config.AccessToken))
-            {
-                Credentials = new TokenCredentials(config.AccessToken);
-            }
-            else if (!string.IsNullOrWhiteSpace(config.Username) && !string.IsNullOrWhiteSpace(config.Password))
-            {
-                Credentials = new BasicAuthenticationCredentials
-                {
-                    UserName = config.Username,
-                    Password = config.Password
-                };
-            }
+            Credentials = CreateCredentials(config);
         }
 
         internal readonly KubernetesClientConfiguration config;
@@ -283,6 +271,23 @@ namespace k8s
             var settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
             settings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
             return settings;
+        }
+
+        /// <summary>Creates <see cref="ServiceClientCredentials"/> from a Kubernetes configuration, or returns null if the configuration
+        /// contains no credentials of that type.
+        /// </summary>
+        internal static ServiceClientCredentials CreateCredentials(KubernetesClientConfiguration config)
+        {
+            if(config == null) throw new ArgumentNullException(nameof(config));
+            if(!string.IsNullOrEmpty(config.AccessToken))
+            {
+                return new TokenCredentials(config.AccessToken);
+            }
+            else if(!string.IsNullOrEmpty(config.Username))
+            {
+                return new BasicAuthenticationCredentials() { UserName = config.Username, Password = config.Password };
+            }
+            return null;
         }
 
         /// <summary>Gets the <see cref="JsonSerializerSettings"/> used to serialize and deserialize Kubernetes objects.</summary>

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -72,7 +72,7 @@ namespace k8s
             get => _scheme;
             set
             {
-                if(value == null) throw new ArgumentNullException(nameof(Scheme));
+                if (value == null) throw new ArgumentNullException(nameof(Scheme));
                 _scheme = value;
             }
         }
@@ -278,12 +278,12 @@ namespace k8s
         /// </summary>
         internal static ServiceClientCredentials CreateCredentials(KubernetesClientConfiguration config)
         {
-            if(config == null) throw new ArgumentNullException(nameof(config));
-            if(!string.IsNullOrEmpty(config.AccessToken))
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (!string.IsNullOrEmpty(config.AccessToken))
             {
                 return new TokenCredentials(config.AccessToken);
             }
-            else if(!string.IsNullOrEmpty(config.Username))
+            else if (!string.IsNullOrEmpty(config.Username))
             {
                 return new BasicAuthenticationCredentials() { UserName = config.Username, Password = config.Password };
             }

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -199,7 +199,7 @@ namespace k8s
         }
 
         /// <summary>
-        ///     Set credentials for the Client
+        ///     Set credentials for the Client based on the config
         /// </summary>
         private void SetCredentials()
         {

--- a/src/KubernetesClient/Kubernetes.Fluent.cs
+++ b/src/KubernetesClient/Kubernetes.Fluent.cs
@@ -27,14 +27,7 @@ namespace k8s
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
         public KubernetesRequest New<T>(string ns = null, string name = null) => New(null, typeof(T), ns, name);
 
-        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
-        public KubernetesRequest New<T>(HttpMethod method, string ns = null, string name = null) =>
-            New(method, typeof(T), ns, name);
-
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
         public KubernetesRequest New(IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(this).Set(obj, setBody);
-
-        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
-        public KubernetesRequest New(HttpMethod method, IKubernetesObject obj, bool setBody = true) => New(method).Set(obj, setBody);
     }
 }

--- a/src/KubernetesClient/Kubernetes.Fluent.cs
+++ b/src/KubernetesClient/Kubernetes.Fluent.cs
@@ -1,33 +1,49 @@
 using System;
 using System.Net.Http;
+using k8s.Models;
 
 namespace k8s
 {
     public partial class Kubernetes
     {
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/> and
+        /// <see cref="IKubernetesObject.Kind"/>.
+        /// </summary>
+        public T New<T>() where T : IKubernetesObject, new() => Scheme.New<T>();
+
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
+        /// <see cref="IKubernetesObject.Kind"/>, and <see cref="V1ObjectMeta.Name"/>.
+        /// </summary>
+        public T New<T>(string name) where T : IKubernetesObject<V1ObjectMeta>, new() => Scheme.New<T>(name);
+
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
+        /// <see cref="IKubernetesObject.Kind"/>, <see cref="V1ObjectMeta.Namespace"/>, and <see cref="V1ObjectMeta.Name"/>.
+        /// </summary>
+        public T New<T>(string ns, string name) where T : IKubernetesObject<V1ObjectMeta>, new() => Scheme.New<T>(ns, name);
+
         /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
         /// (<see cref="HttpMethod.Get"/> by default).
         /// </summary>
-        public KubernetesRequest New(HttpMethod method = null) => new KubernetesRequest(this).Method(method);
+        public KubernetesRequest Request(HttpMethod method = null) => new KubernetesRequest(this).Method(method);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
         /// and resource URI components.
         /// </summary>
-        public KubernetesRequest New(
+        public KubernetesRequest Request(
             HttpMethod method, string type = null, string ns = null, string name = null, string group = null, string version = null) =>
             new KubernetesRequest(this).Method(method).Group(group).Version(version).Type(type).Namespace(ns).Name(name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object.</summary>
-        public KubernetesRequest New(Type type) => new KubernetesRequest(this).GVK(type);
+        public KubernetesRequest Request(Type type) => new KubernetesRequest(this).GVK(type);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
-        public KubernetesRequest New(HttpMethod method, Type type, string ns = null, string name = null) =>
-            New(method).GVK(type).Namespace(ns).Name(name);
+        public KubernetesRequest Request(HttpMethod method, Type type, string ns = null, string name = null) =>
+            Request(method).GVK(type).Namespace(ns).Name(name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
-        public KubernetesRequest New<T>(string ns = null, string name = null) => New(null, typeof(T), ns, name);
+        public KubernetesRequest Request<T>(string ns = null, string name = null) => Request(null, typeof(T), ns, name);
 
         /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
-        public KubernetesRequest New(IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(this).Set(obj, setBody);
+        public KubernetesRequest Request(IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(this).Set(obj, setBody);
     }
 }

--- a/src/KubernetesClient/Kubernetes.Fluent.cs
+++ b/src/KubernetesClient/Kubernetes.Fluent.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.Http;
+
+namespace k8s
+{
+    public partial class Kubernetes
+    {
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
+        /// (<see cref="HttpMethod.Get"/> by default).
+        /// </summary>
+        public KubernetesRequest New(HttpMethod method = null) => new KubernetesRequest(this).Method(method);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> using the given <see cref="HttpMethod"/>
+        /// and resource URI components.
+        /// </summary>
+        public KubernetesRequest New(
+            HttpMethod method, string type = null, string ns = null, string name = null, string group = null, string version = null) =>
+            new KubernetesRequest(this).Method(method).Group(group).Version(version).Type(type).Namespace(ns).Name(name);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object.</summary>
+        public KubernetesRequest New(Type type) => new KubernetesRequest(this).GVK(type);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
+        public KubernetesRequest New(HttpMethod method, Type type, string ns = null, string name = null) =>
+            New(method).GVK(type).Namespace(ns).Name(name);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
+        public KubernetesRequest New<T>(string ns = null, string name = null) => New(null, typeof(T), ns, name);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given type of object with an optional name and namespace.</summary>
+        public KubernetesRequest New<T>(HttpMethod method, string ns = null, string name = null) =>
+            New(method, typeof(T), ns, name);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
+        public KubernetesRequest New(IKubernetesObject obj, bool setBody = true) => new KubernetesRequest(this).Set(obj, setBody);
+
+        /// <summary>Creates a new <see cref="KubernetesRequest"/> to access the given object.</summary>
+        public KubernetesRequest New(HttpMethod method, IKubernetesObject obj, bool setBody = true) => New(method).Set(obj, setBody);
+    }
+}

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -277,19 +277,19 @@ namespace k8s
             }
 
 #if (NET452 || NETSTANDARD2_0)
-            if (this.CaCerts != null)
+            if (this.config.SslCaCerts != null)
             {
                 webSocketBuilder.SetServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
             }
 #endif
 
 #if NETCOREAPP2_1
-            if (this.CaCerts != null)
+            if (this.config.SslCaCerts != null)
             {
-                webSocketBuilder.ExpectServerCertificate(this.CaCerts);
+                webSocketBuilder.ExpectServerCertificate(this.config.SslCaCerts);
             }
 
-            if (this.SkipTlsVerify)
+            if (this.config.SkipTlsVerify)
             {
                 webSocketBuilder.SkipServerCertificateValidation();
             }
@@ -365,7 +365,7 @@ namespace k8s
                 }
 
 #if (NET452 || NETSTANDARD2_0)
-                if (this.CaCerts != null)
+                if (this.config.SslCaCerts != null)
                 {
                     webSocketBuilder.CleanupServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
                 }
@@ -377,7 +377,7 @@ namespace k8s
 #if (NET452 || NETSTANDARD2_0)
         internal bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            return Kubernetes.CertificateValidationCallBack(sender, this.CaCerts, certificate, chain, sslPolicyErrors);
+            return Kubernetes.CertificateValidationCallBack(sender, this.config.SslCaCerts, certificate, chain, sslPolicyErrors);
         }
 #endif
     }

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -277,19 +277,19 @@ namespace k8s
             }
 
 #if (NET452 || NETSTANDARD2_0)
-            if (this.config.SslCaCerts != null)
+            if (this.config?.SslCaCerts != null)
             {
                 webSocketBuilder.SetServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
             }
 #endif
 
 #if NETCOREAPP2_1
-            if (this.config.SslCaCerts != null)
+            if (this.config?.SslCaCerts != null)
             {
                 webSocketBuilder.ExpectServerCertificate(this.config.SslCaCerts);
             }
 
-            if (this.config.SkipTlsVerify)
+            if (this.config?.SkipTlsVerify == true)
             {
                 webSocketBuilder.SkipServerCertificateValidation();
             }
@@ -365,7 +365,7 @@ namespace k8s
                 }
 
 #if (NET452 || NETSTANDARD2_0)
-                if (this.config.SslCaCerts != null)
+                if (this.config?.SslCaCerts != null)
                 {
                     webSocketBuilder.CleanupServerCertificateValidationCallback(this.ServerCertificateValidationCallback);
                 }
@@ -377,7 +377,7 @@ namespace k8s
 #if (NET452 || NETSTANDARD2_0)
         internal bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            return Kubernetes.CertificateValidationCallBack(sender, this.config.SslCaCerts, certificate, chain, sslPolicyErrors);
+            return Kubernetes.CertificateValidationCallBack(sender, this.config?.SslCaCerts, certificate, chain, sslPolicyErrors);
         }
 #endif
     }

--- a/src/KubernetesClient/KubernetesRequest.cs
+++ b/src/KubernetesClient/KubernetesRequest.cs
@@ -1,0 +1,713 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Newtonsoft.Json;
+
+namespace k8s
+{
+    #region KubernetesRequest
+    /// <summary>Represents a single request to Kubernetes.</summary>
+    public sealed class KubernetesRequest : ICloneable
+    {
+        /// <summary>Initializes a <see cref="KubernetesRequest"/> based on a <see cref="KubernetesClient"/>.</summary>
+        public KubernetesRequest(Kubernetes client) : this(client.config, client.HttpClient, client.Scheme) { }
+
+        /// <summary>Initializes a <see cref="KubernetesRequest"/> based on a <see cref="KubernetesClientConfiguration"/> and
+        /// <see cref="HttpClient"/>.
+        /// </summary>
+        /// <remarks>Any necessary SSL configuration must have already been applied to the <paramref name="client"/>.</remarks>
+        public KubernetesRequest(KubernetesClientConfiguration config, HttpClient client, KubernetesScheme scheme = null)
+        {
+            if(config == null) throw new ArgumentNullException(nameof(config));
+            if(string.IsNullOrEmpty(config.Host)) throw new ArgumentException("The kubernetes host must be provided.");
+            this.config = config;
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            Scheme(scheme);
+        }
+
+        /// <summary>Gets the value of the Accept header, or null to use the default of application/json.</summary>
+        public string Accept() => _accept;
+
+        /// <summary>Sets the value of the Accept header, or null or empty to use the default of application/json.</summary>
+        public KubernetesRequest Accept(string mediaType) { _accept = NormalizeEmpty(mediaType); return this; }
+
+        /// <summary>Adds a query-string parameter to the request. Multiple headers with the same name can be set this way.</summary>
+        public KubernetesRequest AddHeader(string key, string value) => Add(ref headers, key, value);
+
+        /// <summary>Adds a query-string parameter to the request. Multiple parameters with the same name can be set this way.</summary>
+        public KubernetesRequest AddQuery(string key, string value) => Add(ref query, key, value);
+
+        /// <summary>Gets the body to be sent to the server.</summary>
+        public object Body() => _body;
+
+        /// <summary>Sets the body to be sent to the server. If null, no body will be sent. If a string, byte array, or stream, the
+        /// contents will be sent directly. Otherwise, the body will be serialized into JSON and sent.
+        /// </summary>
+        public KubernetesRequest Body(object body) { _body = body; return this; }
+
+        /// <summary>Clears all custom header values.</summary>
+        public KubernetesRequest ClearHeaders()
+        {
+            if(headers != null) headers.Clear();
+            return this;
+        }
+
+        /// <summary>Clears custom header values with the given name.</summary>
+        public KubernetesRequest ClearHeaders(string headerName)
+        {
+            if(headerName == null) throw new ArgumentNullException(nameof(headerName));
+            if(headers != null) headers.Remove(headerName);
+            return this;
+        }
+
+        /// <summary>Clears all query-string parameters.</summary>
+        public KubernetesRequest ClearQuery()
+        {
+            if(query != null) query.Clear();
+            return this;
+        }
+
+        /// <summary>Clears all query-string parameters with the given key.</summary>
+        public KubernetesRequest ClearQuery(string key)
+        {
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            if(query != null) query.Remove(key);
+            return this;
+        }
+
+        /// <summary>Creates a deep copy of the <see cref="KubernetesRequest"/>.</summary>
+        public KubernetesRequest Clone()
+        {
+            var clone = (KubernetesRequest)MemberwiseClone();
+            if(headers != null)
+            {
+                clone.headers = new Dictionary<string, List<string>>(headers.Count);
+                foreach(KeyValuePair<string, List<string>> pair in headers) clone.headers.Add(pair.Key, new List<string>(pair.Value));
+            }
+            if(query != null)
+            {
+                clone.query = new Dictionary<string, List<string>>(query.Count);
+                foreach(KeyValuePair<string, List<string>> pair in query) clone.query.Add(pair.Key, new List<string>(pair.Value));
+            }
+            return clone;
+        }
+
+        /// <summary>Sets the <see cref="Method()"/> to <see cref="HttpMethod.Delete"/>.</summary>
+        public KubernetesRequest Delete() => Method(HttpMethod.Delete);
+
+        /// <summary>Sets the <see cref="Method()"/> to <see cref="HttpMethod.Get"/>.</summary>
+        public KubernetesRequest Get() => Method(HttpMethod.Get);
+
+        /// <summary>Sets the <see cref="Method()"/> to <see cref="HttpMethod.Patch"/>.</summary>
+        public KubernetesRequest Patch() => Method(new HttpMethod("PATCH"));
+
+        /// <summary>Sets the <see cref="Method()"/> to <see cref="HttpMethod.Post"/>.</summary>
+        public KubernetesRequest Post() => Method(HttpMethod.Post);
+
+        /// <summary>Sets the <see cref="Method()"/> to <see cref="HttpMethod.Put"/>.</summary>
+        public KubernetesRequest Put() => Method(HttpMethod.Put);
+
+        /// <summary>Sets the value of the "dryRun" query-string parameter, as a boolean.</summary>
+        public bool DryRun() => string.IsNullOrEmpty(GetQuery("dryRun"));
+
+        /// <summary>Sets the value of the "dryRun" query-string parameter to "All" or removes it.</summary>
+        public KubernetesRequest DryRun(bool dryRun) => SetQuery("dryRun", dryRun ? "All" : null);
+
+        /// <summary>Executes the request and returns a <see cref="KubernetesResponse"/>. The request can be executed multiple times,
+        /// and can be executed multiple times in parallel.
+        /// </summary>
+        public async Task<KubernetesResponse> ExecuteAsync(CancellationToken cancelToken = default)
+        {
+            cancelToken.ThrowIfCancellationRequested();
+            HttpRequestMessage req = CreateRequestMessage();
+            // requests like watches may not send a body immediately, so return as soon as we've got the response headers
+            var completion = _streamResponse || _watchVersion != null ?
+                HttpCompletionOption.ResponseHeadersRead : HttpCompletionOption.ResponseContentRead;
+            return new KubernetesResponse(await client.SendAsync(req, completion, cancelToken).ConfigureAwait(false));
+        }
+
+        /// <summary>Executes the request and returns the deserialized response body (or the default value of type
+        /// <typeparamref name="T"/> if the response was 404 Not Found).
+        /// </summary>
+        /// <exception cref="KubernetesException">Thrown if the response was any error besides 404 Not Found.</exception>
+        public Task<T> ExecuteAsync<T>(CancellationToken cancelToken = default) => ExecuteAsync<T>(false, cancelToken);
+
+        /// <summary>Executes the request and returns the deserialized response body.</summary>
+        /// <param name="failIfMissing">If true and the response is 404 Not Found, an exception will be thrown. If false, the default
+        /// value of type <typeparamref name="T"/> will be returned in that case. The default is false.
+        /// </param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the request</param>
+        /// <exception cref="KubernetesException">Thrown if the response was any error besides 404 Not Found.</exception>
+        public Task<T> ExecuteAsync<T>(bool failIfMissing, CancellationToken cancelToken = default)
+        {
+            if(_watchVersion != null) throw new InvalidOperationException("Watch requests cannot be deserialized all at once.");
+            cancelToken.ThrowIfCancellationRequested();
+            return ExecuteMessageAsync<T>(CreateRequestMessage(), failIfMissing, cancelToken);
+        }
+
+        /// <summary>Gets the "fieldManager" query-string parameter, or null if there is no field manager.</summary>
+        public string FieldManager() => NormalizeEmpty(GetQuery("fieldManager"));
+
+        /// <summary>Sets the "fieldManager" query-string parameter, or removes it if the value is null or empty.</summary>
+        public KubernetesRequest FieldManager(string manager) =>
+            SetQuery("fieldManager", !string.IsNullOrEmpty(manager) ? manager : null);
+
+        /// <summary>Gets the "fieldSelector" query-string parameter, or null if there is no field selector.</summary>
+        public string FieldSelector() => NormalizeEmpty(GetQuery("fieldSelector"));
+
+        /// <summary>Sets the "fieldSelector" query-string parameter, or removes it if the selector is null or empty.</summary>
+        public KubernetesRequest FieldSelector(string selector) =>
+            SetQuery("fieldSelector", !string.IsNullOrEmpty(selector) ? selector : null);
+
+        /// <summary>Gets the value of the named custom header, or null if it doesn't exist.</summary>
+        /// <exception cref="InvalidOperationException">Thrown if there are multiple custom headers with the given name</exception>
+        public string GetHeader(string key)
+        {
+            List<string> values = null;
+            if(headers != null) headers.TryGetValue(key, out values);
+            return values == null || values.Count == 0 ? null : values.Count == 1 ? values[0] :
+                throw new InvalidOperationException($"There are multiple query-string parameters named '{key}'.");
+        }
+
+        /// <summary>Gets the values of the named custom header, or null if it has no values.</summary>
+        /// <remarks>The returned collection, if not null, can be mutated to change the set of values.</remarks>
+        public List<string> GetHeaderValues(string key)
+        {
+            List<string> values = null;
+            if(headers != null) headers.TryGetValue(key, out values);
+            return values;
+        }
+
+        /// <summary>Gets the value of the named query-string parameter, or null if it doesn't exist.</summary>
+        /// <exception cref="InvalidOperationException">Thrown if there are multiple query-string parameters with the given name</exception>
+        public string GetQuery(string key)
+        {
+            List<string> values = GetQueryValues(key);
+            return values == null || values.Count == 0 ? null : values.Count == 1 ? values[0] :
+                throw new InvalidOperationException($"There are multiple query-string parameters named '{key}'.");
+        }
+
+        /// <summary>Gets the values of the named query-string parameter, or null if it has no values.</summary>
+        /// <remarks>The returned collection, if not null, can be mutated to change the set of values.</remarks>
+        public List<string> GetQueryValues(string key)
+        {
+            List<string> values = null;
+            if(query != null) query.TryGetValue(key, out values);
+            return values;
+        }
+
+        /// <summary>Gets the Kubernetes API group to use, or null or empty to use the default, which is the core API group
+        /// unless a <see cref="RawUri(string)"/> is given.
+        /// </summary>
+        public string Group() => _group;
+
+        /// <summary>Sets the Kubernetes API group to use, or null or empty to use the default, which is the core API group
+        /// unless a <see cref="RawUri(string)"/> is given.
+        /// </summary>
+        public KubernetesRequest Group(string group) { _group = NormalizeEmpty(group); return this; }
+
+        /// <summary>Attempts to set the <see cref="Group()"/>, <see cref="Version()"/>, and <see cref="Type()"/> based on an object.</summary>
+        /// <remarks>The method calls <see cref="GVK(Type)"/> with the object's type. Then, if <see cref="IKuberenetesObject.ApiVersion"/>
+        /// is set, it will override <see cref="Group()"/> and <see cref="Version()"/>.
+        /// </remarks>
+        public KubernetesRequest GVK(IKubernetesObject obj)
+        {
+            if(obj == null) throw new ArgumentNullException();
+            GVK(obj.GetType());
+            if(!string.IsNullOrEmpty(obj.ApiVersion)) // if the object has an API version set, use it...
+            {
+                int slash = obj.ApiVersion.IndexOf('/'); // the ApiVersion field is in the form "version" or "group/version"
+                Group(slash >= 0 ? obj.ApiVersion.Substring(0, slash) : null).Version(obj.ApiVersion.Substring(slash+1));
+            }
+            return this;
+        }
+
+        /// <summary>Attempts to set the <see cref="Group()"/>, <see cref="Version()"/>, and <see cref="Type()"/> based on a Kubernetes
+        /// group, version, and kind. The method uses heuristics and may not work in all cases.
+        /// </summary>
+        public KubernetesRequest GVK(string group, string version, string kind) =>
+            Group(!string.IsNullOrEmpty(group) ? group : null).Version(!string.IsNullOrEmpty(version) ? version : null)
+                .Type(KubernetesScheme.GuessPath(kind));
+
+        /// <summary>Attempts to set the <see cref="Group()"/>, <see cref="Version()"/>, and <see cref="Type()"/> based on a type of object,
+        /// such as <see cref="k8s.Models.V1Pod"/>.
+        /// </summary>
+        public KubernetesRequest GVK(Type type)
+        {
+            if(type == null) throw new ArgumentNullException(nameof(type));
+            _scheme.GetGVK(type, out string group, out string version, out string kind, out string path);
+            return Group(NormalizeEmpty(group)).Version(version).Type(path);
+        }
+
+        /// <summary>Attempts to set the <see cref="Group()"/>, <see cref="Version()"/>, and <see cref="Type()"/> based on a type of object,
+        /// such as <see cref="k8s.Models.V1Pod"/>.
+        /// </summary>
+        public KubernetesRequest GVK<T>() => GVK(typeof(T));
+
+        /// <summary>Gets the "labelSelector" query-string parameter, or null if there is no label selector.</summary>
+        public string LabelSelector() => NormalizeEmpty(GetQuery("labelSelector"));
+
+        /// <summary>Sets the "labelSelector" query-string parameter, or removes it if the selecor is null or empty.</summary>
+        public KubernetesRequest LabelSelector(string selector) =>
+            SetQuery("labelSelector", !string.IsNullOrEmpty(selector) ? selector : null);
+
+        /// <summary>Gets the value of the Content-Type header, or null to use the default of application/json.</summary>
+        public string MediaType() => _mediaType;
+
+        /// <summary>Sets the value of the Content-Type header, not including any parameters, or null or empty to use the default
+        /// of application/json. The header value will only be used if a <see cref="Body(object)"/> is supplied.
+        /// </summary>
+        public KubernetesRequest MediaType(string mediaType) { _mediaType = NormalizeEmpty(mediaType); return this; }
+
+        /// <summary>Gets the <see cref="HttpMethod"/> to use.</summary>
+        public HttpMethod Method() => _method ?? HttpMethod.Get;
+
+        /// <summary>Sets the <see cref="HttpMethod"/> to use, or null to use the default of <see cref="HttpMethod.Get"/>.</summary>
+        public KubernetesRequest Method(HttpMethod method) { _method = method; return this; }
+
+        /// <summary>Gets the name of the top-level Kubernetes resource to access.</summary>
+        public string Name() => _name;
+
+        /// <summary>Sets the name of the top-level Kubernetes resource to access, or null or empty to not access a specific object.</summary>
+        public KubernetesRequest Name(string name) { _name = name; return this; }
+
+        /// <summary>Gets the Kubernetes namespace to access.</summary>
+        public string Namespace() => _ns;
+
+        /// <summary>Sets the Kubernetes namespace to access, or null or empty to not access a namespaced object.</summary>
+        public KubernetesRequest Namespace(string ns) { _ns = ns; return this; }
+
+        /// <summary>Gets the raw URL to access, relative to the configured Kubernetes host and not including the query string, or
+        /// null if the URL will be constructed piecemeal based on the other properties.
+        /// </summary>
+        public string RawUri() => _rawUri;
+
+        /// <summary>Sets the raw URL to access, relative to the configured Kubernetes host and not including the query string, or
+        /// null or empty to construct the URI piecemeal based on the other properties.
+        /// </summary>
+        public KubernetesRequest RawUri(string uri)
+        {
+            uri = NormalizeEmpty(uri);
+            if(uri != null && uri[0] != '/') throw new ArgumentException("The URI must begin with a slash.");
+            _rawUri = uri;
+            return this;
+        }
+
+        /// <summary>Performs an atomic get-modify-replace operation, using the GET method to read the object and the PUT method to
+        /// replace it.
+        /// </summary>
+        /// <param name="modify">A function that modifies the resource, returning true if any changes were made and false if not</param>
+        /// <param name="failIfMissing">If true, an exception will be thrown if the object doesn't exist. If false, null will be
+        /// returned in that case.
+        /// </param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the request</param>
+        public Task<T> ReplaceAsync<T>(Func<T,bool> update, bool failIfMissing = false, CancellationToken cancelToken = default)
+            where T : class, IMetadata<V1ObjectMeta> => ReplaceAsync<T>(null, update, failIfMissing, cancelToken);
+
+        /// <summary>Performs an atomic get-modify-replace operation, using the GET method to read the object and the PUT method to
+        /// replace it.
+        /// </summary>
+        /// <param name="modify">A function that modifies the resource, returning true if any changes were made and false if not</param>
+        /// <param name="failIfMissing">If true, an exception will be thrown if the object doesn't exist. If false, null will be
+        /// returned in that case.
+        /// </param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the request</param>
+        public Task<T> ReplaceAsync<T>(
+            Func<T,CancellationToken,Task<bool>> update, bool failIfMissing = false, CancellationToken cancelToken = default)
+            where T : class, IMetadata<V1ObjectMeta> => ReplaceAsync<T>(null, update, failIfMissing, cancelToken);
+
+        /// <summary>Performs an atomic get-modify-replace operation, using the GET method to read the object and the PUT method to
+        /// replace it.
+        /// </summary>
+        /// <param name="obj">The initial value of the resource, or null if it should be retrieved with a GET request</param>
+        /// <param name="modify">A function that modifies the resource, returning true if any changes were made and false if not</param>
+        /// <param name="failIfMissing">If true, an exception will be thrown if the object doesn't exist. If false, null will be
+        /// returned in that case.
+        /// </param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the request</param>
+        public Task<T> ReplaceAsync<T>(T obj, Func<T,bool> modify, bool failIfMissing = false, CancellationToken cancelToken = default)
+            where T : class
+        {
+            if(modify == null) throw new ArgumentNullException(nameof(modify));
+            return ReplaceAsync(obj, (o,ct) => Task.FromResult(modify(o)), failIfMissing, cancelToken);
+        }
+
+        /// <summary>Performs an atomic get-modify-replace operation, using the GET method to read the object and the PUT method to
+        /// replace it.
+        /// </summary>
+        /// <param name="obj">The initial value of the resource, or null if it should be retrieved with a GET request</param>
+        /// <param name="modify">A function that modifies the resource, returning true if any changes were made and false if not</param>
+        /// <param name="failIfMissing">If true, an exception will be thrown if the object doesn't exist. If false, null will be
+        /// returned in that case.
+        /// </param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the request</param>
+        public async Task<T> ReplaceAsync<T>(
+            T obj, Func<T,CancellationToken,Task<bool>> modify, bool failIfMissing = false, CancellationToken cancelToken = default)
+            where T : class
+        {
+            if(modify == null) throw new ArgumentNullException(nameof(modify));
+            if(_watchVersion != null) throw new InvalidOperationException("Watches cannot be updated.");
+            while(true)
+            {
+                if(obj == null) // if we need to load the resource...
+                {
+                    cancelToken.ThrowIfCancellationRequested();
+                    HttpRequestMessage getMsg = CreateRequestMessage(); // load it with a GET request
+                    getMsg.Method = HttpMethod.Get;
+                    obj = await ExecuteMessageAsync<T>(getMsg, failIfMissing, cancelToken).ConfigureAwait(false);
+                }
+                cancelToken.ThrowIfCancellationRequested();
+                // if the resource is missing or no changes are needed, return it as-is
+                if(obj == null || !await modify(obj, cancelToken).ConfigureAwait(false)) return obj;
+                HttpRequestMessage updateMsg = CreateRequestMessage(); // otherwise, update it with a PUT request
+                updateMsg.Method = HttpMethod.Put;
+                KubernetesResponse resp = new KubernetesResponse(await client.SendAsync(updateMsg, cancelToken).ConfigureAwait(false));
+                if(resp.StatusCode != HttpStatusCode.Conflict) // if there was no conflict, return the result
+                {
+                    if(resp.IsNotFound && !failIfMissing) return null;
+                    else if(resp.IsError) throw new KubernetesException(await resp.GetErrorAsync().ConfigureAwait(false));
+                    else return await resp.GetBodyAsync<T>().ConfigureAwait(false);
+                }
+                obj = null; // otherwise, there was a conflict, so reload the item
+            }
+        }
+
+        /// <summary>Gets the <see cref="KubernetesScheme"/> used to map types to their Kubernetes groups, version, and kinds.</summary>
+        public KubernetesScheme Scheme() => _scheme;
+
+        /// <summary>Sets the <see cref="KubernetesScheme"/> used to map types to their Kubernetes groups, version, and kinds, or null to
+        /// use the <see cref="KubernetesScheme.Default"/> scheme.
+        /// </summary>
+        public KubernetesRequest Scheme(KubernetesScheme scheme) { _scheme = scheme ?? KubernetesScheme.Default; return this; }
+
+        /// <summary>Attempts to set the <see cref="Group()"/>, <see cref="Version()"/>, <see cref="Type()"/>, <see cref="Namespace()"/>,
+        /// <see cref="Name()"/>, and optionally the <see cref="Body()"/> based on the given object.
+        /// </summary>
+        /// <remarks>If the object implements <see cref="IMetadata{T}"/> of <see cref="V1ObjectMeta"/>, it will be used to set the
+        /// <see cref="Name()"/> and <see cref="Namespace()"/>. The <see cref="Name()"/> will be set if <see cref="V1ObjectMeta.Uid"/>
+        /// is set (on the assumption that you're accessing an existing object), and cleared it's clear (on the assumption that you're
+        /// creating a new object and want to POST to its container).
+        /// </remarks>
+        public KubernetesRequest Set(IKubernetesObject obj, bool setBody = true)
+        {
+            GVK(obj);
+            if(setBody) Body(obj);
+            var kobj = obj as IMetadata<V1ObjectMeta>;
+            if(kobj != null) Namespace(kobj.Namespace()).Name(!string.IsNullOrEmpty(kobj.Uid()) ? kobj.Name() : null);
+            return this;
+        }
+
+        /// <summary>Sets a custom header value, or deletes it if the value is null.</summary>
+        public KubernetesRequest SetHeader(string headerName, string value)
+        {
+            if(headerName == "Accept" || headerName == "Content-Type")
+            {
+                throw new ArgumentException("The header must be set using the corresponding property.");
+            }
+            return Set(ref headers, headerName, value);
+        }
+
+        /// <summary>Sets a query-string value, or deletes it if the value is null.</summary>
+        public KubernetesRequest SetQuery(string key, string value) => Set(ref query, key, value);
+
+        /// <summary>Sets the <see cref="Subresource()"/> to "status", to get or set a resource's status.</summary>
+        public KubernetesRequest Status() => Subresource("status");
+
+        /// <summary>Gets whether the response must be streamed. If true, the response will be returned from <see cref="Execute"/>
+        /// as soon as the headers are read and you will have to dispose the response. Otherwise, the entire response will be downloaded
+        /// before <see cref="Execute"/> returns, and you will not have to dispose it. Note that regardless of the
+        /// value of this property, the response is always streamed when <see cref="WatchVersion()"/> is not null.
+        /// </summary>
+        public bool StreamResponse() => _streamResponse;
+
+        /// <summary>Sets whether the response must be streamed. If true, the response will be returned from <see cref="Execute"/>
+        /// as soon as the headers are read and you will have to dispose the response. Otherwise, the entire response will be downloaded
+        /// before <see cref="Execute"/> returns, and you will not have to dispose it. The default is false. Note that regardless of the
+        /// value of this property, the response is always streamed when <see cref="WatchVersion()"/> is not null.
+        /// </summary>
+        public KubernetesRequest StreamResponse(bool stream) { _streamResponse = stream; return this; }
+
+        /// <summary>Gets the URL-encoded subresource to access, or null to not access a subresource.</summary>
+        public string Subresource() => _subresource;
+
+        /// <summary>Sets the subresource to access, or null or empty to not access a subresource. The value must be URL-encoded
+        /// already if necessary.
+        /// </summary>
+        public KubernetesRequest Subresource(string subresource) { _subresource = NormalizeEmpty(subresource); return this; }
+
+        /// <summary>Sets the value of the <see cref="Subresource(string)"/> by joining together one or more path segments. The
+        /// segments will be URL-escaped (and so should not be URL-escaped already).
+        /// </summary>
+        public KubernetesRequest Subresources(params string[] subresources) =>
+            Subresource(subresources != null && subresources.Length != 0 ?
+                string.Join("/", subresources.Select(Uri.EscapeDataString)) : null);
+
+        /// <inheritdoc/>
+        public override string ToString() => Method().Method + " " + GetRequestUri();
+
+        /// <summary>Gets the resource type access (e.g. "pods").</summary>
+        public string Type() => _type;
+
+        /// <summary>Sets the resource type access (e.g. "pods").</summary>
+        public KubernetesRequest Type(string type) { _type = NormalizeEmpty(type); return this; }
+
+        /// <summary>Gets the Kubernetes API version to use, or null to use the default, which is "v1"
+        /// unless a <see cref="RawUri()"/> is given.
+        /// </summary>
+        public string Version() => _version;
+
+        /// <summary>Sets the Kubernetes API version to use, or null or empty to use the default, which is "v1"
+        /// unless a <see cref="RawUri()"/> is given.
+        /// </summary>
+        public KubernetesRequest Version(string version) { _version = NormalizeEmpty(version); return this; }
+
+        /// <summary>Gets the resource version to use when watching a resource, or empty to watch the current version, or null
+        /// to not execute a watch.
+        /// </summary>
+        public string WatchVersion() => _watchVersion;
+
+        /// <summary>Sets the resource version to use when watching a resource, or empty to watch the current version, or null to not
+        /// execute a watch. The default is null. When set, the response is always streamed (as though <see cref="StreamResponse()"/>
+        /// was true).
+        /// </summary>
+        public KubernetesRequest WatchVersion(string resourceVersion) { _watchVersion = resourceVersion; return this; }
+
+        /// <summary>Adds a value to the query string or headers.</summary>
+        KubernetesRequest Add(ref Dictionary<string,List<string>> dict, string key, string value)
+        {
+            if(string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+            if(dict == null) dict = new Dictionary<string, List<string>>();
+            if(!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
+            values.Add(value);
+            return this;
+        }
+
+        /// <summary>Sets a value in the query string or headers.</summary>
+        KubernetesRequest Set(ref Dictionary<string,List<string>> dict, string key, string value)
+        {
+            if(string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+            dict = dict ?? new Dictionary<string, List<string>>();
+            if(!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
+            values.Clear();
+            values.Add(value);
+            return this;
+        }
+
+        /// <summary>Creates an <see cref="HttpRequestMessage"/> representing the current request.</summary>
+        HttpRequestMessage CreateRequestMessage()
+        {
+            var req = new HttpRequestMessage(Method(), GetRequestUri());
+
+            // add the headers
+            if(!string.IsNullOrEmpty(config.AccessToken))
+            {
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", config.AccessToken);
+            }
+            else if(!string.IsNullOrEmpty(config.Username))
+            {
+                req.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+                    Convert.ToBase64String(Encoding.UTF8.GetBytes(config.Username + ":" + config.Password)));
+            }
+
+            if(_accept != null) req.Headers.Add("Accept", _accept);
+            List<KeyValuePair<string,List<string>>> contentHeaders = null;
+            if(headers != null && headers.Count != 0) // add custom headers
+            {
+                contentHeaders = new List<KeyValuePair<string,List<string>>>(); // some headers must be added to .Content.Headers. track them
+                foreach(KeyValuePair<string,List<string>> pair in headers)
+                {
+                    if(!req.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if it's not legal to set this header on the request...
+                    {
+                        contentHeaders.Add(new KeyValuePair<string,List<string>>(pair.Key, pair.Value)); // assume we should set it on the content
+                        break;
+                    }
+                }
+            }
+
+            // add the body, if any
+            if(_body != null)
+            {
+                if(_body is byte[] bytes) req.Content = new ByteArrayContent(bytes);
+                else if(_body is Stream stream) req.Content = new StreamContent(stream);
+                else
+                {
+                    req.Content = new StringContent(
+                        _body as string ?? JsonConvert.SerializeObject(_body, Kubernetes.DefaultJsonSettings), Encoding.UTF8);
+                }
+                req.Content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType ?? "application/json") { CharSet = "UTF-8" };
+                if(contentHeaders != null && contentHeaders.Count != 0) // go through the headers we couldn't set on the request
+                {
+                    foreach(KeyValuePair<string,List<string>> pair in contentHeaders)
+                    {
+                        if(!req.Content.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if we can't set it on the content either...
+                        {
+                            throw new InvalidOperationException($"{pair.Value} is a response header and cannot be set on the request.");
+                        }
+                    }
+                }
+            }
+            return req;
+        }
+
+        async Task<T> ExecuteMessageAsync<T>(HttpRequestMessage msg, bool failIfMissing, CancellationToken cancelToken)
+        {
+            cancelToken.ThrowIfCancellationRequested();
+            KubernetesResponse resp = new KubernetesResponse(await client.SendAsync(msg, cancelToken).ConfigureAwait(false));
+            if(resp.IsNotFound && !failIfMissing) return default(T);
+            else if(resp.IsError) throw new KubernetesException(await resp.GetErrorAsync().ConfigureAwait(false));
+            else return await resp.GetBodyAsync<T>().ConfigureAwait(false);
+        }
+
+        string GetRequestUri()
+        {
+            if(_rawUri != null && (_group ?? _name ?? _ns ?? _subresource ?? _type ?? _version) != null)
+            {
+                throw new InvalidOperationException("You cannot use both raw and piecemeal URIs.");
+            }
+
+            // construct the request URL
+            var sb = new StringBuilder();
+            sb.Append(config.Host);
+            if(sb[sb.Length-1] != '/') sb.Append('/');
+            if(_rawUri != null) // if a raw URL was given, use it
+            {
+                sb.Append(_rawUri);
+            }
+            else // otherwise, construct it piecemeal
+            {
+                if(_group != null) sb.Append("apis/").Append(_group);
+                else sb.Append("api");
+                sb.Append('/').Append(_version ?? "v1");
+                if(_ns != null) sb.Append("/namespaces/").Append(_ns);
+                sb.Append('/').Append(_type);
+                if(_name != null) sb.Append('/').Append(_name);
+                if(_subresource != null) sb.Append('/').Append(_subresource);
+            }
+            if(query != null) // then add the query string, if any
+            {
+                bool first = true;
+                foreach(KeyValuePair<string,List<string>> pair in query)
+                {
+                    string key = Uri.EscapeDataString(pair.Key);
+                    foreach(string value in pair.Value)
+                    {
+                        sb.Append(first ? '?' : '&').Append(key).Append('=');
+                        if(!string.IsNullOrEmpty(value)) sb.Append(Uri.EscapeDataString(value));
+                        first = false;
+                    }
+                }
+                if(_watchVersion != null)
+                {
+                    sb.Append(first ? '?' : '&').Append("watch=1");
+                    if(_watchVersion.Length != 0) sb.Append("&resourceVersion=").Append(_watchVersion);
+                }
+            }
+            return sb.ToString();
+        }
+
+        object ICloneable.Clone() => Clone();
+
+        readonly HttpClient client;
+        readonly KubernetesClientConfiguration config;
+        Dictionary<string, List<string>> headers, query;
+        string _accept = "application/json", _mediaType = "application/json";
+        string _group, _name, _ns, _rawUri, _subresource, _type, _version, _watchVersion;
+        object _body;
+        HttpMethod _method;
+        KubernetesScheme _scheme;
+        bool _streamResponse;
+
+        static string NormalizeEmpty(string value) => string.IsNullOrEmpty(value) ? null : value; // normalizes empty strings to null
+    }
+    #endregion
+
+    #region KubernetesResponse
+    /// <summary>Represents a response to a <see cref="KubernetesRequest"/>.</summary>
+    public sealed class KubernetesResponse : IDisposable
+    {
+        /// <summary>Initializes a new <see cref="KubernetesResponse"/> from an <see cref="HttpResponseMessage"/>.</summary>
+        public KubernetesResponse(HttpResponseMessage message) => Message = message ?? throw new ArgumentNullException(nameof(message));
+
+        /// <summary>Indicates whether the server returned an error response.</summary>
+        public bool IsError => (int)StatusCode >= 400;
+
+        /// <summary>Indicates whether the server returned a 404 Not Found response.</summary>
+        public bool IsNotFound => StatusCode == HttpStatusCode.NotFound;
+
+        /// <summary>Gets the underlying <see cref="HttpResponseMessage"/>.</summary>
+        public HttpResponseMessage Message { get; }
+
+        /// <summary>Gets the <see cref="HttpStatusCode"/> of the response.</summary>
+        public HttpStatusCode StatusCode => Message.StatusCode;
+
+        /// <inheritdoc/>
+        public void Dispose() => Message.Dispose();
+
+        /// <summary>Deserializes the response body as a <see cref="V1Status"/> object, or creates one from the status code if the
+        /// response body is not a JSON object.
+        /// </summary>
+        public async Task<V1Status> GetErrorAsync()
+        {
+            try { return await GetBodyAsync<V1Status>().ConfigureAwait(false); }
+            catch(JsonException) { }
+            return new V1Status()
+            {
+                Status = IsError ? "Failure" : "Success", Code = (int)StatusCode, Reason = StatusCode.ToString(), Message = body
+            };
+        }
+
+        /// <summary>Returns the response body as a string.</summary>
+        public async Task<string> GetBodyAsync()
+        {
+            if(body == null)
+            {
+                body = Message.Content != null ? await Message.Content.ReadAsStringAsync().ConfigureAwait(false) : string.Empty;
+            }
+            return body;
+        }
+
+        /// <summary>Deserializes the response body from JSON as a value of the given type, or null if the response body is empty.</summary>
+        /// <param name="type">The type of object to return</param>
+        /// <param name="failIfEmpty">If false, an empty response body will be returned as null. If true, an exception will be thrown if
+        /// the body is empty. The default is false.
+        /// </param>
+        public async Task<object> GetBodyAsync(Type type, bool failIfEmpty = false)
+        {
+            string body = await GetBodyAsync().ConfigureAwait(false);
+            if(string.IsNullOrWhiteSpace(body))
+            {
+                if(!failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                return null;
+            }
+            return JsonConvert.DeserializeObject(body, type, Kubernetes.DefaultJsonSettings);
+        }
+
+        /// <summary>Deserializes the response body from JSON as a value of type <typeparamref name="T"/>, or the default value of
+        /// type <typeparamref name="T"/> if the response body is empty.
+        /// </summary>
+        /// <param name="failIfEmpty">If false, an empty response body will be returned as the default value of type
+        /// <typeparamref name="T"/>. If true, an exception will be thrown if the body is empty. The default is false.
+        /// </param>
+        public async Task<T> GetBodyAsync<T>(bool failIfEmpty = false)
+        {
+            string body = await GetBodyAsync().ConfigureAwait(false);
+            if(string.IsNullOrWhiteSpace(body))
+            {
+                if(failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                return default(T);
+            }
+            return JsonConvert.DeserializeObject<T>(body, Kubernetes.DefaultJsonSettings);
+        }
+
+        string body;
+    }
+    #endregion
+}

--- a/src/KubernetesClient/KubernetesRequest.cs
+++ b/src/KubernetesClient/KubernetesRequest.cs
@@ -21,7 +21,7 @@ namespace k8s
         /// <summary>Initializes a <see cref="KubernetesRequest"/> based on a <see cref="KubernetesClient"/>.</summary>
         public KubernetesRequest(Kubernetes client)
         {
-            if(client == null) throw new ArgumentNullException(nameof(client));
+            if (client == null) throw new ArgumentNullException(nameof(client));
             (baseUri, credentials, this.client) = (client.BaseUri.ToString(), client.Credentials, client.HttpClient);
             Scheme(client.Scheme);
         }
@@ -39,9 +39,9 @@ namespace k8s
         /// <remarks>Any necessary SSL configuration must have already been applied to the <paramref name="client"/>.</remarks>
         public KubernetesRequest(KubernetesClientConfiguration config, HttpClient client = null, KubernetesScheme scheme = null)
         {
-            if(config == null) throw new ArgumentNullException(nameof(config));
+            if (config == null) throw new ArgumentNullException(nameof(config));
             this.baseUri = config.Host;
-            if(string.IsNullOrEmpty(this.baseUri)) throw new ArgumentException(nameof(config)+".Host");
+            if (string.IsNullOrEmpty(this.baseUri)) throw new ArgumentException(nameof(config)+".Host");
             credentials = Kubernetes.CreateCredentials(config);
             this.client = client ?? new HttpClient();
             Scheme(scheme);
@@ -61,8 +61,8 @@ namespace k8s
         /// <remarks>Any necessary SSL configuration must have already been applied to the <paramref name="client"/>.</remarks>
         public KubernetesRequest(Uri baseUri, ServiceClientCredentials credentials = null, HttpClient client = null, KubernetesScheme scheme = null)
         {
-            if(baseUri == null) throw new ArgumentNullException(nameof(baseUri));
-            if(!baseUri.IsAbsoluteUri) throw new ArgumentException("The base URI must be absolute.", nameof(baseUri));
+            if (baseUri == null) throw new ArgumentNullException(nameof(baseUri));
+            if (!baseUri.IsAbsoluteUri) throw new ArgumentException("The base URI must be absolute.", nameof(baseUri));
             (this.baseUri, this.credentials, this.client) = (baseUri.ToString(), credentials, client = client ?? new HttpClient());
             Scheme(scheme);
         }
@@ -102,31 +102,31 @@ namespace k8s
         /// <summary>Clears custom header values with the given name.</summary>
         public KubernetesRequest ClearHeader(string headerName)
         {
-            if(headerName == null) throw new ArgumentNullException(nameof(headerName));
+            if (headerName == null) throw new ArgumentNullException(nameof(headerName));
             CheckHeaderName(headerName);
-            if(headers != null) headers.Remove(headerName);
+            if (headers != null) headers.Remove(headerName);
             return this;
         }
 
         /// <summary>Clears all custom header values.</summary>
         public KubernetesRequest ClearHeaders()
         {
-            if(headers != null) headers.Clear();
+            if (headers != null) headers.Clear();
             return this;
         }
 
         /// <summary>Clears all query-string parameters.</summary>
         public KubernetesRequest ClearQuery()
         {
-            if(query != null) query.Clear();
+            if (query != null) query.Clear();
             return this;
         }
 
         /// <summary>Clears all query-string parameters with the given key.</summary>
         public KubernetesRequest ClearQuery(string key)
         {
-            if(key == null) throw new ArgumentNullException(nameof(key));
-            if(query != null) query.Remove(key);
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (query != null) query.Remove(key);
             return this;
         }
 
@@ -134,15 +134,15 @@ namespace k8s
         public KubernetesRequest Clone()
         {
             var clone = (KubernetesRequest)MemberwiseClone();
-            if(headers != null)
+            if (headers != null)
             {
                 clone.headers = new Dictionary<string, List<string>>(headers.Count);
-                foreach(KeyValuePair<string, List<string>> pair in headers) clone.headers.Add(pair.Key, new List<string>(pair.Value));
+                foreach (KeyValuePair<string, List<string>> pair in headers) clone.headers.Add(pair.Key, new List<string>(pair.Value));
             }
-            if(query != null)
+            if (query != null)
             {
                 clone.query = new Dictionary<string, List<string>>(query.Count);
-                foreach(KeyValuePair<string, List<string>> pair in query) clone.query.Add(pair.Key, new List<string>(pair.Value));
+                foreach (KeyValuePair<string, List<string>> pair in query) clone.query.Add(pair.Key, new List<string>(pair.Value));
             }
             return clone;
         }
@@ -195,7 +195,7 @@ namespace k8s
         /// <exception cref="KubernetesException">Thrown if the response was any error besides 404 Not Found.</exception>
         public async Task<T> ExecuteAsync<T>(bool failIfMissing, CancellationToken cancelToken = default)
         {
-            if(_watchVersion != null) throw new InvalidOperationException("Watch requests cannot be deserialized all at once.");
+            if (_watchVersion != null) throw new InvalidOperationException("Watch requests cannot be deserialized all at once.");
             cancelToken.ThrowIfCancellationRequested();
             HttpRequestMessage reqMsg = await CreateRequestMessage(cancelToken).ConfigureAwait(false);
             return await ExecuteMessageAsync<T>(reqMsg, failIfMissing, cancelToken).ConfigureAwait(false);
@@ -220,7 +220,7 @@ namespace k8s
         public string GetHeader(string key)
         {
             List<string> values = null;
-            if(headers != null) headers.TryGetValue(key, out values);
+            if (headers != null) headers.TryGetValue(key, out values);
             return values == null || values.Count == 0 ? null : values.Count == 1 ? values[0] :
                 throw new InvalidOperationException($"There are multiple query-string parameters named '{key}'.");
         }
@@ -230,7 +230,7 @@ namespace k8s
         public List<string> GetHeaderValues(string key)
         {
             List<string> values = null;
-            if(headers != null) headers.TryGetValue(key, out values);
+            if (headers != null) headers.TryGetValue(key, out values);
             return values;
         }
 
@@ -248,7 +248,7 @@ namespace k8s
         public List<string> GetQueryValues(string key)
         {
             List<string> values = null;
-            if(query != null) query.TryGetValue(key, out values);
+            if (query != null) query.TryGetValue(key, out values);
             return values;
         }
 
@@ -268,9 +268,9 @@ namespace k8s
         /// </remarks>
         public KubernetesRequest GVK(IKubernetesObject obj)
         {
-            if(obj == null) throw new ArgumentNullException();
+            if (obj == null) throw new ArgumentNullException();
             GVK(obj.GetType());
-            if(!string.IsNullOrEmpty(obj.ApiVersion)) // if the object has an API version set, use it...
+            if (!string.IsNullOrEmpty(obj.ApiVersion)) // if the object has an API version set, use it...
             {
                 int slash = obj.ApiVersion.IndexOf('/'); // the ApiVersion field is in the form "version" or "group/version"
                 Group(slash >= 0 ? obj.ApiVersion.Substring(0, slash) : null).Version(obj.ApiVersion.Substring(slash+1));
@@ -290,7 +290,7 @@ namespace k8s
         /// </summary>
         public KubernetesRequest GVK(Type type)
         {
-            if(type == null) throw new ArgumentNullException(nameof(type));
+            if (type == null) throw new ArgumentNullException(nameof(type));
             _scheme.GetGVK(type, out string group, out string version, out string kind, out string path);
             return Group(NormalizeEmpty(group)).Version(version).Type(path);
         }
@@ -344,7 +344,7 @@ namespace k8s
         public KubernetesRequest RawUri(string uri)
         {
             uri = NormalizeEmpty(uri);
-            if(uri != null && uri[0] != '/') throw new ArgumentException("The URI must begin with a slash.");
+            if (uri != null && uri[0] != '/') throw new ArgumentException("The URI must begin with a slash.");
             _rawUri = uri;
             return this;
         }
@@ -384,7 +384,7 @@ namespace k8s
         public Task<T> ReplaceAsync<T>(T obj, Func<T,bool> modify, bool failIfMissing = false, CancellationToken cancelToken = default)
             where T : class
         {
-            if(modify == null) throw new ArgumentNullException(nameof(modify));
+            if (modify == null) throw new ArgumentNullException(nameof(modify));
             return ReplaceAsync(obj, (o,ct) => Task.FromResult(modify(o)), failIfMissing, cancelToken);
         }
 
@@ -401,12 +401,12 @@ namespace k8s
             T obj, Func<T,CancellationToken,Task<bool>> modify, bool failIfMissing = false, CancellationToken cancelToken = default)
             where T : class
         {
-            if(modify == null) throw new ArgumentNullException(nameof(modify));
-            if(_watchVersion != null) throw new InvalidOperationException("Watches cannot be updated.");
+            if (modify == null) throw new ArgumentNullException(nameof(modify));
+            if (_watchVersion != null) throw new InvalidOperationException("Watches cannot be updated.");
             KubernetesRequest putReq = null;
-            while(true)
+            while (true)
             {
-                if(obj == null) // if we need to load the resource...
+                if (obj == null) // if we need to load the resource...
                 {
                     cancelToken.ThrowIfCancellationRequested();
                     HttpRequestMessage getMsg = await CreateRequestMessage(cancelToken).ConfigureAwait(false); // load it with a GET request
@@ -415,13 +415,13 @@ namespace k8s
                 }
                 cancelToken.ThrowIfCancellationRequested();
                 // if the resource is missing or no changes are needed, return it as-is
-                if(obj == null || !await modify(obj, cancelToken).ConfigureAwait(false)) return obj;
-                if(putReq == null) putReq = Clone().Put();
+                if (obj == null || !await modify(obj, cancelToken).ConfigureAwait(false)) return obj;
+                if (putReq == null) putReq = Clone().Put();
                 KubernetesResponse resp = await putReq.Body(obj).ExecuteAsync(cancelToken).ConfigureAwait(false);  // otherwise, update it
-                if(resp.StatusCode != HttpStatusCode.Conflict) // if there was no conflict, return the result
+                if (resp.StatusCode != HttpStatusCode.Conflict) // if there was no conflict, return the result
                 {
-                    if(resp.IsNotFound && !failIfMissing) return null;
-                    else if(resp.IsError) throw new KubernetesException(await resp.GetStatusAsync().ConfigureAwait(false));
+                    if (resp.IsNotFound && !failIfMissing) return null;
+                    else if (resp.IsError) throw new KubernetesException(await resp.GetStatusAsync().ConfigureAwait(false));
                     else return await resp.GetBodyAsync<T>().ConfigureAwait(false);
                 }
                 obj = null; // otherwise, there was a conflict, so reload the item
@@ -447,9 +447,9 @@ namespace k8s
         public KubernetesRequest Set(IKubernetesObject obj, bool setBody = true)
         {
             GVK(obj);
-            if(setBody) Body(obj);
+            if (setBody) Body(obj);
             var kobj = obj as IMetadata<V1ObjectMeta>;
-            if(kobj != null) Namespace(kobj.Namespace()).Name(!string.IsNullOrEmpty(kobj.Uid()) ? kobj.Name() : null);
+            if (kobj != null) Namespace(kobj.Namespace()).Name(!string.IsNullOrEmpty(kobj.Uid()) ? kobj.Name() : null);
             return this;
         }
 
@@ -524,9 +524,9 @@ namespace k8s
         /// <summary>Adds a value to the query string or headers.</summary>
         KubernetesRequest Add(ref Dictionary<string,List<string>> dict, string key, string value)
         {
-            if(string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
-            if(dict == null) dict = new Dictionary<string, List<string>>();
-            if(!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
+            if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+            if (dict == null) dict = new Dictionary<string, List<string>>();
+            if (!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
             values.Add(value);
             return this;
         }
@@ -534,11 +534,11 @@ namespace k8s
         /// <summary>Adds a value to the query string or headers.</summary>
         KubernetesRequest Add(ref Dictionary<string, List<string>> dict, string key, IEnumerable<string> values)
         {
-            if(string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
-            if(values != null)
+            if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+            if (values != null)
             {
-                if(dict == null) dict = new Dictionary<string, List<string>>();
-                if(!dict.TryGetValue(key, out List<string> list)) dict[key] = list = new List<string>();
+                if (dict == null) dict = new Dictionary<string, List<string>>();
+                if (!dict.TryGetValue(key, out List<string> list)) dict[key] = list = new List<string>();
                 list.AddRange(values);
             }
             return this;
@@ -547,9 +547,9 @@ namespace k8s
         /// <summary>Sets a value in the query string or headers.</summary>
         KubernetesRequest Set(ref Dictionary<string,List<string>> dict, string key, string value)
         {
-            if(string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
+            if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
             dict = dict ?? new Dictionary<string, List<string>>();
-            if(!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
+            if (!dict.TryGetValue(key, out List<string> values)) dict[key] = values = new List<string>();
             values.Clear();
             values.Add(value);
             return this;
@@ -563,17 +563,17 @@ namespace k8s
 #endif
         {
             var req = new HttpRequestMessage(Method(), GetRequestUri());
-            if(credentials != null) await credentials.ProcessHttpRequestAsync(req, cancelToken).ConfigureAwait(false);
+            if (credentials != null) await credentials.ProcessHttpRequestAsync(req, cancelToken).ConfigureAwait(false);
 
             // add the headers
-            if(_accept != null) req.Headers.Add("Accept", _accept);
+            if (_accept != null) req.Headers.Add("Accept", _accept);
             List<KeyValuePair<string,List<string>>> contentHeaders = null;
-            if(headers != null && headers.Count != 0) // add custom headers
+            if (headers != null && headers.Count != 0) // add custom headers
             {
                 contentHeaders = new List<KeyValuePair<string,List<string>>>(); // some headers must be added to .Content.Headers. track them
-                foreach(KeyValuePair<string,List<string>> pair in headers)
+                foreach (KeyValuePair<string,List<string>> pair in headers)
                 {
-                    if(!req.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if it's not legal to set this header on the request...
+                    if (!req.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if it's not legal to set this header on the request...
                     {
                         contentHeaders.Add(new KeyValuePair<string,List<string>>(pair.Key, pair.Value)); // assume we should set it on the content
                         break;
@@ -582,21 +582,21 @@ namespace k8s
             }
 
             // add the body, if any
-            if(_body != null)
+            if (_body != null)
             {
-                if(_body is byte[] bytes) req.Content = new ByteArrayContent(bytes);
-                else if(_body is Stream stream) req.Content = new StreamContent(stream);
+                if (_body is byte[] bytes) req.Content = new ByteArrayContent(bytes);
+                else if (_body is Stream stream) req.Content = new StreamContent(stream);
                 else
                 {
                     req.Content = new StringContent(
                         _body as string ?? JsonConvert.SerializeObject(_body, Kubernetes.DefaultJsonSettings), Encoding.UTF8);
                 }
                 req.Content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType ?? "application/json") { CharSet = "UTF-8" };
-                if(contentHeaders != null && contentHeaders.Count != 0) // go through the headers we couldn't set on the request
+                if (contentHeaders != null && contentHeaders.Count != 0) // go through the headers we couldn't set on the request
                 {
-                    foreach(KeyValuePair<string, List<string>> pair in contentHeaders)
+                    foreach (KeyValuePair<string, List<string>> pair in contentHeaders)
                     {
-                        if(!req.Content.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if we can't set it on the content either...
+                        if (!req.Content.Headers.TryAddWithoutValidation(pair.Key, pair.Value)) // if we can't set it on the content either...
                         {
                             throw new InvalidOperationException($"{pair.Value} is a response header and cannot be set on the request.");
                         }
@@ -610,14 +610,14 @@ namespace k8s
         {
             cancelToken.ThrowIfCancellationRequested();
             KubernetesResponse resp = new KubernetesResponse(await client.SendAsync(msg, cancelToken).ConfigureAwait(false));
-            if(resp.IsNotFound && !failIfMissing) return default(T);
-            else if(resp.IsError) throw new KubernetesException(await resp.GetStatusAsync().ConfigureAwait(false));
+            if (resp.IsNotFound && !failIfMissing) return default(T);
+            else if (resp.IsError) throw new KubernetesException(await resp.GetStatusAsync().ConfigureAwait(false));
             else return await resp.GetBodyAsync<T>().ConfigureAwait(false);
         }
 
         string GetRequestUri()
         {
-            if(_rawUri != null && (_group ?? _name ?? _ns ?? _subresource ?? _type ?? _version) != null)
+            if (_rawUri != null && (_group ?? _name ?? _ns ?? _subresource ?? _type ?? _version) != null)
             {
                 throw new InvalidOperationException("You cannot use both raw and piecemeal URIs.");
             }
@@ -625,40 +625,40 @@ namespace k8s
             // construct the request URL
             var sb = new StringBuilder();
             sb.Append(baseUri);
-            if(_rawUri != null) // if a raw URL was given, use it
+            if (_rawUri != null) // if a raw URL was given, use it
             {
-                if(sb[sb.Length-1] == '/') sb.Length--; // the raw URI starts with a slash, so ensure the base URI doesn't end with one
+                if (sb[sb.Length-1] == '/') sb.Length--; // the raw URI starts with a slash, so ensure the base URI doesn't end with one
                 sb.Append(_rawUri);
             }
             else // otherwise, construct it piecemeal
             {
-                if(sb[sb.Length-1] != '/') sb.Append('/'); // ensure the base URI ends with a slash
-                if(_group != null) sb.Append("apis/").Append(_group);
+                if (sb[sb.Length-1] != '/') sb.Append('/'); // ensure the base URI ends with a slash
+                if (_group != null) sb.Append("apis/").Append(_group);
                 else sb.Append("api");
                 sb.Append('/').Append(_version ?? "v1");
-                if(_ns != null) sb.Append("/namespaces/").Append(_ns);
+                if (_ns != null) sb.Append("/namespaces/").Append(_ns);
                 sb.Append('/').Append(_type);
-                if(_name != null) sb.Append('/').Append(_name);
-                if(_subresource != null) sb.Append('/').Append(_subresource);
+                if (_name != null) sb.Append('/').Append(_name);
+                if (_subresource != null) sb.Append('/').Append(_subresource);
             }
             bool firstParam = true;
-            if(query != null) // then add the query string, if any
+            if (query != null) // then add the query string, if any
             {
-                foreach(KeyValuePair<string,List<string>> pair in query)
+                foreach (KeyValuePair<string,List<string>> pair in query)
                 {
                     string key = Uri.EscapeDataString(pair.Key);
-                    foreach(string value in pair.Value)
+                    foreach (string value in pair.Value)
                     {
                         sb.Append(firstParam ? '?' : '&').Append(key).Append('=');
-                        if(!string.IsNullOrEmpty(value)) sb.Append(Uri.EscapeDataString(value));
+                        if (!string.IsNullOrEmpty(value)) sb.Append(Uri.EscapeDataString(value));
                         firstParam = false;
                     }
                 }
             }
-            if(_watchVersion != null)
+            if (_watchVersion != null)
             {
                 sb.Append(firstParam ? '?' : '&').Append("watch=1");
-                if(_watchVersion.Length != 0) sb.Append("&resourceVersion=").Append(_watchVersion);
+                if (_watchVersion.Length != 0) sb.Append("&resourceVersion=").Append(_watchVersion);
             }
             return sb.ToString();
         }
@@ -678,7 +678,7 @@ namespace k8s
 
         static string CheckHeaderName(string name)
         {
-            if(name == "Accept" || name == "Content-Type")
+            if (name == "Accept" || name == "Content-Type")
             {
                 throw new ArgumentException($"The {name} header must be set using the corresponding property.");
             }
@@ -714,7 +714,7 @@ namespace k8s
         /// <summary>Returns the response body as a string.</summary>
         public async Task<string> GetBodyAsync()
         {
-            if(body == null)
+            if (body == null)
             {
                 body = Message.Content != null ? await Message.Content.ReadAsStringAsync().ConfigureAwait(false) : string.Empty;
             }
@@ -729,9 +729,9 @@ namespace k8s
         public async Task<object> GetBodyAsync(Type type, bool failIfEmpty = false)
         {
             string body = await GetBodyAsync().ConfigureAwait(false);
-            if(string.IsNullOrWhiteSpace(body))
+            if (string.IsNullOrWhiteSpace(body))
             {
-                if(!failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                if (!failIfEmpty) throw new InvalidOperationException("The response body was empty.");
                 return null;
             }
             return JsonConvert.DeserializeObject(body, type, Kubernetes.DefaultJsonSettings);
@@ -746,9 +746,9 @@ namespace k8s
         public async Task<T> GetBodyAsync<T>(bool failIfEmpty = false)
         {
             string body = await GetBodyAsync().ConfigureAwait(false);
-            if(string.IsNullOrWhiteSpace(body))
+            if (string.IsNullOrWhiteSpace(body))
             {
-                if(failIfEmpty) throw new InvalidOperationException("The response body was empty.");
+                if (failIfEmpty) throw new InvalidOperationException("The response body was empty.");
                 return default(T);
             }
             return JsonConvert.DeserializeObject<T>(body, Kubernetes.DefaultJsonSettings);
@@ -762,9 +762,9 @@ namespace k8s
             try
             {
                 var status = await GetBodyAsync<V1Status>().ConfigureAwait(false);
-                if(status != null && (status.Status == "Success" || status.Status == "Failure")) return status;
+                if (status != null && (status.Status == "Success" || status.Status == "Failure")) return status;
             }
-            catch(JsonException) { }
+            catch (JsonException) { }
             return new V1Status()
             {
                 Status = IsError ? "Failure" : "Success", Code = (int)StatusCode, Reason = StatusCode.ToString(), Message = body

--- a/src/KubernetesClient/KubernetesRequest.cs
+++ b/src/KubernetesClient/KubernetesRequest.cs
@@ -285,6 +285,17 @@ namespace k8s
         /// <summary>Sets the Kubernetes namespace to access, or null or empty to not access a namespaced object.</summary>
         public KubernetesRequest Namespace(string ns) { _ns = ns; return this; }
 
+        /// <summary>Gets whether to use the old-style Kubernetes watch (e.g. /api/v1/watch/...) rather than the new-style watch.</summary>
+        public bool OldStyleWatch() => _oldStyleWatch;
+
+        /// <summary>Sets whether to use the old-style Kubernetes watch (e.g. /api/v1/watch/...) rather than the new-style watch.</summary>
+        /// <remarks>If set to false (the default), Kubernetes requires you to use a list request combined with a field selector to watch
+        /// a single item. If set to true, you can watch an item with a GET request to the specific item. If used with the the
+        /// <see cref="Watch{T}"/> class, it's generally not necessary to set this property because the watch class will usually apply a
+        /// suitable default.
+        /// </remarks>
+        public KubernetesRequest OldStyleWatch(bool value) { _oldStyleWatch = value; return this; }
+
         /// <summary>Gets the raw URL to access, relative to the configured Kubernetes host and not including the query string, or
         /// null if the URL will be constructed piecemeal based on the other properties.
         /// </summary>
@@ -597,7 +608,8 @@ namespace k8s
                 if(_group != null) sb.Append("apis/").Append(_group);
                 else sb.Append("api");
                 sb.Append('/').Append(_version ?? "v1");
-                if(_ns != null) sb.Append("/namespaces/").Append(_ns);
+                if (_oldStyleWatch) sb.Append("/watch");
+                if (_ns != null) sb.Append("/namespaces/").Append(_ns);
                 sb.Append('/').Append(_type);
                 if(_name != null) sb.Append('/').Append(_name);
                 if(_subresource != null) sb.Append('/').Append(_subresource);
@@ -634,7 +646,7 @@ namespace k8s
         object _body;
         HttpMethod _method;
         KubernetesScheme _scheme;
-        bool _streamResponse;
+        bool _oldStyleWatch, _streamResponse;
 
         static string NormalizeEmpty(string value) => string.IsNullOrEmpty(value) ? null : value; // normalizes empty strings to null
     }

--- a/src/KubernetesClient/KubernetesRequest.cs
+++ b/src/KubernetesClient/KubernetesRequest.cs
@@ -453,6 +453,17 @@ namespace k8s
         /// <inheritdoc/>
         public override string ToString() => Method().Method + " " + GetRequestUri();
 
+        /// <summary>Creates a <see cref="Watch{T}"/> that watches for changes to the item or list of items represented by this request.</summary>
+        /// <typeparam name="T">The type of item to watch for changes to</typeparam>
+        /// <param name="initialVersion">The initial version to watch for. This will be used to set the <see cref="WatchVersion(string)"/>
+        /// before creating the watch. If null or empty, the watch will start from the current version. The default is null.
+        /// </param>
+        /// <param name="isListWatch">Indicates whether the request will return a list of possibly multiple items (true) or only a single item
+        /// (false). If null, the default value will be false if <see cref="Name()"/> is set and true if <see cref="Name()"/> is not set.
+        /// </param>
+        public Watch<T> ToWatch<T>(string initialVersion = null, bool? isListWatch = null) where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+            => new Watch<T>(this, initialVersion, isListWatch);
+
         /// <summary>Gets the resource type access (e.g. "pods").</summary>
         public string Type() => _type;
 

--- a/src/KubernetesClient/KubernetesScheme.cs
+++ b/src/KubernetesClient/KubernetesScheme.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using k8s.Models;
 
 namespace k8s
 {
@@ -49,6 +50,31 @@ namespace k8s
         /// </summary>
         public void GetVK<T>(out string apiVersion, out string kind, out string path) =>
             GetVK(typeof(T), out apiVersion, out kind, out path);
+
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/> and
+        /// <see cref="IKubernetesObject.Kind"/>.
+        /// </summary>
+        public T New<T>() where T : IKubernetesObject, new()
+        {
+            string apiVersion, kind;
+            GetVK(typeof(T), out apiVersion, out kind);
+            return new T() { ApiVersion = apiVersion, Kind = kind };
+        }
+
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
+        /// <see cref="IKubernetesObject.Kind"/>, and <see cref="V1ObjectMeta.Name"/>.
+        /// </summary>
+        public T New<T>(string name) where T : IKubernetesObject<V1ObjectMeta>, new() => New<T>(null, name);
+
+        /// <summary>Creates a new Kubernetes object of the given type and sets its <see cref="IKubernetesObject.ApiVersion"/>,
+        /// <see cref="IKubernetesObject.Kind"/>, <see cref="V1ObjectMeta.Namespace"/>, and <see cref="V1ObjectMeta.Name"/>.
+        /// </summary>
+        public T New<T>(string ns, string name) where T : IKubernetesObject<V1ObjectMeta>, new()
+        {
+            T obj = New<T>();
+            obj.Metadata = new V1ObjectMeta() { NamespaceProperty = ns, Name = name };
+            return obj;
+        }
 
         /// <summary>Removes GVK information about the given type of object.</summary>
         public void RemoveGVK(Type type)

--- a/src/KubernetesClient/KubernetesScheme.cs
+++ b/src/KubernetesClient/KubernetesScheme.cs
@@ -15,7 +15,7 @@ namespace k8s
         /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
         public void GetGVK(Type type, out string group, out string version, out string kind, out string path)
         {
-            if(!TryGetGVK(type, out group, out version, out kind, out path))
+            if (!TryGetGVK(type, out group, out version, out kind, out path))
             {
                 throw new ArgumentException($"The GVK of type {type.Name} is unknown.");
             }
@@ -79,7 +79,7 @@ namespace k8s
         /// <summary>Removes GVK information about the given type of object.</summary>
         public void RemoveGVK(Type type)
         {
-            lock(gvks) gvks.Remove(type);
+            lock (gvks) gvks.Remove(type);
         }
 
         /// <summary>Removes GVK information about the given type of object.</summary>
@@ -88,11 +88,11 @@ namespace k8s
         /// <summary>Sets GVK information for the given type of object.</summary>
         public void SetGVK(Type type, string group, string version, string kind, string path)
         {
-            if(type == null) throw new ArgumentNullException(nameof(type));
-            if(string.IsNullOrEmpty(version)) throw new ArgumentNullException(nameof(version));
-            if(string.IsNullOrEmpty(kind)) throw new ArgumentNullException(nameof(kind));
-            if(string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
-            lock(gvks) gvks[type] = Tuple.Create(group ?? string.Empty, version, kind, path);
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (string.IsNullOrEmpty(version)) throw new ArgumentNullException(nameof(version));
+            if (string.IsNullOrEmpty(kind)) throw new ArgumentNullException(nameof(kind));
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+            lock (gvks) gvks[type] = Tuple.Create(group ?? string.Empty, version, kind, path);
         }
 
         /// <summary>Sets GVK information for the given type of object.</summary>
@@ -106,13 +106,13 @@ namespace k8s
         /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
         public bool TryGetGVK(Type type, out string group, out string version, out string kind, out string path)
         {
-            if(type == null) throw new ArgumentNullException(nameof(type));
-            lock(gvks)
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            lock (gvks)
             {
-                if(!gvks.TryGetValue(type, out Tuple<string,string,string,string> gvk))
+                if (!gvks.TryGetValue(type, out Tuple<string,string,string,string> gvk))
                 {
                     var attr = type.GetCustomAttribute<k8s.Models.KubernetesEntityAttribute>(); // newer types have this attribute
-                    if(attr != null)
+                    if (attr != null)
                     {
                         gvk = Tuple.Create(attr.Group, attr.ApiVersion, attr.Kind, attr.PluralName);
                     }
@@ -120,7 +120,7 @@ namespace k8s
                     {
                         const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
                         FieldInfo kindf = type.GetField("KubeKind", Flags), versionf = type.GetField("KubeApiVersion", Flags);
-                        if(kindf != null && versionf != null)
+                        if (kindf != null && versionf != null)
                         {
                             FieldInfo groupf = type.GetField("KubeGroup", Flags);
                             string k = (string)kindf.GetValue(null);
@@ -131,7 +131,7 @@ namespace k8s
                     gvks[type] = gvk;
                 }
 
-                if(gvk != null)
+                if (gvk != null)
                 {
                     (group, version, kind, path) = gvk;
                     return true;
@@ -161,7 +161,7 @@ namespace k8s
         /// </summary>
         public bool TryGetVK(Type type, out string apiVersion, out string kind, out string path)
         {
-            if(TryGetGVK(type, out string group, out string version, out kind, out path))
+            if (TryGetGVK(type, out string group, out string version, out kind, out path))
             {
                 apiVersion = string.IsNullOrEmpty(group) ? version : group + "/" + version;
                 return true;
@@ -188,8 +188,8 @@ namespace k8s
         /// <summary>Attempts to guess a type's API path segment based on its kind.</summary>
         internal static string GuessPath(string kind)
         {
-            if(string.IsNullOrEmpty(kind)) return null;
-            if(kind.Length > 4 && kind.EndsWith("List")) kind = kind.Substring(0, kind.Length-4); // e.g. PodList -> Pod
+            if (string.IsNullOrEmpty(kind)) return null;
+            if (kind.Length > 4 && kind.EndsWith("List")) kind = kind.Substring(0, kind.Length-4); // e.g. PodList -> Pod
             kind = kind.ToLowerInvariant(); // e.g. Pod -> pod
             return kind + (kind[kind.Length-1] == 's' ? "es" : "s"); // e.g. pod -> pods
         }

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -102,10 +102,7 @@ namespace k8s.Models
             string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
             if (string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
             {
-                object[] attrs = obj.GetType().GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
-                if (attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
-                var attr = (KubernetesEntityAttribute)attrs[0];
-                (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);
+                KubernetesScheme.Default.GetVK(obj.GetType(), out apiVersion, out kind); // get it from the default scheme
             }
             return new V1ObjectReference()
             {
@@ -117,14 +114,11 @@ namespace k8s.Models
         /// <summary>Creates a <see cref="V1OwnerReference"/> that refers to the given object.</summary>
         public static V1OwnerReference CreateOwnerReference(this IKubernetesObject<V1ObjectMeta> obj, bool? controller = null, bool? blockDeletion = null)
         {
-            if (obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
             string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
-            if (string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
+            if(string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
             {
-                object[] attrs = obj.GetType().GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
-                if (attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
-                var attr = (KubernetesEntityAttribute)attrs[0];
-                (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);
+                KubernetesScheme.Default.GetVK(obj.GetType(), out apiVersion, out kind); // get it from the default scheme
             }
             return new V1OwnerReference()
             {

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace k8s.Models
+{
+    public static class ModelExtensions
+    {
+        /// <summary>Extracts the Kubernetes API group from the <see cref="IKubernetesObject.ApiVersion"/>.</summary>
+        public static string ApiGroup(this IKubernetesObject obj)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null) return null;
+            int slash = obj.ApiVersion.IndexOf('/');
+            return slash < 0 ? string.Empty : obj.ApiVersion.Substring(0, slash);
+        }
+
+        /// <summary>Extracts the Kubernetes API version (excluding the group) from the <see cref="IKubernetesObject.ApiVersion"/>.</summary>
+        public static string ApiGroupVersion(this IKubernetesObject obj)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null) return null;
+            int slash = obj.ApiVersion.IndexOf('/');
+            return slash < 0 ? obj.ApiVersion : obj.ApiVersion.Substring(slash+1);
+        }
+
+        /// <summary>Splits the Kubernetes API version into the group and version.</summary>
+        public static (string, string) ApiGroupAndVersion(this IKubernetesObject obj)
+        {
+            string group, version;
+            obj.GetApiGroupAndVersion(out group, out version);
+            return (group, version);
+        }
+
+        /// <summary>Splits the Kubernetes API version into the group and version.</summary>
+        public static void GetApiGroupAndVersion(this IKubernetesObject obj, out string group, out string version)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(obj.ApiVersion == null)
+            {
+                group = version = null;
+            }
+            else
+            {
+                int slash = obj.ApiVersion.IndexOf('/');
+                if(slash < 0) (group, version) = (string.Empty, obj.ApiVersion);
+                else (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash+1));
+            }
+        }
+
+        /// <summary>Gets the continuation token version of a Kubernetes list.</summary>
+        public static string Continue(this IMetadata<V1ListMeta> list) => list.Metadata?.ContinueProperty;
+
+        /// <summary>Ensures that the <see cref="V1ListMeta"/> metadata field is set, and returns it.</summary>
+        public static V1ListMeta EnsureMetadata(this IMetadata<V1ListMeta> obj)
+        {
+            if(obj.Metadata == null) obj.Metadata = new V1ListMeta();
+            return obj.Metadata;
+        }
+
+        /// <summary>Gets the resource version of a Kubernetes list.</summary>
+        public static string ResourceVersion(this IMetadata<V1ListMeta> list) => list.Metadata?.ResourceVersion;
+
+        /// <summary>Adds an owner reference to the object. No attempt is made to ensure the reference is correct or fits with the
+        /// other references.
+        /// </summary>
+        public static void AddOwnerReference(this IMetadata<V1ObjectMeta> obj, V1OwnerReference ownerRef)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(ownerRef == null) throw new ArgumentNullException(nameof(ownerRef));
+            if(obj.EnsureMetadata().OwnerReferences == null) obj.Metadata.OwnerReferences = new List<V1OwnerReference>();
+            obj.Metadata.OwnerReferences.Add(ownerRef);
+        }
+
+        /// <summary>Gets the annotations of a Kubernetes object.</summary>
+        public static IDictionary<string, string> Annotations(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Annotations;
+
+        /// <summary>Gets the creation time of a Kubernetes object, or null if it hasn't been created yet.</summary>
+        public static DateTime? CreationTimestamp(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.CreationTimestamp;
+
+        /// <summary>Gets the deletion time of a Kubernetes object, or null if it hasn't been scheduled for deletion.</summary>
+        public static DateTime? DeletionTimestamp(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.DeletionTimestamp;
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta"/> metadata field is set, and returns it.</summary>
+        public static V1ObjectMeta EnsureMetadata(this IMetadata<V1ObjectMeta> obj)
+        {
+            if(obj.Metadata == null) obj.Metadata = new V1ObjectMeta();
+            return obj.Metadata;
+        }
+
+        /// <summary>Gets the index of the <see cref="V1OwnerReference"/> that matches the given object, or -1 if no such
+        /// reference could be found.
+        /// </summary>
+        public static int FindOwnerRef(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
+        {
+            var ownerRefs = obj.OwnerReferences();
+            if(ownerRefs != null)
+            {
+                for(int i = 0; i < ownerRefs.Count; i++)
+                {
+                    if(ownerRefs[i].Matches(owner)) return i;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>Gets the generation a Kubernetes object.</summary>
+        public static long? Generation(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Generation;
+
+        /// <summary>Returns the given annotation from a Kubernetes object or null if the annotation was not found.</summary>
+        public static string GetAnnotation(this IMetadata<V1ObjectMeta> obj, string key)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            IDictionary<string, string> annotations = obj.Annotations();
+            return annotations != null && annotations.TryGetValue(key, out string value) ? value : null;
+        }
+
+        /// <summary>Gets the <see cref="V1OwnerReference"/> for the controller of this object, or null if it couldn't be found.</summary>
+        public static V1OwnerReference GetController(this IMetadata<V1ObjectMeta> obj) =>
+            obj.OwnerReferences()?.FirstOrDefault(r => r.Controller.GetValueOrDefault());
+
+        /// <summary>Returns the given label from a Kubernetes object or null if the label was not found.</summary>
+        public static string GetLabel(this IMetadata<V1ObjectMeta> obj, string key)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            IDictionary<string, string> labels = obj.Labels();
+            return labels != null && labels.TryGetValue(key, out string value) ? value : null;
+        }
+
+        /// <summary>Creates a <see cref="V1ObjectReference"/> that refers to the given object.</summary>
+        public static V1ObjectReference GetObjectReference<T>(this T obj) where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
+            if(string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
+            {
+                object[] attrs = typeof(T).GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
+                if(attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
+                var attr = (KubernetesEntityAttribute)attrs[0];
+                (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);
+            }
+            return new V1ObjectReference()
+            {
+                ApiVersion = apiVersion, Kind = kind, Name = obj.Name(), NamespaceProperty = obj.Namespace(), Uid = obj.Uid(),
+                ResourceVersion = obj.ResourceVersion()
+            };
+        }
+
+        /// <summary>Gets the labels of a Kubernetes object.</summary>
+        public static IDictionary<string, string> Labels(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Labels;
+
+        /// <summary>Gets the name of a Kubernetes object.</summary>
+        public static string Name(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Name;
+
+        /// <summary>Gets the namespace of a Kubernetes object.</summary>
+        public static string Namespace(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.NamespaceProperty;
+
+        /// <summary>Gets the owner references of a Kubernetes object.</summary>
+        public static IList<V1OwnerReference> OwnerReferences(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.OwnerReferences;
+
+        /// <summary>Gets the resource version of a Kubernetes object.</summary>
+        public static string ResourceVersion(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.ResourceVersion;
+
+        /// <summary>Sets or removes an annotation on a Kubernetes object.</summary>
+        public static void SetAnnotation(this IMetadata<V1ObjectMeta> obj, string key, string value)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            if(value != null) obj.EnsureMetadata().EnsureAnnotations()[key] = value;
+            else obj.Metadata?.Annotations?.Remove(key);
+        }
+
+        /// <summary>Sets or removes a label on a Kubernetes object.</summary>
+        public static void SetLabel(this IMetadata<V1ObjectMeta> obj, string key, string value)
+        {
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            if(key == null) throw new ArgumentNullException(nameof(key));
+            if(value != null) obj.EnsureMetadata().EnsureLabels()[key] = value;
+            else obj.Metadata?.Labels?.Remove(key);
+        }
+
+        /// <summary>Gets the unique ID of a Kubernetes object.</summary>
+        public static string Uid(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Uid;
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta.Annotations"/> field is not null, and returns it.</summary>
+        public static IDictionary<string, string> EnsureAnnotations(this V1ObjectMeta meta)
+        {
+            if(meta.Annotations == null) meta.Annotations = new Dictionary<string, string>();
+            return meta.Annotations;
+        }
+
+        /// <summary>Ensures that the <see cref="V1ObjectMeta.Labels"/> field is not null, and returns it.</summary>
+        public static IDictionary<string, string> EnsureLabels(this V1ObjectMeta meta)
+        {
+            if(meta.Labels == null) meta.Labels = new Dictionary<string, string>();
+            return meta.Labels;
+        }
+
+        /// <summary>Gets the namespace from Kubernetes metadata.</summary>
+        public static string Namespace(this V1ObjectMeta meta) => meta.NamespaceProperty;
+
+        /// <summary>Sets the namespace from Kubernetes metadata.</summary>
+        public static void SetNamespace(this V1ObjectMeta meta, string ns) => meta.NamespaceProperty = ns;
+
+        /// <summary>Determines whether an object reference references the given object.</summary>
+        public static bool Matches(this V1ObjectReference objref, IKubernetesObject<V1ObjectMeta> obj)
+        {
+            if(objref == null) throw new ArgumentNullException(nameof(objref));
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            return objref.ApiVersion == obj.ApiVersion && objref.Kind == obj.Kind && objref.Name == obj.Name() && objref.Uid == obj.Uid() &&
+                   objref.NamespaceProperty == obj.Namespace();
+        }
+
+        /// <summary>Determines whether an owner reference references the given object.</summary>
+        public static bool Matches(this V1OwnerReference owner, IKubernetesObject<V1ObjectMeta> obj)
+        {
+            if(owner == null) throw new ArgumentNullException(nameof(owner));
+            if(obj == null) throw new ArgumentNullException(nameof(obj));
+            return owner.ApiVersion == obj.ApiVersion && owner.Kind == obj.Kind && owner.Name == obj.Name() && owner.Uid == obj.Uid();
+        }
+    }
+
+    public partial class V1Status
+    {
+        /// <summary>Converts a <see cref="V1Status"/> object representing an error into a short description of the error.</summary>
+        public override string ToString()
+        {
+            string reason = Reason;
+            if(string.IsNullOrEmpty(reason) && Code.GetValueOrDefault() != 0)
+            {
+                reason = ((HttpStatusCode)Code.Value).ToString();
+            }
+            return string.IsNullOrEmpty(Message) ? reason : string.IsNullOrEmpty(reason) ? Message : $"{reason} - {Message}";
+        }
+    }
+}

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -12,9 +12,15 @@ namespace k8s.Models
         /// <returns>Returns true if the finalizer was added and false if it already existed.</returns>
         public static bool AddFinalizer(this IMetadata<V1ObjectMeta> obj, string finalizer)
         {
+<<<<<<< HEAD
             if (string.IsNullOrEmpty(finalizer)) throw new ArgumentNullException(nameof(finalizer));
             if (EnsureMetadata(obj).Finalizers == null) obj.Metadata.Finalizers = new List<string>();
             if (obj.Metadata.Finalizers.Contains(finalizer)) return false;
+=======
+            if(string.IsNullOrEmpty(finalizer)) throw new ArgumentNullException(nameof(finalizer));
+            if(obj.EnsureMetadata().Finalizers == null) obj.Metadata.Finalizers = new List<string>();
+            if(obj.Metadata.Finalizers.Contains(finalizer)) return false;
+>>>>>>> Merge from modelExtensions
             obj.Metadata.Finalizers.Add(finalizer);
             return true;
         }
@@ -95,6 +101,7 @@ namespace k8s.Models
         /// <summary>Gets the annotations of a Kubernetes object.</summary>
         public static IDictionary<string, string> Annotations(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Annotations;
 
+<<<<<<< HEAD
         /// <summary>Creates a <see cref="V1ObjectReference"/> that refers to the given object.</summary>
         public static V1ObjectReference CreateObjectReference(this IKubernetesObject<V1ObjectMeta> obj)
         {
@@ -111,6 +118,8 @@ namespace k8s.Models
             };
         }
 
+=======
+>>>>>>> Merge from modelExtensions
         /// <summary>Creates a <see cref="V1OwnerReference"/> that refers to the given object.</summary>
         public static V1OwnerReference CreateOwnerReference(this IKubernetesObject<V1ObjectMeta> obj, bool? controller = null, bool? blockDeletion = null)
         {
@@ -211,9 +220,18 @@ namespace k8s.Models
             return obj.Finalizers() != null && obj.Metadata.Finalizers.Contains(finalizer);
         }
 
+<<<<<<< HEAD
         /// <summary>Determines whether one object is owned by another.</summary>
         public static bool IsOwnedBy(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner) =>
             FindOwnerReference(obj, owner) >= 0;
+=======
+        /// <summary>Determines whether the Kubernetes object has the given finalizer.</summary>
+        public static bool HasFinalizer(this IMetadata<V1ObjectMeta> obj, string finalizer)
+        {
+            if(string.IsNullOrEmpty(finalizer)) throw new ArgumentNullException(nameof(finalizer));
+            return obj.Finalizers() != null && obj.Metadata.Finalizers.Contains(finalizer);
+        }
+>>>>>>> Merge from modelExtensions
 
         /// <summary>Gets the labels of a Kubernetes object.</summary>
         public static IDictionary<string, string> Labels(this IMetadata<V1ObjectMeta> obj) => obj.Metadata?.Labels;
@@ -231,8 +249,12 @@ namespace k8s.Models
         /// <returns>Returns true if the finalizer was removed and false if it didn't exist.</returns>
         public static bool RemoveFinalizer(this IMetadata<V1ObjectMeta> obj, string finalizer)
         {
+<<<<<<< HEAD
             if (obj == null) throw new ArgumentNullException(nameof(obj));
             if (string.IsNullOrEmpty(finalizer)) throw new ArgumentNullException(nameof(finalizer));
+=======
+            if(string.IsNullOrEmpty(finalizer)) throw new ArgumentNullException(nameof(finalizer));
+>>>>>>> Merge from modelExtensions
             return obj.Finalizers() != null && obj.Metadata.Finalizers.Remove(finalizer);
         }
 
@@ -241,9 +263,15 @@ namespace k8s.Models
         /// </summary>
         public static V1OwnerReference RemoveOwnerReference(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
         {
+<<<<<<< HEAD
             int index = FindOwnerReference(obj, owner);
             V1OwnerReference ownerRef = index >= 0 ? obj.Metadata.OwnerReferences[index] : null;
             if (index >= 0) obj.Metadata.OwnerReferences.RemoveAt(index);
+=======
+            int index = obj.FindOwnerReference(owner);
+            V1OwnerReference ownerRef = index >= 0 ? obj.Metadata.OwnerReferences[index] : null;
+            if(index >= 0) obj.Metadata.OwnerReferences.RemoveAt(index);
+>>>>>>> Merge from modelExtensions
             return ownerRef;
         }
 
@@ -252,6 +280,7 @@ namespace k8s.Models
         /// </summary>
         public static bool RemoveOwnerReferences(this IMetadata<V1ObjectMeta> obj, Predicate<V1OwnerReference> predicate)
         {
+<<<<<<< HEAD
             if (obj == null) throw new ArgumentNullException(nameof(obj));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
             bool removed = false;
@@ -261,6 +290,16 @@ namespace k8s.Models
                 for (int i = refs.Count-1; i >= 0; i--)
                 {
                     if (predicate(refs[i]))
+=======
+            if(predicate == null) throw new ArgumentNullException(nameof(predicate));
+            bool removed = false;
+            IList<V1OwnerReference> refs = obj.Metadata?.OwnerReferences;
+            if(refs != null)
+            {
+                for(int i = refs.Count-1; i >= 0; i--)
+                {
+                    if(predicate(refs[i]))
+>>>>>>> Merge from modelExtensions
                     {
                         refs.RemoveAt(i);
                         removed = true;
@@ -311,8 +350,12 @@ namespace k8s.Models
         /// <summary>Ensures that the <see cref="V1ObjectMeta.Finalizers"/> field is not null, and returns it.</summary>
         public static IList<string> EnsureFinalizers(this V1ObjectMeta meta)
         {
+<<<<<<< HEAD
             if (meta == null) throw new ArgumentNullException(nameof(meta));
             if (meta.Finalizers == null) meta.Finalizers = new List<string>();
+=======
+            if(meta.Finalizers == null) meta.Finalizers = new List<string>();
+>>>>>>> Merge from modelExtensions
             return meta.Finalizers;
         }
 

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -92,7 +92,7 @@ namespace k8s.Models
         /// <summary>Gets the index of the <see cref="V1OwnerReference"/> that matches the given object, or -1 if no such
         /// reference could be found.
         /// </summary>
-        public static int FindOwnerRef(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
+        public static int FindOwnerReference(this IMetadata<V1ObjectMeta> obj, IKubernetesObject<V1ObjectMeta> owner)
         {
             var ownerRefs = obj.OwnerReferences();
             if(ownerRefs != null)
@@ -131,13 +131,13 @@ namespace k8s.Models
         }
 
         /// <summary>Creates a <see cref="V1ObjectReference"/> that refers to the given object.</summary>
-        public static V1ObjectReference GetObjectReference<T>(this T obj) where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+        public static V1ObjectReference GetObjectReference(this IKubernetesObject<V1ObjectMeta> obj)
         {
             if(obj == null) throw new ArgumentNullException(nameof(obj));
             string apiVersion = obj.ApiVersion, kind = obj.Kind; // default to using the API version and kind from the object
             if(string.IsNullOrEmpty(apiVersion) || string.IsNullOrEmpty(kind)) // but if either of them is missing...
             {
-                object[] attrs = typeof(T).GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
+                object[] attrs = obj.GetType().GetCustomAttributes(typeof(KubernetesEntityAttribute), true);
                 if(attrs.Length == 0) throw new ArgumentException("Unable to determine the object's API version and Kind.");
                 var attr = (KubernetesEntityAttribute)attrs[0];
                 (apiVersion, kind) = (string.IsNullOrEmpty(attr.Group) ? attr.ApiVersion : attr.Group + "/" + attr.ApiVersion, attr.Kind);

--- a/src/KubernetesClient/Scheme.cs
+++ b/src/KubernetesClient/Scheme.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace k8s
+{
+    /// <summary>Represents a map between object types and Kubernetes group, version, and kind triplets.</summary>
+    public sealed class KubernetesScheme
+    {
+        /// <summary>Gets the Kubernetes group, version, and kind for the given type of object.</summary>
+        public void GetGVK(Type type, out string group, out string version, out string kind) =>
+            GetGVK(type, out group, out version, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
+        public void GetGVK(Type type, out string group, out string version, out string kind, out string path)
+        {
+            if(!TryGetGVK(type, out group, out version, out kind, out path))
+            {
+                throw new ArgumentException($"The GVK of type {type.Name} is unknown.");
+            }
+        }
+
+        /// <summary>Gets the Kubernetes group, version, and kind for the given type of object.</summary>
+        public void GetGVK<T>(out string group, out string version, out string kind) =>
+            GetGVK(typeof(T), out group, out version, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
+        public void GetGVK<T>(out string group, out string version, out string kind, out string path) =>
+            GetGVK(typeof(T), out group, out version, out kind, out path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any), and kind for the given type of object.</summary>
+        public void GetVK(Type type, out string apiVersion, out string kind) => GetVK(type, out apiVersion, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any), kind, and API path segment for the given type of
+        /// object.
+        /// </summary>
+        public void GetVK(Type type, out string apiVersion, out string kind, out string path)
+        {
+            string group, version;
+            GetGVK(type, out group, out version, out kind, out path);
+            apiVersion = string.IsNullOrEmpty(group) ? version : group + "/" + version;
+        }
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any) and kind for the given type of object.</summary>
+        public void GetVK<T>(out string apiVersion, out string kind) => GetVK(typeof(T), out apiVersion, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any), kind, and API path segment for the given type of
+        /// object.
+        /// </summary>
+        public void GetVK<T>(out string apiVersion, out string kind, out string path) =>
+            GetVK(typeof(T), out apiVersion, out kind, out path);
+
+        /// <summary>Removes GVK information about the given type of object.</summary>
+        public void RemoveGVK(Type type)
+        {
+            lock(gvks) gvks.Remove(type);
+        }
+
+        /// <summary>Removes GVK information about the given type of object.</summary>
+        public void RemoveGVK<T>() => RemoveGVK(typeof(T));
+
+        /// <summary>Sets GVK information for the given type of object.</summary>
+        public void SetGVK(Type type, string group, string version, string kind, string path)
+        {
+            if(type == null) throw new ArgumentNullException(nameof(type));
+            if(string.IsNullOrEmpty(version)) throw new ArgumentNullException(nameof(version));
+            if(string.IsNullOrEmpty(kind)) throw new ArgumentNullException(nameof(kind));
+            if(string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+            lock(gvks) gvks[type] = Tuple.Create(group ?? string.Empty, version, kind, path);
+        }
+
+        /// <summary>Sets GVK information for the given type of object.</summary>
+        public void SetGVK<T>(string group, string version, string kind, string path) =>
+            SetGVK(typeof(T), group, version, kind, path);
+
+        /// <summary>Gets the Kubernetes group, version, and kind for the given type of object.</summary>
+        public bool TryGetGVK(Type type, out string group, out string version, out string kind)
+            => TryGetGVK(type, out group, out version, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
+        public bool TryGetGVK(Type type, out string group, out string version, out string kind, out string path)
+        {
+            if(type == null) throw new ArgumentNullException(nameof(type));
+            lock(gvks)
+            {
+                if(!gvks.TryGetValue(type, out Tuple<string,string,string,string> gvk))
+                {
+                    var attr = type.GetCustomAttribute<k8s.Models.KubernetesEntityAttribute>(); // newer types have this attribute
+                    if(attr != null)
+                    {
+                        gvk = Tuple.Create(attr.Group, attr.ApiVersion, attr.Kind, attr.PluralName);
+                    }
+                    else // some older types (and ours) just have static/const fields
+                    {
+                        const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+                        FieldInfo kindf = type.GetField("KubeKind", Flags), versionf = type.GetField("KubeApiVersion", Flags);
+                        if(kindf != null && versionf != null)
+                        {
+                            FieldInfo groupf = type.GetField("KubeGroup", Flags);
+                            string k = (string)kindf.GetValue(null);
+                            gvk = Tuple.Create(
+                                (string)groupf?.GetValue(null) ?? string.Empty, (string)versionf.GetValue(null), k, GuessPath(k));
+                        }
+                    }
+                    gvks[type] = gvk;
+                }
+
+                if(gvk != null)
+                {
+                    (group, version, kind, path) = gvk;
+                    return true;
+                }
+                else
+                {
+                    group = version = kind = path = null;
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>Gets the Kubernetes group, version, and kind for the given type of object.</summary>
+        public bool TryGetGVK<T>(out string group, out string version, out string kind) =>
+            TryGetGVK(typeof(T), out group, out version, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes group, version, kind, and API path segment for the given type of object.</summary>
+        public bool TryGetGVK<T>(out string group, out string version, out string kind, out string path) =>
+            TryGetGVK(typeof(T), out group, out version, out kind, out path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any) and kind for the given type of object.</summary>
+        public bool TryGetVK(Type type, out string apiVersion, out string kind) =>
+            TryGetVK(type, out apiVersion, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any), kind, and API path segment for the given type of
+        /// object.
+        /// </summary>
+        public bool TryGetVK(Type type, out string apiVersion, out string kind, out string path)
+        {
+            if(TryGetGVK(type, out string group, out string version, out kind, out path))
+            {
+                apiVersion = string.IsNullOrEmpty(group) ? version : group + "/" + version;
+                return true;
+            }
+            else
+            {
+                apiVersion = null;
+                return false;
+            }
+        }
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any) and kind for the given type of object.</summary>
+        public bool TryGetVK<T>(out string apiVersion, out string kind) => TryGetVK(typeof(T), out apiVersion, out kind, out string path);
+
+        /// <summary>Gets the Kubernetes API version (including the group, if any), kind, and API path segment for the given type of
+        /// object.
+        /// </summary>
+        public bool TryGetVK<T>(out string apiVersion, out string kind, out string path) =>
+            TryGetVK(typeof(T), out apiVersion, out kind, out path);
+
+        /// <summary>Gets the default <see cref="KubernetesScheme"/>.</summary>
+        public static readonly KubernetesScheme Default = new KubernetesScheme();
+
+        /// <summary>Attempts to guess a type's API path segment based on its kind.</summary>
+        internal static string GuessPath(string kind)
+        {
+            if(string.IsNullOrEmpty(kind)) return null;
+            if(kind.Length > 4 && kind.EndsWith("List")) kind = kind.Substring(0, kind.Length-4); // e.g. PodList -> Pod
+            kind = kind.ToLowerInvariant(); // e.g. Pod -> pod
+            return kind + (kind[kind.Length-1] == 's' ? "es" : "s"); // e.g. pod -> pods
+        }
+
+        readonly Dictionary<Type,Tuple<string,string,string,string>> gvks = new Dictionary<Type, Tuple<string,string,string,string>>();
+    }
+}

--- a/src/KubernetesClient/Watch.cs
+++ b/src/KubernetesClient/Watch.cs
@@ -440,7 +440,7 @@ namespace k8s
                 while(buffer.Length != 0 && (charRead != charWrite || await EnsureDataAsync().ConfigureAwait(false)))
                 {
                     int toRead = Math.Min(buffer.Length, charWrite-charRead);
-                    charBuffer.AsMemory(0, toRead).CopyTo(buffer);
+                    charBuffer.AsSpan(charRead, toRead).CopyTo(buffer.Span);
                     totalRead += toRead;
                     charRead += toRead;
                     if (!block) break;
@@ -449,17 +449,17 @@ namespace k8s
                 return totalRead;
             }
 #else
-            async Task<int> ReadAsync(char[] buffer, int index, int length, bool block)
+            async Task<int> ReadAsync(char[] buffer, int index, int count, bool block)
             {
                 int start = index;
-                while(length != 0 && (charRead != charWrite || await EnsureDataAsync().ConfigureAwait(false)))
+                while(count != 0 && (charRead != charWrite || await EnsureDataAsync().ConfigureAwait(false)))
                 {
-                    int toRead = Math.Min(length, charWrite-charRead);
-                    Array.Copy(charBuffer, 0, buffer, index, toRead);
+                    int toRead = Math.Min(count, charWrite-charRead);
+                    Array.Copy(charBuffer, charRead, buffer, index, toRead);
                     charRead += toRead;
                     index += toRead;
                     if (!block) break;
-                    length -= toRead;
+                    count -= toRead;
                 }
                 return index - start;
             }

--- a/src/KubernetesClient/Watch.cs
+++ b/src/KubernetesClient/Watch.cs
@@ -1,0 +1,451 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Newtonsoft.Json;
+
+namespace k8s
+{
+    #region Watch
+    /// <summary>Watches one or more Kubernetes objects, reopening the watch and managing versions as necessary.</summary>
+    public sealed class Watch<T> : IDisposable where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+    {
+        /// <summary>Initializes a new watch from a <see cref="KubernetesRequest"/> that represents the item or list of items to watch.</summary>
+        /// <param name="request">A <see cref="KubernetesRequest"/> that selects the item or list of items to watch</param>
+        /// <param name="initialVersion">The resource version to resume from, or null to start from the current version</param>
+        /// <param name="isListWatch">The value of the <see cref="IsListWatch"/> property, or null to use the default</param>
+        public Watch(KubernetesRequest request, string initialVersion = null, bool? isListWatch = null)
+        {
+            this.req = request?.Clone() ?? throw new ArgumentNullException();
+            IsListWatch = isListWatch ?? req.Name() == null;
+            if (IsListWatch) req.AddQuery("allowWatchBookmarks", "true");
+            LastVersion = initialVersion;
+        }
+
+        /// <summary>Raised after the watch is closed.</summary>
+        public event Action<Watch<T>> Closed;
+
+        /// <summary>Raised when a non-bookmark watch event is received.</summary>
+        public event Action<Watch<T>, WatchEventType, T> EventReceived;
+
+        /// <summary>Raised when an error occurs, either an exception or a failure status.</summary>
+        public event Action<Watch<T>, Exception, V1Status> Error;
+
+        /// <summary>Raised after the initial list of item events has been sent when operating in list-watching mode (i.e.
+        /// when <see cref="IsListWatch"/> is true). If a resource version is passed to the constructor, the watch will attempt to
+        /// resume without obtaining an initial list, and this event may not be raised.
+        /// </summary>
+        public event Action<Watch<T>> InitialList;
+
+        /// <summary>Raised after the watch is opened.</summary>
+        public event Action<Watch<T>> Opened;
+
+        /// <summary>Raised after the watch is opened without a resource version or when events may have been lost.</summary>
+        public event Action<Watch<T>> Reset;
+
+        /// <summary>Gets or sets whether the watch should use list-watching semantics instead of item-watching semantics. This must
+        /// be true when watching multiple items and should be false when watching a single item and must be false when the request does
+        /// not return a list. By default, the property is initialized to true if the request <see cref="KubernetesRequest.Name()"/> is
+        /// null, but if you're using a request with a null name that is nonetheless guaranteed to return only one item, you can improve
+        /// efficiency by setting this to false.
+        /// </summary>
+        public bool IsListWatch { get; set; }
+
+        /// <summary>Gets or sets the version of the most recently received resource, or null if no resource has been received or
+        /// the version information is known to be out of date.
+        /// </summary>
+        public string LastVersion { get; private set; }
+
+        /// <summary>Gets or sets how long the watch will wait between retries after an error. The default is 15 seconds.</summary>
+        public TimeSpan OpenRetryTime { get; set; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>Stops the watch.</summary>
+        public void Dispose() => cts?.Cancel();
+
+        /// <summary>Runs the watch. To stop it, call <see cref="Dispose"/> or cancel the <see cref="CancellationToken"/>.</summary>
+        /// <param name="shutdownToken">A <see cref="CancellationToken"/> that can be used to stop the watch</param>
+        public Task Run(CancellationToken shutdownToken = default)
+        {
+            if (task != null) throw new InvalidOperationException();
+            shutdownToken.ThrowIfCancellationRequested();
+            cts = shutdownToken.CanBeCanceled ?
+                CancellationTokenSource.CreateLinkedTokenSource(shutdownToken) : new CancellationTokenSource();
+            task = Task.Run(Run);
+            return task;
+        }
+
+        async Task Run()
+        {
+            while(!cts.IsCancellationRequested)
+            {
+                bool wasOpen = false; // used to determine whether we should raise OnClosed
+                try
+                {
+                    // when watching multiple items when we don't know the starting version, we first have to retrieve the list and then
+                    // watch for changes. if we just started watching, we'd get an initial mishmash of resource versions and wouldn't be
+                    // able to know what the latest version is. when listing, the appropriate version is part of the list metadata
+                    KubernetesList<T> list = null;
+                    if (IsListWatch && LastVersion == null)
+                    {
+                        using (KubernetesResponse listResponse = await req.WatchVersion(null).ExecuteAsync(cts.Token).ConfigureAwait(false))
+                        {
+                            if (listResponse.IsError)
+                            {
+                                await ReportErrorAndWait(listResponse).ConfigureAwait(false);
+                                continue;
+                            }
+                            list = await listResponse.GetBodyAsync<KubernetesList<T>>(failIfEmpty: true).ConfigureAwait(false);
+                            LastVersion = list.Metadata?.ResourceVersion;
+                        }
+                    }
+
+                    // now start the watch
+                    using (KubernetesResponse response = await req.WatchVersion(LastVersion ?? "").ExecuteAsync(cts.Token).ConfigureAwait(false))
+                    {
+                        if (response.IsError) // if the watch request failed...
+                        {
+                            // if our resource version is too old, reset it. otherwise report the error
+                            if (response.StatusCode == HttpStatusCode.Gone) LastVersion = null; // NOTE: in practice this seems to be reported as a watch event...
+                            else await ReportErrorAndWait(response).ConfigureAwait(false);
+                        }
+                        else // if the response was successful, then the watch is open...
+                        {
+                            if ((LastVersion == null || list != null) && Reset != null) Reset(this); // if we may have lost events, let the client know
+                            if (Opened != null) Opened(this);
+                            wasOpen = true; // since it was opened, we have to call OnClosed later
+                            // if we started a new watch based on a list, send out the initial events from the list.
+                            // otherwise, the initial event(s) will be sent from the watch
+                            if (list != null)
+                            {
+                                if (EventReceived != null)
+                                {
+                                    // annoyingly, Kubernetes may exclude the API version and kind from items in lists and the list itself
+                                    // only has the API version (of the list). the kind is the kind of the list (e.g. PodList). 
+                                    string guessedApiVersion, guessedKind;
+                                    if (!req.Scheme().TryGetVK(typeof(T), out guessedApiVersion, out guessedKind)) // so try to get them from the scheme
+                                    {
+                                        guessedApiVersion = list.ApiVersion; // if it's missing, assume the API version is the same as the list's
+                                        // and for the kind, we'll use a heuristic that if the list kind is FooList then the item kind is Foo
+                                        guessedKind = list.Kind != null && list.Kind.Length > 4 && list.Kind.EndsWith("List") ?
+                                            list.Kind.Substring(0, list.Kind.Length-4) : null;
+                                    }
+                                    foreach (T item in list.Items)
+                                    {
+                                        if (item.ApiVersion == null) item.ApiVersion = guessedApiVersion;
+                                        if (item.Kind == null) item.Kind = guessedKind;
+                                        EventReceived(this, WatchEventType.Added, item);
+                                    }
+                                }
+                                if (InitialList != null) InitialList(this);
+                            }
+                            list = null; // the initial list may be large, so help out the garbage collector, maybe
+                            using (var watchReader = new WatchReader<T>(response))
+                            {
+                                WatchEvent<T> e;
+                                while((e = await watchReader.ReadAsync(cts.Token).ConfigureAwait(false)) != null)
+                                {
+                                    if (e.Type == WatchEventType.Error) // if an error occurred...
+                                    {
+                                        if (e.Error.Code.GetValueOrDefault() == (int)HttpStatusCode.Gone) // if our version is outdated...
+                                        {
+                                            LastVersion = null; // reset it
+                                            break; // and restart the watch
+                                        }
+                                        else // otherwise, if the error was unknown...
+                                        {
+                                            if (Error != null) Error(this, null, e.Error); // report and ignore it
+                                        }
+                                    }
+                                    else // otherwise, no error occurred. update our version number and inform the client
+                                    {
+                                        LastVersion = e.Object.Metadata.ResourceVersion;
+                                        if (e.Type != WatchEventType.Bookmark && EventReceived != null) EventReceived(this, e.Type, e.Object);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    if (Error != null) Error(this, ex, null);
+                    try { await Task.Delay(OpenRetryTime, cts.Token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { }
+                }
+                finally
+                {
+                    if (wasOpen && Closed != null) Closed(this);
+                }
+            }
+        }
+
+        async Task ReportErrorAndWait(KubernetesResponse response)
+        {
+            if (Error != null) Error(this, null, await response.GetStatusAsync().ConfigureAwait(false));
+            await Task.Delay(OpenRetryTime, cts.Token).ConfigureAwait(false); // and wait before trying again
+        }
+
+        readonly KubernetesRequest req;
+        CancellationTokenSource cts;
+        Task task;
+    }
+    #endregion
+
+    #region WatchEvent
+    /// <summary>Represents an event from a watch stream.</summary>
+    public sealed class WatchEvent<T>
+    {
+        /// <summary>Gets or sets the <see cref="WatchEventType"/>.</summary>
+        public WatchEventType Type { get; set; }
+
+        /// <summary>Gets or sets the error that occurred, if the <see cref="Type"/> is <see cref="WatchEventType.Error"/>.</summary>
+        public V1Status Error { get; set; }
+
+        /// <summary>Gets or sets object that the event applies to, if the <see cref="Type"/> is not <see cref="WatchEventType.Error"/>.</summary>
+        public T Object { get; set; }
+    }
+    #endregion
+
+    #region WatchReader
+    /// <summary>Represents a stream of watch events.</summary>
+    /// <typeparam name="T">The type of items to watch</typeparam>
+    public sealed class WatchReader<T> : IDisposable
+    {
+        /// <summary>Initializes a new <see cref="WatchReader{T}"/> from a <see cref="KubernetesResponse"/> containing a watch stream.</summary>
+        public WatchReader(KubernetesResponse response) : this((response ?? throw new ArgumentNullException(nameof(response))).Message) { }
+
+        /// <summary>Initializes a new <see cref="WatchReader{T}"/> from a <see cref="HttpResponseMessage"/> containing a watch stream.</summary>
+        public WatchReader(HttpResponseMessage response)
+        {
+            Response = response ?? throw new ArgumentNullException(nameof(response));
+            if(response.Content == null && !IsError) throw new ArgumentException("The response has no content.");
+        }
+
+        /// <summary>Initializes a new <see cref="WatchReader{T}"/> from a <see cref="Stream"/> containing a watch stream.</summary>
+        public WatchReader(Stream stream) => CreateReader(stream ?? throw new ArgumentNullException(nameof(stream)));
+
+        /// <summary>Indicates whether the request failed and so the <see cref="Response"/> does not contain a valid watch stream.</summary>
+        public bool IsError => Response != null && (int)Response.StatusCode >= 400;
+
+        /// <summary>Gets the underlying <see cref="HttpResponseMessage"/>, or null if the watch reader was initialized from a <see cref="Stream"/>.</summary>
+        public HttpResponseMessage Response { get; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            streamReader?.Dispose();
+            Response?.Dispose();
+        }
+
+        /// <summary>Reads the next <see cref="WatchEvent{T}"/> from the stream, or returns null if the stream was closed or
+        /// <see cref="IsError"/> is true.
+        /// </summary>
+        public async Task<WatchEvent<T>> ReadAsync(CancellationToken cancelToken = default)
+        {
+            if (IsError) return null;
+            cancelToken.ThrowIfCancellationRequested();
+            if (reader == null) CreateReader(await Response.Content.ReadAsStreamAsync().ConfigureAwait(false));
+            try
+            {
+                streamReader.CancelToken = cancelToken;
+#if NETCOREAPP2_1
+                if (!await reader.ReadAsync(cancelToken).ConfigureAwait(false)) return null; // wait for the next event
+#else
+                if (!reader.Read()) return null; // wait for the next event
+#endif
+            }
+            catch (IOException ex) when (ex.InnerException is WebException wex && wex.Status == WebExceptionStatus.RequestCanceled)
+            {
+                throw new OperationCanceledException("The watch read was canceled.", ex.InnerException, cancelToken);
+            }
+
+            // deserialize the watch event
+            var e = new WatchEvent<T>();
+            for (bool gotType = false;;)
+            {
+                reader.Read(); // move to the next property, if any
+                if (reader.TokenType != JsonToken.PropertyName) break;
+                string name = (string)reader.Value;
+                reader.Read(); // move to the property value
+                if (name == "type")
+                {
+                    e.Type = (WatchEventType)Enum.Parse(typeof(WatchEventType), (string)reader.Value, true);
+                    gotType = true;
+                }
+                else if (name == "object")
+                {
+                    if (!gotType) throw new JsonSerializationException("Expected type property before object.");
+                    if (e.Type != WatchEventType.Error) e.Object = serializer.Deserialize<T>(reader);
+                    else e.Error = serializer.Deserialize<V1Status>(reader);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+            return e;
+        }
+
+        #region CancelableStreamReader
+        // HACK: annoyingly, the TextReader interface doesn't support cancellation of async reads outside .NET core. furthermore, Json.NET
+        // doesn't support cancellation even in several versions of .NET core. so we have this hacky TextReader that attempts cancellation
+        sealed class CancelableStreamReader : TextReader
+        {
+            public CancelableStreamReader(Stream stream) => this.stream = stream;
+
+            // the CancellationToken used to cancel reads
+            public CancellationToken CancelToken { get; set; }
+
+            public override int Peek() => EnsureData() ? charBuffer[charRead] : -1;
+            public override int Read() => EnsureData() ? charBuffer[charRead++] : -1;
+            public override int Read(char[] buffer, int index, int count) => Read(buffer, index, count, false);
+
+#if NETCOREAPP2_1
+            public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken _) => ReadAsync(buffer, false);
+
+            public override Task<int> ReadAsync(char[] buffer, int index, int count) =>
+                ReadAsync(buffer.AsMemory(index, count), false).AsTask();
+
+            public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken _) => ReadAsync(buffer, true);
+
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) =>
+                ReadAsync(buffer.AsMemory(index, count), true).AsTask();
+#else
+            public override Task<int> ReadAsync(char[] buffer, int index, int count) => ReadAsync(buffer, index, count, false);
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) => ReadAsync(buffer, index, count, true);
+#endif
+
+            public override string ReadToEnd()
+            {
+                var sb = new System.Text.StringBuilder(4096);
+                while(EnsureData())
+                {
+                    sb.Append(charBuffer, charRead, charWrite-charRead);
+                    charRead = charWrite;
+                }
+                return sb.ToString();
+            }
+
+            public async override Task<string> ReadToEndAsync()
+            {
+                var sb = new System.Text.StringBuilder(4096);
+                while(await EnsureDataAsync().ConfigureAwait(false))
+                {
+                    sb.Append(charBuffer, charRead, charWrite-charRead);
+                    charRead = charWrite;
+                }
+                return sb.ToString();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                stream?.Dispose();
+            }
+
+            bool EnsureData()
+            {
+                if (charRead == charWrite)
+                {
+                    charRead = charWrite = 0;
+                    do
+                    {
+                        int bytesRead;
+                        try { bytesRead = stream.ReadAsync(byteBuffer, 0, byteBuffer.Length, CancelToken).GetAwaiter().GetResult(); }
+                        catch (OperationCanceledException) { bytesRead = 0; } // non-async callers aren't expecting OperationCanceledException
+                        if (bytesRead == 0) return false;
+                        charWrite = decoder.GetChars(byteBuffer, 0, bytesRead, charBuffer, 0);
+                    } while(charWrite == 0);
+                }
+                return true;
+            }
+
+            async Task<bool> EnsureDataAsync()
+            {
+                if (charRead == charWrite)
+                {
+                    CancelToken.ThrowIfCancellationRequested();
+                    charRead = charWrite = 0;
+                    do
+                    {
+                        int bytesRead = await stream.ReadAsync(byteBuffer, 0, byteBuffer.Length, CancelToken).ConfigureAwait(false);
+                        if (bytesRead == 0) return false;
+                        charWrite = decoder.GetChars(byteBuffer, 0, bytesRead, charBuffer, 0);
+                    } while(charWrite == 0);
+                }
+                return true;
+            }
+
+            int Read(char[] buffer, int index, int count, bool block)
+            {
+                int start = index;
+                while(count != 0 && EnsureData())
+                {
+                    int toRead = Math.Min(count, charWrite-charRead);
+                    Array.Copy(charBuffer, charRead, buffer, index, toRead);
+                    charRead += toRead;
+                    index += toRead;
+                    if (!block) break;
+                    count -= toRead;
+                }
+                return index - start;
+            }
+
+#if NETCOREAPP2_1
+            async ValueTask<int> ReadAsync(Memory<char> buffer, bool block)
+            {
+                int totalRead = 0;
+                while(buffer.Length != 0 && (charRead != charWrite || await EnsureDataAsync().ConfigureAwait(false)))
+                {
+                    int toRead = Math.Min(buffer.Length, charWrite-charRead);
+                    charBuffer.AsMemory(0, toRead).CopyTo(buffer);
+                    totalRead += toRead;
+                    charRead += toRead;
+                    if (!block) break;
+                    buffer = buffer.Slice(toRead);
+                }
+                return totalRead;
+            }
+#else
+            async Task<int> ReadAsync(char[] buffer, int index, int length, bool block)
+            {
+                int start = index;
+                while(length != 0 && (charRead != charWrite || await EnsureDataAsync().ConfigureAwait(false)))
+                {
+                    int toRead = Math.Min(length, charWrite-charRead);
+                    Array.Copy(charBuffer, 0, buffer, index, toRead);
+                    charRead += toRead;
+                    index += toRead;
+                    if (!block) break;
+                    length -= toRead;
+                }
+                return index - start;
+            }
+#endif
+
+            readonly Stream stream;
+            readonly System.Text.Decoder decoder = System.Text.Encoding.UTF8.GetDecoder();
+            readonly char[] charBuffer = new char[4096];
+            readonly byte[] byteBuffer = new byte[4096];
+            int charRead, charWrite;
+        }
+#endregion
+
+        void CreateReader(Stream stream)
+        {
+            streamReader = new CancelableStreamReader(stream);
+            reader = new JsonTextReader(streamReader);
+            reader.SupportMultipleContent = true; // we'll be reading multiple objects out of the stream
+            serializer = JsonSerializer.Create(Kubernetes.DefaultJsonSettings);
+        }
+
+        JsonTextReader reader;
+        JsonSerializer serializer;
+        CancelableStreamReader streamReader;
+    }
+#endregion
+}

--- a/src/KubernetesClient/Watch.cs
+++ b/src/KubernetesClient/Watch.cs
@@ -158,7 +158,7 @@ namespace k8s
                                     {
                                         if (item.ApiVersion == null) item.ApiVersion = guessedApiVersion;
                                         if (item.Kind == null) item.Kind = guessedKind;
-                                        EventReceived(this, WatchEventType.Added, item);
+                                        EventReceived?.Invoke(this, WatchEventType.Added, item);
                                     }
                                 }
                                 InitialListSent?.Invoke(this);
@@ -298,18 +298,10 @@ namespace k8s
             bool gotType = false, gotObject = false;
             while (true)
             {
-#if !NET452
-                if (!await reader.ReadAsync(cancelToken).ConfigureAwait(false)) throw EOFError(); // move to the next property, if any
-#else
                 if (!reader.Read()) throw EOFError(); // move to the next property, if any
-#endif
                 if (reader.TokenType != JsonToken.PropertyName) break;
                 string name = (string)reader.Value;
-#if !NET452
-                if (!await reader.ReadAsync(cancelToken).ConfigureAwait(false)) throw EOFError(); // move to the property value
-#else
                 if (!reader.Read()) throw EOFError(); // move to the property value
-#endif
                 if (name == "type")
                 {
                     e.Type = (WatchEventType)Enum.Parse(typeof(WatchEventType), (string)reader.Value, true);
@@ -324,11 +316,7 @@ namespace k8s
                 }
                 else
                 {
-#if !NET452
-                    await reader.SkipAsync(cancelToken).ConfigureAwait(false); // move to the next property, if any
-#else
                     reader.Skip(); // move to the next property, if any
-#endif
                 }
             }
             if (!gotObject) throw new JsonSerializationException("The stream does not appear to contain watch events.");

--- a/src/KubernetesClient/Watch.cs
+++ b/src/KubernetesClient/Watch.cs
@@ -39,7 +39,7 @@ namespace k8s
                 }
                 else if (req.Name() != null && req.Subresource() == null)
                 {
-                    if(req.FieldSelector() == null) req.OldStyleWatch(false).FieldSelector("metadata.name="+req.Name()).Name(null);
+                    if (req.FieldSelector() == null) req.OldStyleWatch(false).FieldSelector("metadata.name="+req.Name()).Name(null);
                     else req.OldStyleWatch(true);
                 }
             }
@@ -251,7 +251,7 @@ namespace k8s
         public WatchReader(HttpResponseMessage response)
         {
             Response = response ?? throw new ArgumentNullException(nameof(response));
-            if(response.Content == null && !IsError) throw new ArgumentException("The response has no content.");
+            if (response.Content == null && !IsError) throw new ArgumentException("The response has no content.");
         }
 
         /// <summary>Initializes a new <see cref="WatchReader{T}"/> from a <see cref="Stream"/> containing a watch stream.</summary>
@@ -317,7 +317,7 @@ namespace k8s
                     reader.Skip();
                 }
             }
-            if(!gotType) throw new JsonSerializationException("The stream does not appear to contain watch events.");
+            if (!gotType) throw new JsonSerializationException("The stream does not appear to contain watch events.");
             return e;
         }
 

--- a/src/KubernetesClient/Watcher.cs
+++ b/src/KubernetesClient/Watcher.cs
@@ -10,16 +10,26 @@ using Microsoft.Rest.Serialization;
 
 namespace k8s
 {
+    #region WatchEventType
+    /// <summary>Describes the type of a watch event.</summary>
     public enum WatchEventType
     {
-        [EnumMember(Value = "ADDED")] Added,
-
-        [EnumMember(Value = "MODIFIED")] Modified,
-
-        [EnumMember(Value = "DELETED")] Deleted,
-
-        [EnumMember(Value = "ERROR")] Error
+        /// <summary>Emitted when an object is created, modified to match a watch's filter, or when a watch is first opened.</summary>
+        [EnumMember(Value="ADDED")] Added,
+        /// <summary>Bookmarks may be emitted periodically to update the resource version. The object will
+        /// contain only the resource version.
+        /// </summary>
+        [EnumMember(Value="BOOKMARK")] Bookmark,
+        /// <summary>Emitted when an object is deleted or modified to no longer match a watch's filter.</summary>
+        [EnumMember(Value="DELETED")] Deleted,
+        /// <summary>Emitted when an error occurs while watching resources. Most commonly, the error is 410 Gone which indicates that
+        /// the watch resource version was outdated.
+        /// </summary>
+        [EnumMember(Value="ERROR")] Error,
+        /// <summary>Emitted when an object is modified.</summary>
+        [EnumMember(Value="MODIFIED")] Modified
     }
+    #endregion
 
     public class Watcher<T> : IDisposable
     {

--- a/tests/KubernetesClient.Tests/FluentWatchTests.cs
+++ b/tests/KubernetesClient.Tests/FluentWatchTests.cs
@@ -118,7 +118,7 @@ namespace k8s.Tests
                 w.Closed += _ => closeCount++;
                 w.Error += (_, ex, err) => error = err;
                 w.EventReceived += (_, t, o) => events.Add(new WatchEvent<V1Pod>() { Type = t, Object = o });
-                w.InitialList += _ => initialListCount++;
+                w.InitialListSent += _ => initialListCount++;
                 w.Opened += _ => openCount++;
                 w.Reset += _ => resetCount++;
 
@@ -258,7 +258,7 @@ namespace k8s.Tests
                 w.Closed += _ => closeCount++;
                 w.Error += (_, ex, err) => error = err;
                 w.EventReceived += (_, t, o) => events.Add(new WatchEvent<V1Pod>() { Type = t, Object = o });
-                w.InitialList += _ => initialListCount++;
+                w.InitialListSent += _ => initialListCount++;
                 w.Opened += _ => openCount++;
                 w.Reset += _ => resetCount++;
 

--- a/tests/KubernetesClient.Tests/FluentWatchTests.cs
+++ b/tests/KubernetesClient.Tests/FluentWatchTests.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using k8s.Tests.Mock;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class FluentWatchTests
+    {
+        [Fact]
+        public async Task TestWatchReader()
+        {
+            Assert.True(new WatchReader<V1Pod>(new KubernetesResponse(new HttpResponseMessage(HttpStatusCode.BadRequest))).IsError);
+
+            for (int i = 0; i < 2; i++) // run twice, once using a Stream and again using an HttpResponseMessage
+            {
+                using (var stream = new PipeStream())
+                {
+                    var respMsg = i == 0 ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) } : null;
+                    var events = new BlockingCollection<WatchEvent<V1Pod>>();
+                    var cts = new CancellationTokenSource();
+                    using (var wr = i == 0 ? new WatchReader<V1Pod>(new KubernetesResponse(respMsg)) : new WatchReader<V1Pod>(stream))
+                    {
+                        Assert.False(wr.IsError);
+
+                        Task task = Task.Run(async () => // start a background task to read items from the watch
+                        {
+                            WatchEvent<V1Pod> we;
+                            try
+                            {
+                                while ((we = await wr.ReadAsync(cts.Token)) != null) events.Add(we);
+                            }
+                            catch (OperationCanceledException) { }
+                            events.CompleteAdding();
+                        });
+
+                        void writeEvent(WatchEventType t, object o) =>
+                            stream.QueueData(Encoding.UTF8.GetBytes(
+                                new JObject(new JProperty("type", t.ToString()), new JProperty("object", JObject.FromObject(o))).ToString()));
+
+                        WatchEvent<V1Pod> e;
+                        Assert.False(events.TryTake(out e, 100));
+
+                        var pod = new V1Pod() { ApiVersion = "v1", Kind = "Pod" };
+                        pod.Metadata = new V1ObjectMeta() { Name = "pod", NamespaceProperty = "ns", ResourceVersion = "1", Uid = "id" };
+                        pod.Spec = new V1PodSpec();
+                        writeEvent(WatchEventType.Added, pod);
+                        pod.SetLabel("a", "b");
+                        pod.Metadata.ResourceVersion = "2";
+                        writeEvent(WatchEventType.Modified, pod);
+                        pod.Metadata.ResourceVersion = "3";
+                        pod.Spec = null;
+                        writeEvent(WatchEventType.Bookmark, pod);
+                        writeEvent(WatchEventType.Deleted, pod);
+                        writeEvent(WatchEventType.Error, new V1Status() { Status = "Failure", Code = 410, Reason = "Gone" });
+
+                        Assert.True(events.TryTake(out e, 1000));
+                        Assert.Equal(WatchEventType.Added, e.Type);
+                        Assert.Equal("1", e.Object.ResourceVersion());
+                        Assert.True(events.TryTake(out e, 1000));
+                        Assert.Equal(WatchEventType.Modified, e.Type);
+                        Assert.Equal("2", e.Object.ResourceVersion());
+                        Assert.Equal("b", e.Object.GetLabel("a"));
+                        Assert.True(events.TryTake(out e, 1000));
+                        Assert.Equal(WatchEventType.Bookmark, e.Type);
+                        Assert.Equal("3", e.Object.ResourceVersion());
+                        Assert.True(events.TryTake(out e, 1000));
+                        Assert.Equal(WatchEventType.Deleted, e.Type);
+                        Assert.Equal("3", e.Object.ResourceVersion());
+                        Assert.True(events.TryTake(out e, 1000));
+                        Assert.Null(e.Object);
+                        Assert.Equal("Failure", e.Error.Status);
+                        Assert.Equal(410, e.Error.Code.Value);
+
+                        cts.Cancel();
+                        await task;
+                        Assert.False(events.TryTake(out e));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestSingleItemWatch()
+        {
+            Pipe pipe = null;
+            void writeEvent(WatchEventType t, object o) =>
+                pipe.Write(Encoding.UTF8.GetBytes(
+                    new JObject(new JProperty("type", t.ToString()), new JProperty("object", JObject.FromObject(o))).ToString()));
+
+            var pipeResetEvent = new AutoResetEvent(false);
+            PipeStream stream = null;
+            var handler = new MockHttpHandler(_ =>
+            {
+                pipe = new Pipe();
+                pipeResetEvent.Set();
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream = new PipeStream(pipe, true)) };
+            });
+
+            var c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost" }, new HttpClient(handler));
+            Assert.True(c.Request<V1Pod>("ns").ToWatch<V1Pod>().IsListWatch);
+            Assert.False(c.Request<V1Pod>("ns", "name").ToWatch<V1Pod>().IsListWatch);
+
+            using (var w = new Watch<V1Pod>(c.Request<V1Pod>("ns", "name")) { OpenRetryTime = TimeSpan.FromSeconds(0.1) })
+            {
+                var events = new BlockingCollection<WatchEvent<V1Pod>>();
+                V1Status error = null;
+                int closeCount = 0, openCount = 0, resetCount = 0;
+                w.Closed += _ => closeCount++;
+                w.Error += (_, ex, err) => error = err;
+                w.EventReceived += (_, t, o) => events.Add(new WatchEvent<V1Pod>() { Type = t, Object = o });
+                w.Opened += _ => openCount++;
+                w.Reset += _ => resetCount++;
+
+                var cts = new CancellationTokenSource();
+                Task runTask = w.Run(cts.Token);
+                Assert.Null(w.LastVersion);
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the initial connection
+
+                // add some events and check that we receive them all
+                var pod = c.New<V1Pod>("ns", "name");
+                (pod.Metadata.ResourceVersion, pod.Metadata.Uid) = ("1", "id");
+                writeEvent(WatchEventType.Added, pod);
+                Assert.True(events.TryTake(out WatchEvent<V1Pod> we, 5000));
+                Assert.Equal("ns", we.Object.Namespace());
+                Assert.Equal("name", we.Object.Name());
+                Assert.Equal("1", we.Object.ResourceVersion());
+                Assert.Equal("id", we.Object.Uid());
+                Assert.False(events.TryTake(out we, 100));
+
+                pod.SetLabel("x", "y");
+                pod.Metadata.ResourceVersion = "2";
+                writeEvent(WatchEventType.Modified, pod);
+                pod.Metadata.ResourceVersion = "3";
+                writeEvent(WatchEventType.Bookmark, pod);
+                pod.Metadata.ResourceVersion = "4";
+                writeEvent(WatchEventType.Deleted, pod);
+
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type);
+                Assert.Equal("2", we.Object.ResourceVersion());
+
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Deleted, we.Type); // the bookmark should not be emitted
+                Assert.Equal("4", we.Object.ResourceVersion());
+
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal("4", w.LastVersion);
+                Assert.Equal(0, closeCount);
+                Assert.Equal(1, openCount);
+                Assert.Equal(1, resetCount);
+
+                // now issue a 410 Gone error and see that it's processed correctly
+                writeEvent(WatchEventType.Error, new V1Status() { Status = "Failure", Code = 410 });
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the next open call
+                Assert.Null(w.LastVersion);
+                writeEvent(WatchEventType.Added, pod);
+                Assert.True(events.TryTake(out we, 1000));
+                Assert.Equal(WatchEventType.Added, we.Type);
+                Assert.Equal("4", we.Object.ResourceVersion());
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal(1, closeCount);
+                Assert.Equal(2, openCount);
+                Assert.Equal(2, resetCount);
+                Assert.Equal("4", w.LastVersion);
+                Assert.Null(error); // 410 Gone errors are "normal" errors and aren't reported
+
+                // now issue a 500 Internal Server Error and see that it does get reported
+                writeEvent(WatchEventType.Error, new V1Status() { Status = "Failure", Code = 500 });
+                writeEvent(WatchEventType.Modified, pod);
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type);
+                Assert.Equal("4", we.Object.ResourceVersion());
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal(1, closeCount); // it should not cause a reconnection
+                Assert.Equal(2, openCount);
+                Assert.Equal(2, resetCount);
+                Assert.Equal("4", w.LastVersion);
+                Assert.NotNull(error);
+                Assert.Equal(500, error.Code.Value);
+
+                // now close the connection and ensure it gets reopened
+                error = null;
+                stream.Close();
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the reconnection
+                Assert.Equal("4", w.LastVersion);
+                writeEvent(WatchEventType.Modified, pod);
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type);
+                Assert.Equal("4", we.Object.ResourceVersion());
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal(2, closeCount);
+                Assert.Equal(3, openCount);
+                Assert.Equal(2, resetCount); // the version should not be reset
+                Assert.Null(error);
+
+                // test graceful shutdown
+                cts.Cancel();
+                await runTask;
+            }
+        }
+
+        [Fact]
+        public async Task TestListWatch()
+        {
+            Pipe pipe = null;
+            void writeEvent(WatchEventType t, object o) =>
+                pipe.Write(Encoding.UTF8.GetBytes(
+                    new JObject(new JProperty("type", t.ToString()), new JProperty("object", JObject.FromObject(o))).ToString()));
+
+            var pipeResetEvent = new AutoResetEvent(false);
+            PipeStream stream = null;
+            var pods = new V1PodList() { Items = new List<V1Pod>(), Metadata = new V1ListMeta() };
+            var handler = new MockHttpHandler(req =>
+            {
+                if (req.RequestUri.Query.Contains("watch=1")) // if it's a watch request...
+                {
+                    pipe = new Pipe();
+                    pipeResetEvent.Set();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream = new PipeStream(pipe, true)) };
+                }
+                else // otherwise, it's a request for the initial list
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(pods)) };
+                }
+            });
+
+            var c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost" }, new HttpClient(handler));
+
+            var pod1 = c.New<V1Pod>("ns", "name1");
+            (pod1.Metadata.ResourceVersion, pod1.Metadata.Uid) = ("10", "id1");
+            var pod2 = c.New<V1Pod>("ns", "name2");
+            (pod2.Metadata.ResourceVersion, pod2.Metadata.Uid) = ("1", "id2");
+            pods.Items.Add(pod1);
+            pods.Items.Add(pod2);
+            pods.Metadata.ResourceVersion = "10";
+
+            using (var w = new Watch<V1Pod>(c.Request<V1Pod>("ns")) { OpenRetryTime = TimeSpan.FromSeconds(0.1) })
+            {
+                var events = new BlockingCollection<WatchEvent<V1Pod>>();
+                V1Status error = null;
+                int closeCount = 0, openCount = 0, resetCount = 0;
+                w.Closed += _ => closeCount++;
+                w.Error += (_, ex, err) => error = err;
+                w.EventReceived += (_, t, o) => events.Add(new WatchEvent<V1Pod>() { Type = t, Object = o });
+                w.Opened += _ => openCount++;
+                w.Reset += _ => resetCount++;
+
+                var cts = new CancellationTokenSource();
+                Task runTask = w.Run(cts.Token);
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the initial connection
+
+                // check that we received the initial events from the list
+                Assert.True(events.TryTake(out WatchEvent<V1Pod> we, 5000));
+                Assert.Equal("ns", we.Object.Namespace());
+                Assert.Equal("name1", we.Object.Name());
+                Assert.Equal("10", we.Object.ResourceVersion());
+                Assert.Equal("id1", we.Object.Uid());
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal("ns", we.Object.Namespace());
+                Assert.Equal("name2", we.Object.Name());
+                Assert.Equal("1", we.Object.ResourceVersion());
+                Assert.Equal("id2", we.Object.Uid());
+                Assert.Equal("10", w.LastVersion);
+                Assert.False(events.TryTake(out we, 100));
+
+                pod2.SetLabel("x", "y");
+                pod2.Metadata.ResourceVersion = "11";
+                writeEvent(WatchEventType.Modified, pod2);
+                pod2.Metadata.ResourceVersion = "12";
+                writeEvent(WatchEventType.Bookmark, pod2);
+                pod2.Metadata.ResourceVersion = "13";
+                writeEvent(WatchEventType.Deleted, pod2);
+
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type);
+                Assert.Equal("11", we.Object.ResourceVersion());
+
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Deleted, we.Type); // the bookmark should not be emitted
+                Assert.Equal("13", we.Object.ResourceVersion());
+
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal("13", w.LastVersion);
+                Assert.Equal(0, closeCount);
+                Assert.Equal(1, openCount);
+                Assert.Equal(1, resetCount);
+
+                // now issue a 410 Gone error and see that it's processed correctly
+                pods.Metadata.ResourceVersion = "13";
+                writeEvent(WatchEventType.Error, new V1Status() { Status = "Failure", Code = 410 });
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the next open call
+                Assert.True(events.TryTake(out we, 1000)); // we should get events from the initial list
+                Assert.Equal(WatchEventType.Added, we.Type);
+                Assert.Equal("10", we.Object.ResourceVersion());
+                Assert.True(events.TryTake(out we, 1000));
+                Assert.Equal(WatchEventType.Added, we.Type);
+                Assert.Equal("13", we.Object.ResourceVersion());
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal(1, closeCount);
+                Assert.Equal(2, openCount);
+                Assert.Equal(2, resetCount);
+                Assert.Equal("13", w.LastVersion);
+                Assert.Null(error); // 410 Gone errors are "normal" errors and aren't reported
+
+                // now issue a 500 Internal Server Error and see that it does get reported
+                writeEvent(WatchEventType.Error, new V1Status() { Status = "Failure", Code = 500 });
+                pod1.Metadata.ResourceVersion = "14";
+                writeEvent(WatchEventType.Modified, pod1);
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type); // we should not get events from the initial list
+                Assert.Equal("14", we.Object.ResourceVersion());
+                Assert.False(events.TryTake(out we, 100));
+                Assert.Equal(1, closeCount); // it should not cause a reconnection
+                Assert.Equal(2, openCount);
+                Assert.Equal(2, resetCount);
+                Assert.Equal("14", w.LastVersion);
+                Assert.NotNull(error);
+                Assert.Equal(500, error.Code.Value);
+
+                // now close the connection and ensure it gets reopened
+                error = null;
+                stream.Close();
+                Assert.True(pipeResetEvent.WaitOne(5000)); // wait for the reconnection
+                Assert.Equal("14", w.LastVersion);
+                pod1.Metadata.ResourceVersion = "15";
+                writeEvent(WatchEventType.Modified, pod1);
+                Assert.True(events.TryTake(out we, 5000));
+                Assert.Equal(WatchEventType.Modified, we.Type);
+                Assert.Equal("15", we.Object.ResourceVersion());
+                Assert.Equal("15", w.LastVersion);
+                Assert.False(events.TryTake(out we, 100)); // we should not get events from the initial list
+                Assert.Equal(2, closeCount);
+                Assert.Equal(3, openCount);
+                Assert.Equal(2, resetCount); // the version should not be reset
+                Assert.Null(error);
+
+                // test graceful shutdown
+                cts.Cancel();
+                await runTask;
+            }
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/Kubernetes.Fluent.Tests.cs
+++ b/tests/KubernetesClient.Tests/Kubernetes.Fluent.Tests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using k8s.Fluent;
 using k8s.Models;
 using k8s.Tests.Mock;
 using Newtonsoft.Json;

--- a/tests/KubernetesClient.Tests/Kubernetes.Fluent.Tests.cs
+++ b/tests/KubernetesClient.Tests/Kubernetes.Fluent.Tests.cs
@@ -1,0 +1,508 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class FluentTests
+    {
+        [Fact]
+        public void TestRequestProperties()
+        {
+            var testScheme = new KubernetesScheme();
+            var r = new KubernetesRequest(new Uri("http://somewhere"), new HttpClient(), testScheme);
+
+            // verify the initial values
+            Assert.Equal("application/json", r.Accept());
+            Assert.Null(r.Body());
+            Assert.False(r.DryRun());
+            Assert.Null(r.FieldManager());
+            Assert.Null(r.FieldSelector());
+            Assert.Null(r.Group());
+            Assert.Null(r.LabelSelector());
+            Assert.Equal("application/json", r.MediaType());
+            Assert.Same(HttpMethod.Get, r.Method());
+            Assert.Null(r.Name());
+            Assert.Null(r.Namespace());
+            Assert.Null(r.RawUri());
+            Assert.Same(testScheme, r.Scheme());
+            Assert.False(r.StreamResponse());
+            Assert.Null(r.Type());
+            Assert.Null(r.Version());
+            Assert.Null(r.WatchVersion());
+
+            // test basic value setters
+            r.Accept("foo/bar")
+                .Body("abc")
+                .DryRun(true)
+                .FieldManager("joe")
+                .FieldSelector("fs")
+                .Group("mygroup")
+                .LabelSelector("x=y")
+                .MediaType("bar/baz")
+                .Method(HttpMethod.Post)
+                .Name("name")
+                .Namespace("ns")
+                .RawUri("/anywhere")
+                .StreamResponse(true)
+                .Subresource("exec")
+                .Type("mytype")
+                .Version("v2")
+                .WatchVersion("42");
+            Assert.Equal("foo/bar", r.Accept());
+            Assert.Equal("abc", (string)r.Body());
+            Assert.True(r.DryRun());
+            Assert.Equal("joe", r.FieldManager());
+            Assert.Equal("fs", r.FieldSelector());
+            Assert.Equal("mygroup", r.Group());
+            Assert.Equal("x=y", r.LabelSelector());
+            Assert.Equal("bar/baz", r.MediaType());
+            Assert.Same(HttpMethod.Post, r.Method());
+            Assert.Equal("name", r.Name());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Equal("/anywhere", r.RawUri());
+            Assert.True(r.StreamResponse());
+            Assert.Equal("mytype", r.Type());
+            Assert.Equal("v2", r.Version());
+            Assert.Equal("42", r.WatchVersion());
+
+            // test value normalization
+            r.Accept("")
+                .FieldManager("")
+                .FieldSelector("")
+                .Group("")
+                .LabelSelector("")
+                .MediaType("")
+                .Method(null)
+                .Name("")
+                .Namespace("")
+                .RawUri("")
+                .Scheme(null)
+                .Subresource("")
+                .Type("")
+                .Version("")
+                .WatchVersion("");
+            Assert.Null(r.Accept());
+            Assert.Null(r.FieldManager());
+            Assert.Null(r.FieldSelector());
+            Assert.Null(r.Group());
+            Assert.Null(r.LabelSelector());
+            Assert.Null(r.MediaType());
+            Assert.Same(HttpMethod.Get, r.Method());
+            Assert.Null(r.Name());
+            Assert.Null(r.Namespace());
+            Assert.Null(r.RawUri());
+            Assert.Same(KubernetesScheme.Default, r.Scheme());
+            Assert.Null(r.Type());
+            Assert.Null(r.Version());
+            Assert.Equal("", r.WatchVersion());
+
+            // test exceptions from property setters
+            Assert.Throws<ArgumentException>(() => r.RawUri("foo"));
+
+            // test more advanced/specific setters
+            r.Delete();
+            Assert.Same(HttpMethod.Delete, r.Method());
+            r.Get();
+            Assert.Same(HttpMethod.Get, r.Method());
+            r.Patch();
+            Assert.Equal(new HttpMethod("PATCH"), r.Method());
+            r.Post();
+            Assert.Same(HttpMethod.Post, r.Method());
+            r.Put();
+            Assert.Same(HttpMethod.Put, r.Method());
+
+            r.Status();
+            Assert.Equal("status", r.Subresource());
+            r.Subresources("a", "b c");
+            Assert.Equal("a/b%20c", r.Subresource());
+
+            r.GVK<CustomNew>();
+            Assert.Equal("v3", r.Version());
+            Assert.Equal("cgrp", r.Group());
+            Assert.Equal("newz", r.Type());
+
+            r.GVK<CustomOld>();
+            Assert.Equal("v0", r.Version());
+            Assert.Equal("ogrp", r.Group());
+            Assert.Equal("nos", r.Type());
+
+            r.GVK("grp", "v1", "PigList");
+            Assert.Equal("v1", r.Version());
+            Assert.Equal("grp", r.Group());
+            Assert.Equal("pigs", r.Type());
+
+            r.GVK(new CustomOld());
+            Assert.Equal("v0", r.Version());
+            Assert.Equal("ogrp", r.Group());
+            Assert.Equal("nos", r.Type());
+
+            var res = new CustomNew() { ApiVersion = "coolstuff/v7", Kind = "yep", Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns" } };
+            r.GVK(res);
+            Assert.Equal("v7", r.Version());
+            Assert.Equal("coolstuff", r.Group());
+            Assert.Equal("newz", r.Type());
+            Assert.Null(r.Name());
+            Assert.Null(r.Namespace());
+
+            res.ApiVersion = "v7";
+            r.Body(null).Set(res, setBody: false);
+            Assert.Equal("v7", r.Version());
+            Assert.Null(r.Group());
+            Assert.Equal("newz", r.Type());
+            Assert.Null(r.Name());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Null(r.Body());
+
+            (res.ApiVersion, res.Metadata.Uid) = ("", "id");
+            r.Set(res);
+            Assert.Equal("v3", r.Version());
+            Assert.Equal("cgrp", r.Group());
+            Assert.Equal("newz", r.Type());
+            Assert.Equal("name", r.Name());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Same(res, r.Body());
+
+            // test with a custom scheme
+            var scheme = new KubernetesScheme();
+            scheme.SetGVK(typeof(CustomOld), "group", "version", "Custom", "customs");
+            r.Scheme(scheme).GVK<CustomOld>();
+            Assert.Equal("group", r.Group());
+            Assert.Equal("version", r.Version());
+            Assert.Equal("customs", r.Type());
+        }
+
+        [Fact]
+        public void TestRequestQuery()
+        {
+            var r = new KubernetesRequest(new Uri("http://somewhere"), new HttpClient());
+
+            // test basic query-string operations
+            Assert.Null(r.GetQuery("k"));
+            r.AddQuery("k", "y");
+            Assert.Equal("y", r.GetQuery("k"));
+            r.AddQuery("k", "x");
+            Assert.Throws<InvalidOperationException>(() => r.GetQuery("k"));
+            Assert.Equal(new[] { "y", "x" }, r.GetQueryValues("k"));
+            r.SetQuery("k", "z");
+            Assert.Equal("z", r.GetQuery("k"));
+            r.SetQuery("k2", "a").ClearQuery("k");
+            Assert.Null(r.GetQuery("k"));
+            Assert.Equal("a", r.GetQuery("k2"));
+            r.ClearQuery();
+            Assert.Null(r.GetQuery("k2"));
+            r.AddQuery("k", "a", "b");
+            Assert.Equal(new[] { "a", "b" }, r.GetQueryValues("k"));
+            r.SetQuery("k", "x");
+            Assert.Equal("x", r.GetQuery("k"));
+            r.SetQuery("k", null);
+            Assert.Null(r.GetQuery("k"));
+
+            // test property setters that work via the query string
+            r.DryRun(true).FieldManager("fm").FieldSelector("fs").LabelSelector("ls");
+            Assert.Equal("All", r.GetQuery("dryRun"));
+            Assert.Equal("fm", r.GetQuery("fieldManager"));
+            Assert.Equal("fs", r.GetQuery("fieldSelector"));
+            Assert.Equal("ls", r.GetQuery("labelSelector"));
+        }
+
+        [Fact]
+        public void TestRequestHeaders()
+        {
+            var r = new KubernetesRequest(new Uri("http://somewhere"), new HttpClient());
+
+            // test basic header operations
+            Assert.Null(r.GetHeader("k"));
+            r.AddHeader("k", "y");
+            Assert.Equal("y", r.GetHeader("k"));
+            r.AddHeader("k", "x");
+            Assert.Throws<InvalidOperationException>(() => r.GetHeader("k"));
+            Assert.Equal(new[] { "y", "x" }, r.GetHeaderValues("k"));
+            r.SetHeader("k", "z");
+            Assert.Equal("z", r.GetHeader("k"));
+            r.SetHeader("k2", "a").ClearHeader("k");
+            Assert.Null(r.GetHeader("k"));
+            Assert.Equal("a", r.GetHeader("k2"));
+            r.ClearHeaders();
+            Assert.Null(r.GetHeader("k2"));
+            r.AddHeader("k", "a", "b");
+            Assert.Equal(new[] { "a", "b" }, r.GetHeaderValues("k"));
+            r.SetHeader("k", "x");
+            Assert.Equal("x", r.GetHeader("k"));
+            r.SetHeader("k", null);
+            Assert.Null(r.GetHeader("k"));
+
+            // test exceptions
+            Assert.Null(r.GetHeader("Accept"));
+            Assert.Throws<ArgumentException>(() => r.AddHeader("Accept", "text/plain"));
+            Assert.Throws<ArgumentException>(() => r.AddHeader("Accept", Enumerable.Repeat("text/plain", 2)));
+            Assert.Throws<ArgumentException>(() => r.AddHeader("Accept", "text/plain", "text/fancy"));
+            Assert.Throws<ArgumentException>(() => r.ClearHeader("Content-Type"));
+            Assert.Throws<ArgumentException>(() => r.SetHeader("Content-Type", "text/plain"));
+        }
+
+        [Fact]
+        public async Task TestExecution()
+        {
+            var h = new MockHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"apiVersion\":\"xyz\"}") });
+            var c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080" }, new HttpClient(h));
+
+            await c.New<V1Pod>().AddHeader("Test", "yes").AddQuery("x", "a", "b c").Body("hello").ExecuteAsync();
+            Assert.Equal(HttpMethod.Get, h.Request.Method);
+            Assert.Equal(new Uri("http://localhost:8080/api/v1/pods?x=a&x=b%20c"), h.Request.RequestUri);
+            Assert.Equal("yes", h.Request.Headers.GetValues("Test").Single());
+            Assert.Equal("application/json", h.Request.Headers.Accept.ToString());
+            Assert.Equal("application/json; charset=UTF-8", h.Request.Content.Headers.ContentType.ToString());
+            Assert.Equal("hello", await h.Request.Content.ReadAsStringAsync());
+
+            var res = new CustomNew() { ApiVersion = "abc" };
+            await c.New<CustomNew>("ns", "name")
+                .Accept("text/plain").MediaType("text/rtf").Delete().DryRun(true).Body(res).Status().ExecuteAsync();
+            Assert.Equal(HttpMethod.Delete, h.Request.Method);
+            Assert.Equal(new Uri("http://localhost:8080/apis/cgrp/v3/namespaces/ns/newz/name/status?dryRun=All"), h.Request.RequestUri);
+            Assert.Equal("text/plain", h.Request.Headers.Accept.ToString());
+            Assert.Equal("text/rtf; charset=UTF-8", h.Request.Content.Headers.ContentType.ToString());
+            Assert.Equal("{\"apiVersion\":\"abc\"}", await h.Request.Content.ReadAsStringAsync());
+
+            await c.New().RawUri("/foobar").Post().LabelSelector("ls").WatchVersion("3").Body(Encoding.UTF8.GetBytes("bytes")).ExecuteAsync();
+            Assert.Equal(HttpMethod.Post, h.Request.Method);
+            Assert.Equal(new Uri("http://localhost:8080/foobar?labelSelector=ls&watch=1&resourceVersion=3"), h.Request.RequestUri);
+            Assert.Equal("bytes", await h.Request.Content.ReadAsStringAsync());
+
+            await c.New().RawUri("/foobar/").WatchVersion("").Body(new MemoryStream(Encoding.UTF8.GetBytes("streaming"))).ExecuteAsync();
+            Assert.Equal(new Uri("http://localhost:8080/foobar/?watch=1"), h.Request.RequestUri);
+            Assert.Equal("streaming", await h.Request.Content.ReadAsStringAsync());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => c.New().Name("x").RawUri("/y").ExecuteAsync()); // can't use raw and non-raw
+
+            c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080", AccessToken = "token" }, new HttpClient(h));
+            await c.New().ExecuteAsync();
+            Assert.Equal(new Uri("http://localhost:8080/api/v1/"), h.Request.RequestUri);
+            Assert.Equal("Bearer token", h.Request.Headers.Authorization.ToString());
+
+            c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080", Username = "joe" }, new HttpClient(h));
+            await c.New().ExecuteAsync();
+            Assert.Equal("Basic am9lOg==", h.Request.Headers.Authorization.ToString());
+
+            res = await c.New().ExecuteAsync<CustomNew>();
+            Assert.Equal("xyz", res.ApiVersion);
+
+            h = new MockHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") });
+            c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080" }, new HttpClient(h));
+            res = await c.New().ExecuteAsync<CustomNew>();
+            Assert.Null(res);
+            res = await c.New().ExecuteAsync<CustomNew>(failIfMissing: true); // missing only refers to 404 Not Found
+            Assert.Null(res);
+
+            h = new MockHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("{}") });
+            c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080" }, new HttpClient(h));
+            res = await c.New().ExecuteAsync<CustomNew>();
+            Assert.Null(res);
+            await Assert.ThrowsAsync<KubernetesException>(() => c.New().ExecuteAsync<CustomNew>(failIfMissing: true));
+
+            h = new MockHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("{}") });
+            c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080" }, new HttpClient(h));
+            await Assert.ThrowsAsync<KubernetesException>(() => c.New().ExecuteAsync<CustomNew>());
+        }
+
+        [Fact]
+        public void TestNew()
+        {
+            var c = new Kubernetes(new Uri("http://somewhere"), new Microsoft.Rest.TokenCredentials("token"), new MockHandler(null));
+            c.Scheme = new KubernetesScheme();
+            c.Scheme.SetGVK(typeof(CustomOld), "group", "version", "Custom", "customs");
+
+            // test New(HttpMethod = null)
+            var r = c.New();
+            Assert.Same(HttpMethod.Get, r.Method());
+            r = c.New(HttpMethod.Delete);
+            Assert.Same(HttpMethod.Delete, r.Method());
+
+            // test New(Type)
+            r = c.New(typeof(V1MutatingWebhookConfiguration));
+            Assert.Equal("admissionregistration.k8s.io", r.Group());
+            Assert.Equal("v1", r.Version());
+            Assert.Equal("mutatingwebhookconfigurations", r.Type());
+            r = c.New(typeof(CustomOld)); // ensure it defaults to the scheme from the client
+            Assert.Same(c.Scheme, r.Scheme());
+            Assert.Equal("group", r.Group());
+            Assert.Equal("version", r.Version());
+            Assert.Equal("customs", r.Type());
+
+            // test c.New(obj, bool)
+            var res = new CustomNew() { ApiVersion = "coolstuff/v7", Kind = "yep", Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns" } };
+            r = c.New(res);
+            Assert.Equal("coolstuff", r.Group());
+            Assert.Equal("v7", r.Version());
+            Assert.Equal("newz", r.Type());
+            Assert.Null(r.Name());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Same(res, r.Body());
+
+            res.Metadata.Uid = "id";
+            r = c.New(res, setBody: false);
+            Assert.Equal("name", r.Name());
+            Assert.Null(r.Body());
+
+            // test c.New(HttpMethod, Type, string, string)
+            r = c.New(null, typeof(V1PodList), "ns", "name");
+            Assert.Same(HttpMethod.Get, r.Method());
+            Assert.Null(r.Group());
+            Assert.Equal("v1", r.Version());
+            Assert.Equal("pods", r.Type());
+            Assert.Equal("name", r.Name());
+            Assert.Equal("ns", r.Namespace());
+            r = c.New(HttpMethod.Delete, typeof(V1PodList), "ns", "name");
+            Assert.Same(HttpMethod.Delete, r.Method());
+
+            // test c.New(HttpMethod, string, string, string, string, string)
+            r = c.New(HttpMethod.Put, "type", "ns", "name", "group", "version");
+            Assert.Same(HttpMethod.Put, r.Method());
+            Assert.Equal("type", r.Type());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Equal("name", r.Name());
+            Assert.Equal("group", r.Group());
+            Assert.Equal("version", r.Version());
+
+            // test c.New<T>(string, string)
+            c.Scheme = KubernetesScheme.Default;
+            r = c.New<CustomOld>("ns", "name");
+            Assert.Equal("v0", r.Version());
+            Assert.Equal("ogrp", r.Group());
+            Assert.Equal("nos", r.Type());
+            Assert.Equal("ns", r.Namespace());
+            Assert.Equal("name", r.Name());
+        }
+
+        [Fact]
+        public async Task TestReplace()
+        {
+            string value = "{}";
+            bool conflict = true;
+            var h = new MockHandler(req =>
+            {
+                if(value == null)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+                }
+                else if(req.Method == HttpMethod.Get)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(value) };
+                }
+                else if(req.Method == HttpMethod.Put)
+                {
+                    if(conflict)
+                    {
+                        conflict = false;
+                        return new HttpResponseMessage(HttpStatusCode.Conflict);
+                    }
+                    value = req.Content.ReadAsStringAsync().Result;
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(value) };
+                }
+                throw new Exception("i shouldn't exist");
+            });
+            var c = new Kubernetes(new KubernetesClientConfiguration() { Host = "http://localhost:8080" }, new HttpClient(h));
+
+            int i = 0;
+            var res = await c.New().ReplaceAsync<CustomNew>(r => { r.SetAnnotation("a", (i++).ToString(CultureInfo.InvariantCulture)); return true; });
+            Assert.Equal("1", res.GetAnnotation("a"));
+
+            res = await c.New().ReplaceAsync<CustomNew>(r => { r.SetAnnotation("b", "x"); return true; });
+            Assert.Equal("1", res.GetAnnotation("a"));
+            Assert.Equal("x", res.GetAnnotation("b"));
+
+            res = await c.New().ReplaceAsync<CustomNew>(r => { r.SetAnnotation("c", "y"); return false; });
+            Assert.Equal("x", res.GetAnnotation("b"));
+            Assert.Equal("y", res.GetAnnotation("c"));
+
+            res = await c.New().ReplaceAsync<CustomNew>(r => false);
+            Assert.Equal("x", res.GetAnnotation("b"));
+            Assert.Null(res.GetAnnotation("c"));
+
+            value = null;
+            res = await c.New().ReplaceAsync<CustomNew>(r => { r.SetAnnotation("a", "x"); return true; });
+            Assert.Null(res);
+        }
+
+        [Fact]
+        public async Task TestResponse()
+        {
+            var msg = new HttpResponseMessage(HttpStatusCode.Ambiguous) { Content = new StringContent("{\"ApiVersion\":\"123\"}") };
+            var resp = new KubernetesResponse(msg);
+            Assert.False(resp.IsError);
+            Assert.False(resp.IsNotFound);
+            Assert.Same(msg, resp.Message);
+            Assert.Equal(HttpStatusCode.Ambiguous, resp.StatusCode);
+            Assert.Equal("{\"ApiVersion\":\"123\"}", await resp.GetBodyAsync());
+            var cn = await resp.GetBodyAsync<CustomNew>();
+            Assert.Equal("123", cn.ApiVersion);
+            var status = await resp.GetStatusAsync();
+            Assert.Equal("Success", status.Status);
+            Assert.Equal((int)resp.StatusCode, status.Code.Value);
+            Assert.Equal("{\"ApiVersion\":\"123\"}", status.Message);
+
+            msg = new HttpResponseMessage(HttpStatusCode.NotFound);
+            resp = new KubernetesResponse(msg);
+            Assert.True(resp.IsError);
+            Assert.True(resp.IsNotFound);
+            Assert.Equal("", await resp.GetBodyAsync());
+            Assert.Null(await resp.GetBodyAsync<CustomNew>());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => resp.GetBodyAsync<CustomNew>(failIfEmpty: true));
+            status = await resp.GetStatusAsync();
+            Assert.Equal("Failure", status.Status);
+            Assert.Equal((int)resp.StatusCode, status.Code.Value);
+            Assert.Equal("", status.Message);
+
+            msg = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("It's bad, yo.") };
+            resp = new KubernetesResponse(msg);
+            Assert.True(resp.IsError);
+            Assert.False(resp.IsNotFound);
+            Assert.Equal("It's bad, yo.", await resp.GetBodyAsync());
+            await Assert.ThrowsAnyAsync<JsonException>(() => resp.GetBodyAsync<CustomNew>());
+            status = await resp.GetStatusAsync();
+            Assert.Equal("Failure", status.Status);
+            Assert.Equal((int)resp.StatusCode, status.Code.Value);
+            Assert.Equal("It's bad, yo.", status.Message);
+        }
+
+        [KubernetesEntity(ApiVersion = "v3", Group = "cgrp", Kind = "yes", PluralName = "newz")]
+        class CustomNew : IKubernetesObject<V1ObjectMeta>
+        {
+            public string ApiVersion { get; set; }
+            public string Kind { get; set; }
+            public V1ObjectMeta Metadata { get; set; }
+        }
+
+        class CustomOld : IKubernetesObject<V1ObjectMeta>
+        {
+            public const string KubeApiVersion = "v0", KubeGroup = "ogrp", KubeKind = "no";
+            public string ApiVersion { get; set; }
+            public string Kind { get; set; }
+            public V1ObjectMeta Metadata { get; set; }
+        }
+
+        class MockHandler : HttpClientHandler
+        {
+            public MockHandler(Func<HttpRequestMessage,HttpResponseMessage> respFunc) => this.respFunc = respFunc;
+
+            public HttpRequestMessage Request;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+                return Task.FromResult(respFunc(request));
+            }
+
+            readonly Func<HttpRequestMessage,HttpResponseMessage> respFunc;
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/KubernetesSchemeTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesSchemeTests.cs
@@ -1,0 +1,172 @@
+using System;
+using k8s.Models;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class KubernetesSchemeTests
+    {
+        [Fact]
+        public void TestGVK()
+        {
+            Assert.NotNull(KubernetesScheme.Default);
+
+            var s = new KubernetesScheme();
+
+            // test s.GetGVK
+            string g, v, k, p;
+            s.GetGVK<V1Pod>(out g, out v, out k, out p);
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("Pod", k);
+            Assert.Equal("pods", p);
+
+            s.GetGVK<V1PodList>(out g, out v, out k, out p);
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("PodList", k);
+            Assert.Equal("pods", p);
+
+            s.GetGVK<CustomNew>(out g, out v, out k, out p);
+            Assert.Equal("cgrp", g);
+            Assert.Equal("v3", v);
+            Assert.Equal("Yes", k);
+            Assert.Equal("newz", p);
+
+            s.GetGVK<CustomOld>(out g, out v, out k, out p);
+            Assert.Equal("ogrp", g);
+            Assert.Equal("v0", v);
+            Assert.Equal("No", k);
+            Assert.Equal("nos", p);
+
+            Assert.Throws<ArgumentException>(() => s.GetGVK<Custom>(out g, out v, out k));
+
+            // test s.GetVK
+            s.GetVK<V1Pod>(out v, out k, out p);
+            Assert.Equal("v1", v);
+            Assert.Equal("Pod", k);
+            Assert.Equal("pods", p);
+
+            s.GetVK<V1PodList>(out v, out k, out p);
+            Assert.Equal("v1", v);
+            Assert.Equal("PodList", k);
+            Assert.Equal("pods", p);
+
+            s.GetVK<CustomNew>(out v, out k, out p);
+            Assert.Equal("cgrp/v3", v);
+            Assert.Equal("Yes", k);
+            Assert.Equal("newz", p);
+
+            s.GetVK<CustomOld>(out v, out k, out p);
+            Assert.Equal("ogrp/v0", v);
+            Assert.Equal("No", k);
+            Assert.Equal("nos", p);
+
+            Assert.Throws<ArgumentException>(() => s.GetVK<Custom>(out v, out k));
+
+            // test s.TryGetGVK
+            Assert.True(s.TryGetGVK<V1Pod>(out g, out v, out k, out p));
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("Pod", k);
+            Assert.Equal("pods", p);
+
+            Assert.False(s.TryGetGVK<Custom>(out g, out v, out k, out p));
+
+            // test s.TryGetVK
+            Assert.True(s.TryGetVK<V1Pod>(out v, out k, out p));
+            Assert.Equal("v1", v);
+            Assert.Equal("Pod", k);
+            Assert.Equal("pods", p);
+
+            Assert.True(s.TryGetVK<CustomOld>(out v, out k, out p));
+            Assert.Equal("ogrp/v0", v);
+            Assert.Equal("No", k);
+            Assert.Equal("nos", p);
+
+            Assert.False(s.TryGetVK<Custom>(out v, out k, out p));
+
+            // test s.SetGVK and s.RemoveGVK
+            s.SetGVK<V1Pod>("g", "v", "k", "p");
+            s.GetVK<V1Pod>(out v, out k, out p);
+            Assert.Equal("g/v", v);
+            Assert.Equal("k", k);
+            Assert.Equal("p", p);
+
+            s.GetGVK<V1PodList>(out g, out v, out k, out p);
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("PodList", k);
+            Assert.Equal("pods", p);
+
+            s.SetGVK<Custom>("g2", "v2", "k2", "p2");
+            s.GetVK<Custom>(out v, out k, out p);
+            Assert.Equal("g2/v2", v);
+            Assert.Equal("k2", k);
+            Assert.Equal("p2", p);
+
+            s.RemoveGVK<V1Pod>();
+            s.GetGVK<V1Pod>(out g, out v, out k, out p);
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("Pod", k);
+            Assert.Equal("pods", p);
+
+            s.RemoveGVK<Custom>();
+            Assert.Throws<ArgumentException>(() => s.GetGVK<Custom>(out g, out v, out k));
+        }
+
+        [Fact]
+        public void TestNew()
+        {
+            var s = new KubernetesScheme();
+
+            var p = s.New<V1Pod>();
+            Assert.Equal("v1", p.ApiVersion);
+            Assert.Equal("Pod", p.Kind);
+
+            var cn = s.New<CustomNew>("name");
+            Assert.Equal("cgrp/v3", cn.ApiVersion);
+            Assert.Equal("Yes", cn.Kind);
+            Assert.Equal("name", cn.Metadata.Name);
+
+            var co = s.New<CustomOld>("ns", "name");
+            Assert.Equal("ogrp/v0", co.ApiVersion);
+            Assert.Equal("No", co.Kind);
+            Assert.Equal("name", co.Metadata.Name);
+            Assert.Equal("ns", co.Metadata.NamespaceProperty);
+
+            Assert.Throws<ArgumentException>(() => s.New<Custom>());
+            s.SetGVK<Custom>("g", "v", "k", "p");
+
+            var c = s.New<Custom>("ns", "name");
+            Assert.Equal("g/v", c.ApiVersion);
+            Assert.Equal("k", c.Kind);
+            Assert.Equal("name", c.Metadata.Name);
+            Assert.Equal("ns", c.Metadata.NamespaceProperty);
+        }
+
+        [KubernetesEntity(ApiVersion = "v3", Group = "cgrp", Kind = "Yes", PluralName = "newz")]
+        class CustomNew : IKubernetesObject<V1ObjectMeta>
+        {
+            public string ApiVersion { get; set; }
+            public string Kind { get; set; }
+            public V1ObjectMeta Metadata { get; set; }
+        }
+
+        class CustomOld : IKubernetesObject<V1ObjectMeta>
+        {
+            public const string KubeApiVersion = "v0", KubeGroup = "ogrp", KubeKind = "No";
+            public string ApiVersion { get; set; }
+            public string Kind { get; set; }
+            public V1ObjectMeta Metadata { get; set; }
+        }
+
+        class Custom : IKubernetesObject<V1ObjectMeta>
+        {
+            public string ApiVersion { get; set; }
+            public string Kind { get; set; }
+            public V1ObjectMeta Metadata { get; set; }
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/Mock/MockHttpHandler.cs
+++ b/tests/KubernetesClient.Tests/Mock/MockHttpHandler.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s.Tests.Mock
+{
+    class MockHttpHandler : HttpClientHandler
+    {
+        public MockHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> respFunc) => this.respFunc = respFunc;
+
+        public HttpRequestMessage Request;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(respFunc(request));
+        }
+
+        readonly Func<HttpRequestMessage, HttpResponseMessage> respFunc;
+    }
+}

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -1,0 +1,171 @@
+using System;
+using k8s.Models;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class ModelExtensionTests
+    {
+        [Fact]
+        public void TestMetadata()
+        {
+            // test getters on null metadata
+            var pod = new V1Pod();
+            Assert.Null(pod.Annotations());
+            Assert.Null(pod.ApiGroup());
+            var (g, v) = pod.ApiGroupAndVersion();
+            Assert.Null(g);
+            Assert.Null(v);
+            Assert.Null(pod.ApiGroupVersion());
+            Assert.Null(pod.CreationTimestamp());
+            Assert.Null(pod.DeletionTimestamp());
+            Assert.Null(pod.Finalizers());
+            Assert.Null(pod.Generation());
+            Assert.Null(pod.GetAnnotation("x"));
+            Assert.Null(pod.GetController());
+            Assert.Null(pod.GetLabel("x"));
+            Assert.False(pod.HasFinalizer("x"));
+            Assert.Null(pod.Labels());
+            Assert.Null(pod.Name());
+            Assert.Null(pod.Namespace());
+            Assert.Null(pod.OwnerReferences());
+            Assert.Null(pod.ResourceVersion());
+            Assert.Null(pod.Uid());
+            Assert.Null(pod.Metadata);
+
+            // test API version stuff
+            pod = new V1Pod() { ApiVersion = "v1" };
+            Assert.Equal("", pod.ApiGroup());
+            (g, v) = pod.ApiGroupAndVersion();
+            Assert.Equal("", g);
+            Assert.Equal("v1", v);
+            Assert.Equal("v1", pod.ApiGroupVersion());
+            pod.ApiVersion = "abc/v2";
+            Assert.Equal("abc", pod.ApiGroup());
+            (g, v) = pod.ApiGroupAndVersion();
+            Assert.Equal("abc", g);
+            Assert.Equal("v2", v);
+            Assert.Equal("v2", pod.ApiGroupVersion());
+
+            // test the Ensure*() functions
+            Assert.NotNull(pod.EnsureMetadata());
+            Assert.NotNull(pod.Metadata);
+            Assert.NotNull(pod.Metadata.EnsureAnnotations());
+            Assert.NotNull(pod.Metadata.Annotations);
+            Assert.NotNull(pod.Metadata.EnsureFinalizers());
+            Assert.NotNull(pod.Metadata.Finalizers);
+            Assert.NotNull(pod.Metadata.EnsureLabels());
+            Assert.NotNull(pod.Metadata.Labels);
+
+            // test getters with non-null values
+            DateTime ts = DateTime.UtcNow, ts2 = DateTime.Now;
+            pod.Metadata = new V1ObjectMeta()
+            {
+                CreationTimestamp = ts, DeletionTimestamp = ts2, Generation = 1, Name = "name", NamespaceProperty = "ns", ResourceVersion = "42", Uid = "id"
+            };
+            Assert.Equal(ts, pod.CreationTimestamp().Value);
+            Assert.Equal(ts2, pod.DeletionTimestamp().Value);
+            Assert.Equal(1, pod.Generation().Value);
+            Assert.Equal("name", pod.Name());
+            Assert.Equal("ns", pod.Namespace());
+            Assert.Equal("42", pod.ResourceVersion());
+            Assert.Equal("id", pod.Uid());
+
+            // test annotations and labels
+            pod.SetAnnotation("x", "y");
+            pod.SetLabel("a", "b");
+            Assert.Equal(1, pod.Annotations().Count);
+            Assert.Equal(1, pod.Labels().Count);
+            Assert.Equal("y", pod.GetAnnotation("x"));
+            Assert.Equal("y", pod.Metadata.Annotations["x"]);
+            Assert.Null(pod.GetAnnotation("a"));
+            Assert.Equal("b", pod.GetLabel("a"));
+            Assert.Equal("b", pod.Metadata.Labels["a"]);
+            Assert.Null(pod.GetLabel("x"));
+            pod.SetAnnotation("x", null);
+            Assert.Equal(0, pod.Annotations().Count);
+            pod.SetLabel("a", null);
+            Assert.Equal(0, pod.Labels().Count);
+
+            // test finalizers
+            Assert.False(pod.HasFinalizer("abc"));
+            Assert.True(pod.AddFinalizer("abc"));
+            Assert.True(pod.HasFinalizer("abc"));
+            Assert.False(pod.AddFinalizer("abc"));
+            Assert.False(pod.HasFinalizer("xyz"));
+            Assert.False(pod.RemoveFinalizer("xyz"));
+            Assert.True(pod.RemoveFinalizer("abc"));
+            Assert.False(pod.HasFinalizer("abc"));
+            Assert.False(pod.RemoveFinalizer("abc"));
+        }
+
+        [Fact]
+        public void TestReferences()
+        {
+            // test object references
+            var pod = new V1Pod() { ApiVersion = "abc/xyz", Kind = "sometimes" };
+            pod.Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns", ResourceVersion = "ver", Uid = "id" };
+            var objr = pod.GetObjectReference();
+            Assert.Equal(pod.ApiVersion, objr.ApiVersion);
+            Assert.Equal(pod.Kind, objr.Kind);
+            Assert.Equal(pod.Name(), objr.Name);
+            Assert.Equal(pod.Namespace(), objr.NamespaceProperty);
+            Assert.Equal(pod.ResourceVersion(), objr.ResourceVersion);
+            Assert.Equal(pod.Uid(), objr.Uid);
+            Assert.True(objr.Matches(pod));
+
+            (pod.ApiVersion, pod.Kind) = (null, null);
+            objr = pod.GetObjectReference();
+            Assert.Equal("v1", objr.ApiVersion);
+            Assert.Equal("Pod", objr.Kind);
+            Assert.False(objr.Matches(pod));
+            (pod.ApiVersion, pod.Kind) = (objr.ApiVersion, objr.Kind);
+            Assert.True(objr.Matches(pod));
+            pod.Metadata.Name = "nome";
+            Assert.False(objr.Matches(pod));
+
+            // test owner references
+            (pod.ApiVersion, pod.Kind) = ("abc/xyz", "sometimes");
+            var ownr = pod.CreateOwnerReference(true, false);
+            Assert.Equal(pod.ApiVersion, ownr.ApiVersion);
+            Assert.Equal(pod.Kind, ownr.Kind);
+            Assert.Equal(pod.Name(), ownr.Name);
+            Assert.Equal(pod.Uid(), ownr.Uid);
+            Assert.True(ownr.Controller.Value);
+            Assert.False(ownr.BlockOwnerDeletion.Value);
+            Assert.True(ownr.Matches(pod));
+
+            (pod.ApiVersion, pod.Kind) = (null, null);
+            Assert.False(ownr.Matches(pod));
+            ownr = pod.CreateOwnerReference();
+            Assert.Equal("v1", ownr.ApiVersion);
+            Assert.Equal("Pod", ownr.Kind);
+            Assert.Null(ownr.Controller);
+            Assert.Null(ownr.BlockOwnerDeletion);
+            Assert.False(ownr.Matches(pod));
+            (pod.ApiVersion, pod.Kind) = (ownr.ApiVersion, ownr.Kind);
+            Assert.True(ownr.Matches(pod));
+            ownr.Name = "nim";
+            Assert.False(ownr.Matches(pod));
+            ownr.Name = pod.Name();
+
+            var svc = new V1Service();
+            svc.AddOwnerReference(ownr);
+            Assert.Equal(0, svc.FindOwnerReference(pod));
+            Assert.Equal(-1, svc.FindOwnerReference(svc));
+            Assert.Null(svc.GetController());
+            svc.OwnerReferences()[0].Controller = true;
+            Assert.Same(ownr, svc.GetController());
+            Assert.Same(ownr, svc.RemoveOwnerReference(pod));
+            Assert.Equal(0, svc.OwnerReferences().Count);
+            svc.AddOwnerReference(pod.CreateOwnerReference(true));
+            svc.AddOwnerReference(pod.CreateOwnerReference(false));
+            svc.AddOwnerReference(pod.CreateOwnerReference());
+            Assert.Equal(3, svc.OwnerReferences().Count);
+            Assert.NotNull(svc.RemoveOwnerReference(pod));
+            Assert.Equal(2, svc.OwnerReferences().Count);
+            Assert.True(svc.RemoveOwnerReferences(pod));
+            Assert.Equal(0, svc.OwnerReferences().Count);
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -20,10 +20,12 @@ namespace k8s.Tests
             Assert.Null(pod.CreationTimestamp());
             Assert.Null(pod.DeletionTimestamp());
             Assert.Null(pod.Finalizers());
+            Assert.Equal(-1, pod.FindOwnerReference(r => true));
             Assert.Null(pod.Generation());
             Assert.Null(pod.GetAnnotation("x"));
             Assert.Null(pod.GetController());
             Assert.Null(pod.GetLabel("x"));
+            Assert.Null(pod.GetOwnerReference(r => true));
             Assert.False(pod.HasFinalizer("x"));
             Assert.Null(pod.Labels());
             Assert.Null(pod.Name());
@@ -105,7 +107,7 @@ namespace k8s.Tests
             // test object references
             var pod = new V1Pod() { ApiVersion = "abc/xyz", Kind = "sometimes" };
             pod.Metadata = new V1ObjectMeta() { Name = "name", NamespaceProperty = "ns", ResourceVersion = "ver", Uid = "id" };
-            var objr = pod.GetObjectReference();
+            var objr = pod.CreateObjectReference();
             Assert.Equal(pod.ApiVersion, objr.ApiVersion);
             Assert.Equal(pod.Kind, objr.Kind);
             Assert.Equal(pod.Name(), objr.Name);
@@ -115,7 +117,7 @@ namespace k8s.Tests
             Assert.True(objr.Matches(pod));
 
             (pod.ApiVersion, pod.Kind) = (null, null);
-            objr = pod.GetObjectReference();
+            objr = pod.CreateObjectReference();
             Assert.Equal("v1", objr.ApiVersion);
             Assert.Equal("Pod", objr.Kind);
             Assert.False(objr.Matches(pod));
@@ -153,6 +155,8 @@ namespace k8s.Tests
             svc.AddOwnerReference(ownr);
             Assert.Equal(0, svc.FindOwnerReference(pod));
             Assert.Equal(-1, svc.FindOwnerReference(svc));
+            Assert.Same(ownr, svc.GetOwnerReference(pod));
+            Assert.Null(svc.GetOwnerReference(svc));
             Assert.Null(svc.GetController());
             svc.OwnerReferences()[0].Controller = true;
             Assert.Same(ownr, svc.GetController());

--- a/tests/KubernetesClient.Tests/PipeStream.cs
+++ b/tests/KubernetesClient.Tests/PipeStream.cs
@@ -38,6 +38,7 @@ namespace k8s.Tests
                     if(set)
                     {
                         set = false;
+                        e.Reset();
                         break;
                     }
                 }
@@ -55,6 +56,7 @@ namespace k8s.Tests
                 if(set)
                 {
                     set = false;
+                    e.Reset();
                     return Task.CompletedTask;
                 }
             }

--- a/tests/KubernetesClient.Tests/PipeStream.cs
+++ b/tests/KubernetesClient.Tests/PipeStream.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s.Tests
+{
+    #region AsyncAutoResetEvent
+    /// <summary>Implements a synchronization event that, when signaled, resets automatically after releasing a single waiting thread
+    /// or task.
+    /// </summary>
+    sealed class AsyncAutoResetEvent : IDisposable
+    {
+        public AsyncAutoResetEvent() { }
+        public AsyncAutoResetEvent(bool initialState) => set = initialState;
+
+        public void Dispose() => e.Dispose(); // NOTE: waiters are not triggered when it's disposed, like the normal AutoResetEvent
+
+        /// <summary>Sets the event, releasing a waiting thread or task.</summary>
+        public void Set()
+        {
+            lock(e)
+            {
+                set = true;
+                e.Set();
+            }
+        }
+
+        /// <summary>Waits for the event to be set.</summary>
+        public void Wait()
+        {
+            while(true)
+            {
+                lock(e)
+                {
+                    if(set)
+                    {
+                        set = false;
+                        break;
+                    }
+                }
+
+                e.WaitOne();
+            }
+        }
+
+        /// <summary>Returns a task that waits for the event to be set.</summary>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> that can be used to cancel the wait.</param>
+        public Task WaitAsync(CancellationToken cancelToken)
+        {
+            lock(e)
+            {
+                if(set)
+                {
+                    set = false;
+                    return Task.CompletedTask;
+                }
+            }
+
+            if(cancelToken.IsCancellationRequested) return Task.FromCanceled(cancelToken);
+
+            // if we need to wait, we'll register a callback on the thread pool that will attempt to complete the task
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            RegisteredWaitHandle tpreg;
+            void callback(object ctx, bool timedOut)
+            {
+                var task = (TaskCompletionSource<object>)ctx;
+                lock(e)
+                {
+                    if(set && task.TrySetResult(null)) // if we consumed the event...
+                    {
+                        set = false; // reset it
+                    }
+                    else if(!task.Task.IsCanceled) // otherwise, if we haven't already been canceled, reregister for the event
+                    {
+                        tpreg = ThreadPool.UnsafeRegisterWaitForSingleObject(e, callback, ctx, Timeout.Infinite, true);
+                    }
+                }
+            }
+            tpreg = ThreadPool.UnsafeRegisterWaitForSingleObject(e, callback, tcs, Timeout.Infinite, true);
+            if(cancelToken.CanBeCanceled) // if the token can be canceled...
+            {
+                var ctreg = cancelToken.Register(ctx => // register a callback that unregisters our thread pool callback
+                {
+                    lock(e)
+                    {
+                        if(((TaskCompletionSource<object>)ctx).TrySetCanceled()) tpreg.Unregister(null);
+                    }
+                }, tcs);
+                tcs.Task.ContinueWith((_, r) => ((CancellationTokenRegistration)r).Dispose(), ctreg);
+            }
+            return tcs.Task;
+        }
+
+        readonly AutoResetEvent e = new AutoResetEvent(false);
+        bool set;
+    }
+    #endregion
+
+    #region Pipe
+    /// <summary>Represents a pipe that blocks on reads when empty.</summary>
+    sealed class Pipe : IDisposable
+    {
+        /// <summary>Gets the number of bytes available to be read. If not zero, the read methods will not block.</summary>
+        public int DataAvailable => buffer.DataAvailable;
+
+        /// <summary>Removes all data from the pipe.</summary>
+        public void Clear()
+        {
+            lock(buffer) buffer.Clear();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if(!disposed)
+            {
+                disposed = true;
+                lock(buffer) buffer.Dispose();
+                readEvent.Set();
+                readEvent.Dispose();
+            }
+        }
+
+        /// <summary>Called when there will be no more writes to the pipe, this method will unblock waiting readers.</summary>
+        public void Finish()
+        {
+            if(!finished)
+            {
+                finished = true;
+                readEvent.Set();
+            }
+        }
+
+        /// <summary>Reads some data and returns the number of bytes read. The method will block until data is available or
+        /// <see cref="Finish"/> is called.
+        /// </summary>
+        public int Read(byte[] buffer, int offset, int count) => Read(new Span<byte>(buffer, offset, count));
+
+        /// <summary>Reads some data and returns the number of bytes read. The method will block until data is available or
+        /// <see cref="Finish"/> is called.
+        /// </summary>
+        public int Read(Span<byte> buffer)
+        {
+            if(buffer.Length == 0) return 0;
+            while(!disposed)
+            {
+                int read;
+                lock(this.buffer) read = this.buffer.Read(buffer);
+                if(read != 0 || finished) return read;
+                readEvent.Wait();
+            }
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        /// <summary>Reads some data and returns the number of bytes read. The task will wait until data is available,
+        /// <see cref="Finish"/> is called, or the task is canceled.
+        /// </summary>
+        public ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancelToken = default) =>
+            ReadAsync(new Memory<byte>(buffer, offset, count), cancelToken);
+
+        /// <summary>Reads some data and returns the number of bytes read. The task will wait until data is available,
+        /// <see cref="Finish"/> is called, or the task is canceled.
+        /// </summary>
+        public async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancelToken = default)
+        {
+            if(buffer.Length == 0) return 0;
+            while(!disposed)
+            {
+                cancelToken.ThrowIfCancellationRequested();
+                int read;
+                lock(this.buffer) read = this.buffer.Read(buffer.Span);
+                if(read != 0 || finished) return read;
+                await readEvent.WaitAsync(cancelToken).ConfigureAwait(false);
+            }
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        /// <summary>Writes data into the pipe. This method will not block.</summary>
+        public void Write(byte[] data, int offset, int count) => Write(new ReadOnlySpan<byte>(data, offset, count));
+
+        /// <summary>Writes data into the pipe. This method will not block.</summary>
+        public void Write(ReadOnlySpan<byte> data)
+        {
+            if(disposed) throw new ObjectDisposedException(GetType().FullName);
+            if(finished) throw new InvalidOperationException("The pipe is draining.");
+            if(data.Length != 0)
+            {
+                lock(buffer) buffer.Write(data);
+                readEvent.Set();
+            }
+        }
+
+        readonly StreamBuffer buffer = new StreamBuffer();
+        readonly AsyncAutoResetEvent readEvent = new AsyncAutoResetEvent();
+        bool disposed, finished;
+    }
+    #endregion
+
+    #region StreamBuffer
+    /// <summary>Implements a buffer into which data can be written and from which data can be read.</summary>
+    sealed class StreamBuffer : IDisposable
+    {
+        /// <summary>Gets the number of bytes available in the buffer.</summary>
+        public int DataAvailable { get; private set; }
+
+        /// <summary>Removes all data from the buffer.</summary>
+        public void Clear()
+        {
+            foreach(Chunk chunk in dataList) chunk.Dispose();
+            dataList.Clear();
+            DataAvailable = 0;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose() => Clear();
+
+        /// <summary>Reads data from the buffer and returns the number of bytes read. This method will not block.</summary>
+        public int Read(byte[] buffer, int offset, int count) => Read(new Span<byte>(buffer, offset, count));
+
+        /// <summary>Reads data from the buffer and returns the number of bytes read. This method will not block.</summary>
+        public int Read(Span<byte> buffer)
+        {
+            int read = 0;
+            while(buffer.Length != 0) // while there's space left in the buffer...
+            {
+                Chunk chunk = dataList.First?.Value; // get the first data chunk in the list
+                if(chunk == null || chunk.AvailableData == 0) break; // if it's nonexistent or empty, we're done
+                int toCopy = Math.Min(chunk.AvailableData, buffer.Length); // otherwise, see how much we should get out of it
+                chunk.Read(toCopy, buffer); // read the data into the buffer
+                if(chunk.AvailableData == 0 && chunk.AvailableSpace == 0) // if the chunk became empty...
+                {
+                    if(chunk.Buffer.Length > DropThreshold || dataList.Count > 1) // if the chunk is extra large or we have others...
+                    {
+                        dataList.RemoveFirst(); // remove this one
+                        chunk.Dispose();
+                    }
+                    else // otherwise, reset it. (we'll keep one normal-sized chunk around so we don't have to create a new one)
+                    {
+                        chunk.Reset();
+                    }
+                }
+                read += toCopy;
+                buffer = buffer.Slice(toCopy);
+            }
+            DataAvailable -= read;
+            return read;
+        }
+
+        /// <summary>Writes data into the buffer. This method will not block.</summary>
+        public void Write(byte[] data, int offset, int count) => Write(new ReadOnlySpan<byte>(data, offset, count));
+
+        /// <summary>Writes data into the buffer. This method will not block.</summary>
+        public void Write(ReadOnlySpan<byte> data)
+        {
+            int length = data.Length;
+            if(length != 0)
+            {
+                if(dataList.Count == 0) dataList.AddLast(new Chunk(length)); // if the chunk list is empty, add a chunk
+                do // while there's still data left to write...
+                {
+                    Chunk chunk = dataList.Last.Value; // get the last chunk
+                    if(chunk.AvailableSpace == 0) // if it's full...
+                    {
+                        chunk = new Chunk(data.Length); // add a new chunk
+                        dataList.AddLast(chunk);
+                    }
+                    int toCopy = Math.Min(chunk.AvailableSpace, data.Length); // now copy as much as we can into the chunk
+                    chunk.Write(data.Slice(0, toCopy));
+                    data = data.Slice(toCopy);
+                } while(data.Length != 0);
+                DataAvailable += length;
+            }
+        }
+
+        const int MinChunkSize = 32*1024, DropThreshold = 64*1024;
+
+        #region Chunk
+        /// <summary>Represents a chunk of data. We maintain multiple chunks of data rather than a single large buffer to avoid having
+        /// to reallocate arrays or copy data.
+        /// </summary>
+        sealed class Chunk
+        {
+            public Chunk(int minSize) => Buffer = ArrayPool<byte>.Shared.Rent(Math.Max(MinChunkSize, minSize));
+            public int AvailableData => WriteIndex - ReadIndex;
+            public int AvailableSpace => Buffer.Length - WriteIndex;
+            public int ReadIndex { get; private set; }
+            public int WriteIndex { get; private set; }
+
+            public void Dispose() => ArrayPool<byte>.Shared.Return(Buffer);
+
+            public void Read(int byteCount, Span<byte> dest)
+            {
+                new Span<byte>(Buffer, ReadIndex, byteCount).CopyTo(dest);
+                ReadIndex += byteCount;
+            }
+
+            public void Reset() => ReadIndex = WriteIndex = 0;
+
+            public void Write(ReadOnlySpan<byte> span)
+            {
+                span.CopyTo(new Span<byte>(Buffer, WriteIndex, AvailableSpace));
+                WriteIndex += span.Length;
+            }
+
+            public readonly byte[] Buffer;
+        }
+        #endregion
+
+        readonly LinkedList<Chunk> dataList = new LinkedList<Chunk>();
+    }
+    #endregion
+
+    #region PipeStream
+    /// <summary>Represents a read-only stream backed by a <see cref="Pipe"/>.</summary>
+    sealed class PipeStream : Stream
+    {
+        public PipeStream() : this(new Pipe(), true) { }
+        public PipeStream(Pipe pipe, bool ownPipe) => (this.readPipe, this.ownPipe) = (pipe, ownPipe);
+
+        /// <inheritdoc/>
+        public override bool CanRead => true;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => false;
+
+        /// <inheritdoc/>
+        /// <remarks>This property is not supported and throws <see cref="NotSupportedException"/>.</remarks>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        /// <remarks>This property is not supported and throws <see cref="NotSupportedException"/>.</remarks>
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        /// <inheritdoc/>
+        public override void Flush() => AssertNotDisposed(); // TODO: should we make Flush wait until data has been sent over the wire?
+
+        /// <summary>Queues data that can later be read from the stream.</summary>
+        public void QueueData(byte[] data, int count) => readPipe.Write(data, 0, count);
+
+        /// <summary>Queues data that can later be read from the stream.</summary>
+        public void QueueData(ReadOnlySpan<byte> data) => readPipe.Write(data);
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            AssertNotDisposed();
+            return readPipe.Read(buffer, offset, count);
+        }
+
+#if NETCOREAPP2_1
+        /// <inheritdoc/>
+        public override int Read(Span<byte> buffer)
+        {
+            AssertNotDisposed();
+            return readPipe.Read(buffer);
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            AssertNotDisposed();
+            return readPipe.ReadAsync(buffer, cancellationToken);
+        }
+#endif
+
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancelToken)
+        {
+            AssertNotDisposed();
+            return readPipe.ReadAsync(buffer, offset, count, cancelToken).AsTask();
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>This method is not supported and throws <see cref="NotSupportedException"/>.</remarks>
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        /// <remarks>This method is not supported and throws <see cref="NotSupportedException"/>.</remarks>
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+#if NETCOREAPP2_1
+        /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException();
+#endif
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool manuallyDisposed)
+        {
+            disposed = true;
+            if(ownPipe) readPipe.Dispose();
+        }
+
+        void AssertNotDisposed()
+        {
+            if(disposed) throw new ObjectDisposedException(GetType().Name);
+        }
+
+        readonly Pipe readPipe;
+        bool disposed, ownPipe;
+    }
+    #endregion
+}


### PR DESCRIPTION
This change adds improved watch support. There are some problems with the existing watch support.

* The design contains a pitfall that will trap users. It has public events like OnEvent but begins listening immediately in the constructor. This means that the usual pattern of creating an object and attaching your event handler will cause a race condition and lead to lost events. The only real way to avoid this is to pass the event handlers at the time you instantiate the watch. Given that watches are normally instantiated from Watch* methods that do not force you to provide the event handler up-front, the behavior is "broken by default".
* It internally uses a cancellation token but does not use it in the place that matters most - in the blocking IO call to read from the stream.
* If you dispose the watch while it's running, it often reports a spurious ObjectDisposedException.
* The watch offers only the lowest level support - reporting a stream of watch events from a single watch request. In practice, watches time out and need to be reopened, and when you reopen them you need to resume where you left off, which requires tracking the latest version, but if you're watching a list of items as opposed to a single item you can't easily do that because the correct version to resume at is not marked in the watch stream itself and must be retrieved from a list request. Support for resuming and for watching multiple items must be built on top, but the watch object itself doesn't have a very good interface for building on top of.
* It deserializes every event twice, which is unnecessary.

This change adds two main classes.

* WatchReader\<T\> -- This class functions similarly to the current Watch\<T\> but fixes the above problems. (I didn't want to make changes to Watch\<T\> itself in case anyone depends on its particular behavior.) It has a pull interface rather than an event-based interface:
      
      // x can be a Stream, HttpResponseMessage, or KubernetesResponse
      using(var wr = new WatchReader<V1Pod>(x))
      {
          WatchEvent<V1Pod> e;
          while((e = await wr.ReadAsync(cancelToken)) != null) /* handle event */
      }
      
* Watch\<T\> -- This class implements a high-level watch that tracks versions, resumes after disconnection, supports watch bookmarks, and can watch both lists and single items. It uses an event-based approach like the current Watcher\<T\>, but has more events:
  * Closed
  * EventReceived - Only raised for Added, Modified, and Removed events
  * Error
  * InitialListSent - Raised after the initial list of items was sent from opening the watch. This can be used to let a watch-based cache know when it has reached a synchronized state, for example.
  * Opened
  * Reset - Raised when the watch is opened without successfully resuming, i.e. when events may have been lost. This can be used to clear caches based on the watch, for example.
  
  ````    
  // request is a KubernetesRequest
  var w = new Watch<V1Pod>(request); // or use request.ToWatch<T>()
  w.EventReceived += ...;
  w.Run();
  …
  w.Dispose(); // or, give it a cancellation token and cancel it
  // if you need to know exactly when it stops you can await the task returned from Run()
  ````

**NOTE: This PR builds on and includes changes from two other PRs (https://github.com/kubernetes-client/csharp/pull/405 and https://github.com/kubernetes-client/csharp/pull/406).** I'm not sure how best to represent that in a PR, but the files actually added or changed in this specific PR are:

* Watch.cs
* Watcher.cs (trivial changes)
* KubernetesRequest.cs (minor changes)
* tests/KubernetesClient.Tests/FluentWatchTests.cs
* tests/KubernetesClient.Tests/PipeStream.cs