### PR TITLE
Fix ExternalExecution EnvironmentVariables model

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -17,7 +17,7 @@ namespace k8s.KubeConfigModels
         /// Environment variables to set when executing the plugin. Optional.
         /// </summary>
         [YamlMember(Alias = "env")]
-        public IList<NameValuePair> EnvironmentVariables { get; set; }
+        public IList<IDictionary<string, string>> EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Arguments to pass when executing the plugin. Optional.

--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -17,7 +17,7 @@ namespace k8s.KubeConfigModels
         /// Environment variables to set when executing the plugin. Optional.
         /// </summary>
         [YamlMember(Alias = "env")]
-        public IDictionary<string, string> EnvironmentVariables { get; set; }
+        public IList<NameValuePair> EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Arguments to pass when executing the plugin. Optional.


### PR DESCRIPTION
As per seanamosw comment, fixes #396 
The format of EnvironmentVariables is actually:
env:
   - name: name1
     value: value1
   - name: name2
     value: value2

Without this change, any token based auth using environment variables fails to load the config.