### PR TITLE
Quoted non-string values remain quoted after serialization

### DIFF
--- a/src/KubernetesClient/StringQuotingEmitter.cs
+++ b/src/KubernetesClient/StringQuotingEmitter.cs
@@ -6,6 +6,7 @@ using YamlDotNet.Serialization.EventEmitters;
 
 namespace k8s
 {
+    // adapted from https://github.com/cloudbase/powershell-yaml/blob/master/powershell-yaml.psm1
     public class StringQuotingEmitter : ChainedEventEmitter
     {
         // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356

--- a/src/KubernetesClient/StringQuotingEmitter.cs
+++ b/src/KubernetesClient/StringQuotingEmitter.cs
@@ -26,7 +26,7 @@ namespace k8s
             switch (typeCode)
             {
                 case TypeCode.Char:
-                    if (char.IsDigit((char) eventInfo.Source.Value))
+                    if (char.IsDigit((char)eventInfo.Source.Value))
                     {
                         eventInfo.Style = ScalarStyle.DoubleQuoted;
                     }

--- a/src/KubernetesClient/StringQuotingEmitter.cs
+++ b/src/KubernetesClient/StringQuotingEmitter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.RegularExpressions;
+using YamlDotNet;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
+
+namespace k8s
+{
+    public class StringQuotingEmitter : ChainedEventEmitter
+    {
+        // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356
+        // private static Regex quotedRegex = new Regex(`"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
+        private static Regex newRegex = new Regex(@"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
+        // private static Regex quotedRegex = new Regex(@`"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
+        // private static Regex quotedRegex = new Regex(@"^""(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?""$", RegexOptions.Compiled);
+        // private static Regex quotedRegex = new Regex(@"\"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`\"", RegexOptions.Compiled);
+        // private static Regex quotedRegex = new Regex("^(~|null|true|false|-?(0|[1-9][0-9]*)(.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
+
+        public StringQuotingEmitter(IEventEmitter next) : base(next)
+        {
+
+        }
+        public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter) {
+            var typeCode = eventInfo.Source.Value != null
+                ? Type.GetTypeCode(eventInfo.Source.Type)
+                : TypeCode.Empty;
+            switch (typeCode) {
+                case TypeCode.Char:
+                    if (Char.IsDigit((char)eventInfo.Source.Value)) {
+                        eventInfo.Style = ScalarStyle.DoubleQuoted;
+                    }
+                    break;
+                case TypeCode.String:
+                    var val = eventInfo.Source.Value.ToString();
+                    if (newRegex.IsMatch(val))
+                    {
+                        eventInfo.Style = ScalarStyle.DoubleQuoted;
+                    } else if (val.IndexOf('\n') > -1) {
+                        eventInfo.Style = ScalarStyle.Literal;
+                    }
+                    break;
+            }
+            base.Emit(eventInfo, emitter);
+        }
+        public static SerializerBuilder Add(SerializerBuilder builder) {
+            return builder.WithEventEmitter(next => new StringQuotingEmitter(next));
+        }
+    }
+}

--- a/src/KubernetesClient/StringQuotingEmitter.cs
+++ b/src/KubernetesClient/StringQuotingEmitter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text.RegularExpressions;
-using YamlDotNet;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.EventEmitters;
@@ -10,41 +9,43 @@ namespace k8s
     public class StringQuotingEmitter : ChainedEventEmitter
     {
         // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356
-        // private static Regex quotedRegex = new Regex(`"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
-        private static Regex newRegex = new Regex(@"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
-        // private static Regex quotedRegex = new Regex(@`"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
-        // private static Regex quotedRegex = new Regex(@"^""(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?""$", RegexOptions.Compiled);
-        // private static Regex quotedRegex = new Regex(@"\"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$`\"", RegexOptions.Compiled);
-        // private static Regex quotedRegex = new Regex("^(~|null|true|false|-?(0|[1-9][0-9]*)(.[0-9]*)?([eE][-+]?[0-9]+)?)?$`", RegexOptions.Compiled);
+        private static readonly Regex quotedRegex =
+            new Regex(@"^(\~|null|true|false|-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
 
         public StringQuotingEmitter(IEventEmitter next) : base(next)
         {
-
         }
-        public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter) {
+
+        /// <inheritdoc/>
+        public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
+        {
             var typeCode = eventInfo.Source.Value != null
                 ? Type.GetTypeCode(eventInfo.Source.Type)
                 : TypeCode.Empty;
-            switch (typeCode) {
+            switch (typeCode)
+            {
                 case TypeCode.Char:
-                    if (Char.IsDigit((char)eventInfo.Source.Value)) {
+                    if (char.IsDigit((char) eventInfo.Source.Value))
+                    {
                         eventInfo.Style = ScalarStyle.DoubleQuoted;
                     }
+
                     break;
                 case TypeCode.String:
                     var val = eventInfo.Source.Value.ToString();
-                    if (newRegex.IsMatch(val))
+                    if (quotedRegex.IsMatch(val))
                     {
                         eventInfo.Style = ScalarStyle.DoubleQuoted;
-                    } else if (val.IndexOf('\n') > -1) {
+                    }
+                    else if (val.IndexOf('\n') > -1)
+                    {
                         eventInfo.Style = ScalarStyle.Literal;
                     }
+
                     break;
             }
+
             base.Emit(eventInfo, emitter);
-        }
-        public static SerializerBuilder Add(SerializerBuilder builder) {
-            return builder.WithEventEmitter(next => new StringQuotingEmitter(next));
         }
     }
 }

--- a/src/KubernetesClient/Yaml.cs
+++ b/src/KubernetesClient/Yaml.cs
@@ -135,6 +135,7 @@ namespace k8s
                     .WithNamingConvention(new CamelCaseNamingConvention())
                     .WithTypeInspector(ti => new AutoRestTypeInspector(ti))
                     .WithTypeConverter(new IntOrStringYamlConverter())
+                    .WithEventEmitter(e => new StringQuotingEmitter(e))
                     .BuildValueSerializer();
             emitter.Emit(new StreamStart());
             emitter.Emit(new DocumentStart());

--- a/tests/KubernetesClient.Tests/YamlTests.cs
+++ b/tests/KubernetesClient.Tests/YamlTests.cs
@@ -291,5 +291,29 @@ spec:
             var output = Yaml.SaveToString<V1Service>(obj);
             Assert.True(ToLines(output).SequenceEqual(ToLines(content)));
         }
+
+        [Fact]
+        public void EnvVariableAndAnnotationsShouldBeStrings()
+        {
+            var content = @"apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    should-be-string: ""true""
+  name: cpu-demo
+spec:
+  containers:
+  - env:
+    - name: PORT
+      value: ""3000""
+    name: cpu-demo-ctr
+    image: vish/stress";
+            var obj = Yaml.LoadFromString<V1Pod>(content);
+            Assert.NotNull(obj?.Spec?.Containers);
+            var container = Assert.Single(obj.Spec.Containers);
+            Assert.NotNull(container.Env);
+            var objStr = Yaml.SaveToString(obj);
+            Assert.Equal(content, objStr);
+        }
     }
 }

--- a/tests/KubernetesClient.Tests/YamlTests.cs
+++ b/tests/KubernetesClient.Tests/YamlTests.cs
@@ -293,17 +293,25 @@ spec:
         }
 
         [Fact]
-        public void EnvVariableShouldBeStrings()
+        public void QuotedValuesShouldRemainQuotedAfterSerialization()
         {
             var content = @"apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    custom.annotation: ""null""
   name: cpu-demo
 spec:
   containers:
   - env:
     - name: PORT
       value: ""3000""
+    - name: NUM_RETRIES
+      value: ""3""
+    - name: ENABLE_CACHE
+      value: ""true""
+    - name: ENABLE_OTHER
+      value: ""false""
     image: vish/stress
     name: cpu-demo-ctr";
             var obj = Yaml.LoadFromString<V1Pod>(content);

--- a/tests/KubernetesClient.Tests/YamlTests.cs
+++ b/tests/KubernetesClient.Tests/YamlTests.cs
@@ -293,21 +293,19 @@ spec:
         }
 
         [Fact]
-        public void EnvVariableAndAnnotationsShouldBeStrings()
+        public void EnvVariableShouldBeStrings()
         {
             var content = @"apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    should-be-string: ""true""
   name: cpu-demo
 spec:
   containers:
   - env:
     - name: PORT
       value: ""3000""
-    name: cpu-demo-ctr
-    image: vish/stress";
+    image: vish/stress
+    name: cpu-demo-ctr";
             var obj = Yaml.LoadFromString<V1Pod>(content);
             Assert.NotNull(obj?.Spec?.Containers);
             var container = Assert.Single(obj.Spec.Containers);


### PR DESCRIPTION
As seen in https://github.com/aaubry/YamlDotNet/issues/33, quoted `null`/`int`/`bool` values are not coerced to strings correctly. @gabriel-samfira authored an upstream  fix to this in https://github.com/cloudbase/powershell-yaml/pull/41 that allows values that match the above types to be serialized correctly.

This PR adapts @gabriel-samfira's work into this library to ensure these values are serialized correctly into valid kubernetes YAML configuration.

Closes #387 