### PR TITLE
Remove retry

### DIFF
--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -57,6 +57,7 @@ namespace k8s
         /// </param>
         public Kubernetes(KubernetesClientConfiguration config, params DelegatingHandler[] handlers)
         {
+            Initialize();
             ValidateConfig(config);
             CreateHttpClient(handlers);
             CaCerts = config.SslCaCerts;

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -56,9 +56,9 @@ namespace k8s
         ///     Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
         public Kubernetes(KubernetesClientConfiguration config, params DelegatingHandler[] handlers)
-            : this(handlers)
         {
             ValidateConfig(config);
+            CreateHttpClient(handlers);
             CaCerts = config.SslCaCerts;
             SkipTlsVerify = config.SkipTlsVerify;
             InitializeFromConfig(config);
@@ -161,8 +161,13 @@ namespace k8s
 #if NET452 
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 #endif
-            AppendDelegatingHandler<WatcherDelegatingHandler>();
             DeserializationSettings.Converters.Add(new V1Status.V1StatusObjectViewConverter());
+        }
+
+        /// <summary>A <see cref="DelegatingHandler"/> that simply forwards a request with no further processing.</summary>
+        private sealed class ForwardingHandler : DelegatingHandler
+        {
+            public ForwardingHandler(HttpMessageHandler handler) : base(handler) { }
         }
 
         private void AppendDelegatingHandler<T>() where T : DelegatingHandler, new()
@@ -186,6 +191,32 @@ namespace k8s
 
                 cur = next;
             }
+        }
+
+        // NOTE: this method replicates the logic that the base ServiceClient uses except that it doesn't insert the RetryDelegatingHandler
+        // and it does insert the WatcherDelegatingHandler. we don't want the RetryDelegatingHandler because it has a very broad definition
+        // of what requests have failed. it considers everything outside 2xx to be failed, including 1xx (e.g. 101 Switching Protocols) and
+        // 3xx. in particular, this prevents upgraded connections and certain generic/custom requests from working.
+        private void CreateHttpClient(DelegatingHandler[] handlers)
+        {
+            FirstMessageHandler = HttpClientHandler = CreateRootHandler();
+            if (handlers == null || handlers.Length == 0)
+            {
+                // ensure we have at least one DelegatingHandler so AppendDelegatingHandler will work
+                FirstMessageHandler = new ForwardingHandler(HttpClientHandler);
+            }
+            else
+            {
+                for (int i = handlers.Length - 1; i >= 0; i--)
+                {
+                    DelegatingHandler handler = handlers[i];
+                    while (handler.InnerHandler is DelegatingHandler d) handler = d;
+                    handler.InnerHandler = FirstMessageHandler;
+                    FirstMessageHandler = handlers[i];
+                }
+            }
+            AppendDelegatingHandler<WatcherDelegatingHandler>();
+            HttpClient = new HttpClient(FirstMessageHandler, false);
         }
 
         /// <summary>

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -21,11 +21,11 @@ namespace k8s
         {
             var originResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (originResponse.IsSuccessStatusCode && request.Method == HttpMethod.Get) // watches are GETs so we can exclude non-GET requests
+            if (originResponse.IsSuccessStatusCode)
             {
-                string query = request.RequestUri.Query;
-                int index = query.IndexOf("watch=true");
-                if(index > 0 && (query[index-1] == '?' || query[index-1] == '&'))
+                var query = QueryHelpers.ParseQuery(request.RequestUri.Query);
+
+                if (query.TryGetValue("watch", out var values) && values.Any(v => v == "true"))
                 {
                     originResponse.Content = new LineSeparatedHttpContent(originResponse.Content, cancellationToken);
                 }

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -21,11 +21,11 @@ namespace k8s
         {
             var originResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (originResponse.IsSuccessStatusCode)
+            if (originResponse.IsSuccessStatusCode && request.Method == HttpMethod.Get) // watches are GETs so we can exclude non-GET requests
             {
-                var query = QueryHelpers.ParseQuery(request.RequestUri.Query);
-
-                if (query.TryGetValue("watch", out var values) && values.Any(v => v == "true"))
+                string query = request.RequestUri.Query;
+                int index = query.IndexOf("watch=true");
+                if(index > 0 && (query[index-1] == '?' || query[index-1] == '&'))
                 {
                     originResponse.Content = new LineSeparatedHttpContent(originResponse.Content, cancellationToken);
                 }


### PR DESCRIPTION
This change removes the RetryDelegatingHandler automatically added by the Microsoft.Rest.ClientRuntime framework. The main reason is that it has a very broad definition of what requests have failed. It considers everything outside 2xx to be failed, including 1xx (e.g. 101 Switching Protocols) and 3xx. In particular, this prevents upgraded connections and certain generic/custom requests from working.

It's not clear that we want retry in a Kubernetes client, but if we do I can instead replace the RetryDelegatingHandler with one that has a more reasonable view of what constitutes a failure.