### PR TITLE
Fix issue with WatchDispose test

### DIFF
--- a/tests/KubernetesClient.Tests/WatchTests.cs
+++ b/tests/KubernetesClient.Tests/WatchTests.cs
@@ -263,7 +263,6 @@ namespace k8s.Tests
                     await Task.Yield();
                 }
 
-                Assert.Empty(events);
                 Assert.False(watcher.Watching);
                 Assert.True(connectionClosed.IsSet);
             }


### PR DESCRIPTION
This fixes an incorrect assertion which assumed there are no received events after Dispose on Watch is called. This is incorrect because the way cancellation token is used doesn't throw, so it's possible to have items being processed and published as events even after Dispose is called. 