### PR TITLE
Timeout handler. 

### DIFF
--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using k8s.Exceptions;
 using k8s.Models;
 using Microsoft.Rest;
@@ -233,6 +234,7 @@ namespace k8s
 
             AppendDelegatingHandler<WatcherDelegatingHandler>();
             HttpClient = new HttpClient(FirstMessageHandler, false);
+            HttpClient.Timeout = Timeout.InfiniteTimeSpan; // timeout logic will be handled by WatcherDelegatingHandler
         }
 
         /// <summary>

--- a/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.HttpClientHandler.cs
@@ -54,5 +54,6 @@ namespace k8s
         }
 
         public static DelegatingHandler CreateWatchHandler() => new WatcherDelegatingHandler();
+        public static DelegatingHandler CreateWatchHandler(TimeSpan timeout) => new WatcherDelegatingHandler(timeout);
     }
 }

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -80,8 +80,14 @@ namespace k8s.Models
             else
             {
                 int slash = obj.ApiVersion.IndexOf('/');
-                if (slash < 0) (group, version) = (string.Empty, obj.ApiVersion);
-                else (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash + 1));
+                if (slash < 0)
+                {
+                    (group, version) = (string.Empty, obj.ApiVersion);
+                }
+                else
+                {
+                    (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash + 1));
+                }
             }
         }
 
@@ -162,6 +168,7 @@ namespace k8s.Models
             {
                 throw new ArgumentNullException(nameof(obj));
             }
+
             if (predicate == null)
             {
                 throw new ArgumentNullException(nameof(predicate));
@@ -172,7 +179,10 @@ namespace k8s.Models
             {
                 for (int i = 0; i < ownerRefs.Count; i++)
                 {
-                    if (predicate(ownerRefs[i])) return i;
+                    if (predicate(ownerRefs[i]))
+                    {
+                        return i;
+                    }
                 }
             }
             return -1;

--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -53,7 +53,7 @@ namespace k8s.Models
             if (obj.ApiVersion != null)
             {
                 int slash = obj.ApiVersion.IndexOf('/');
-                return slash < 0 ? obj.ApiVersion : obj.ApiVersion.Substring(slash+1);
+                return slash < 0 ? obj.ApiVersion : obj.ApiVersion.Substring(slash + 1);
             }
             return null;
         }
@@ -81,7 +81,7 @@ namespace k8s.Models
             {
                 int slash = obj.ApiVersion.IndexOf('/');
                 if (slash < 0) (group, version) = (string.Empty, obj.ApiVersion);
-                else (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash+1));
+                else (group, version) = (obj.ApiVersion.Substring(0, slash), obj.ApiVersion.Substring(slash + 1));
             }
         }
 
@@ -307,7 +307,7 @@ namespace k8s.Models
             IList<V1OwnerReference> refs = obj.Metadata?.OwnerReferences;
             if (refs != null)
             {
-                for (int i = refs.Count-1; i >= 0; i--)
+                for (int i = refs.Count - 1; i >= 0; i--)
                 {
                     if (predicate(refs[i]))
                     {

--- a/src/KubernetesClient/WatcherDelegatingHandler.cs
+++ b/src/KubernetesClient/WatcherDelegatingHandler.cs
@@ -46,7 +46,9 @@ namespace k8s
                 string query = request.RequestUri.Query;
                 int index = query.IndexOf("watch=true");
                 if (index > 0 && (query[index - 1] == '&' || query[index - 1] == '?'))
+                {
                     isWatch = true;
+                }
             }
 
             if (!isWatch)

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -63,7 +63,13 @@ namespace k8s.Tests
             DateTime ts = DateTime.UtcNow, ts2 = DateTime.Now;
             pod.Metadata = new V1ObjectMeta()
             {
-                CreationTimestamp = ts, DeletionTimestamp = ts2, Generation = 1, Name = "name", NamespaceProperty = "ns", ResourceVersion = "42", Uid = "id"
+                CreationTimestamp = ts,
+                DeletionTimestamp = ts2,
+                Generation = 1,
+                Name = "name",
+                NamespaceProperty = "ns",
+                ResourceVersion = "42",
+                Uid = "id"
             };
             Assert.Equal(ts, pod.CreationTimestamp().Value);
             Assert.Equal(ts2, pod.DeletionTimestamp().Value);


### PR DESCRIPTION
This is needed to allow KubernetesClient not timeout during watch requests when initialized with externally managed HttpClient