### PR TITLE
Override ToString on V1Status

### DIFF
--- a/src/KubernetesClient/ModelExtensions.cs
+++ b/src/KubernetesClient/ModelExtensions.cs
@@ -1,0 +1,19 @@
+using System.Net;
+
+namespace k8s.Models
+{
+    public partial class V1Status
+    {
+        /// <summary>Converts a <see cref="V1Status"/> object into a short description of the status.</summary>
+        public override string ToString()
+        {
+            string reason = Reason;
+            if (string.IsNullOrEmpty(reason) && Code.GetValueOrDefault() != 0)
+            {
+                reason = ((HttpStatusCode)Code.Value).ToString();
+            }
+            return string.IsNullOrEmpty(Message) ? string.IsNullOrEmpty(reason) ? Status : reason :
+                   string.IsNullOrEmpty(reason) ? Message : $"{reason} - {Message}";
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/ModelExtensionTests.cs
+++ b/tests/KubernetesClient.Tests/ModelExtensionTests.cs
@@ -1,0 +1,36 @@
+using k8s.Models;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class ModelExtensionTests
+    {
+        [Fact]
+        public void TestV1Status()
+        {
+            var s = new V1Status() { Status = "Success" };
+            Assert.Equal("Success", s.ToString());
+
+            s = new V1Status() { Status = "Failure" };
+            Assert.Equal("Failure", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Reason = "BombExploded" };
+            Assert.Equal("BombExploded", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Message = "Something bad happened." };
+            Assert.Equal("Something bad happened.", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Code = 400 };
+            Assert.Equal("BadRequest", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Code = 911 };
+            Assert.Equal("911", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Code = 400, Message = "It's all messed up." };
+            Assert.Equal("BadRequest - It's all messed up.", s.ToString());
+
+            s = new V1Status() { Status = "Failure", Code = 400, Reason = "IllegalValue", Message = "You're breaking the LAW!", };
+            Assert.Equal("IllegalValue - You're breaking the LAW!", s.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This change overrides the ToString method on V1Status so that it returns a short summary of the status value.