### PR TITLE
Fix declaration of authentication environment variables and add test.

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -17,7 +17,7 @@ namespace k8s.KubeConfigModels
         /// Environment variables to set when executing the plugin. Optional.
         /// </summary>
         [YamlMember(Alias = "env")]
-        public IDictionary<string, string> EnvironmentVariables { get; set; }
+        public IList<Dictionary<string, string>> EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Arguments to pass when executing the plugin. Optional.

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -429,7 +429,8 @@ namespace k8s
                             configEnvironmentVariable["name"],
                             configEnvironmentVariable["value"]);
                     }
-                    else {
+                    else
+                    {
                         var badVariable = string.Join(",", configEnvironmentVariable.Select(x => $"{x.Key}={x.Value}"));
                         throw new KubeConfigException($"Invalid environment variable defined: {badVariable}");
                     }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -407,16 +407,7 @@ namespace k8s
             throw new KubeConfigException("Refresh not supported.");
         }
 
-        /// <summary>
-        /// Implementation of the proposal for out-of-tree client
-        /// authentication providers as described here --
-        /// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/kubectl-exec-plugins.md
-        /// Took inspiration from python exec_provider.py --
-        /// https://github.com/kubernetes-client/python-base/blob/master/config/exec_provider.py
-        /// </summary>
-        /// <param name="config">The external command execution configuration</param>
-        /// <returns>The token received from the external command execution</returns>
-        public static string ExecuteExternalCommand(ExternalExecution config)
+        public static Process CreateRunnableExternalProcess(ExternalExecution config)
         {
             var execInfo = new Dictionary<string, dynamic>
             {
@@ -430,10 +421,18 @@ namespace k8s
             process.StartInfo.EnvironmentVariables.Add("KUBERNETES_EXEC_INFO", JsonConvert.SerializeObject(execInfo));
             if (config.EnvironmentVariables != null)
             {
-                foreach (var configEnvironmentVariableKey in config.EnvironmentVariables.Keys)
+                foreach (var configEnvironmentVariable in config.EnvironmentVariables)
                 {
-                    process.StartInfo.EnvironmentVariables.Add(key: configEnvironmentVariableKey,
-                        value: config.EnvironmentVariables[configEnvironmentVariableKey]);
+                    if (configEnvironmentVariable.ContainsKey("name") && configEnvironmentVariable.ContainsKey("value"))
+                    {
+                        process.StartInfo.EnvironmentVariables.Add(
+                            configEnvironmentVariable["name"],
+                            configEnvironmentVariable["value"]);
+                    }
+                    else {
+                        var badVariable = string.Join(",", configEnvironmentVariable.Select(x => $"{x.Key}={x.Value}"));
+                        throw new KubeConfigException($"Invalid environment variable defined: {badVariable}");
+                    }
                 }
             }
 
@@ -446,6 +445,22 @@ namespace k8s
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;
+
+            return process;
+        }
+
+        /// <summary>
+        /// Implementation of the proposal for out-of-tree client
+        /// authentication providers as described here --
+        /// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/kubectl-exec-plugins.md
+        /// Took inspiration from python exec_provider.py --
+        /// https://github.com/kubernetes-client/python-base/blob/master/config/exec_provider.py
+        /// </summary>
+        /// <param name="config">The external command execution configuration</param>
+        /// <returns>The token received from the external command execution</returns>
+        public static string ExecuteExternalCommand(ExternalExecution config)
+        {
+            var process = CreateRunnableExternalProcess(config);
 
             try
             {

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using k8s.KubeConfigModels;
+using Xunit;
+using System;
+
+namespace k8s.Tests
+{
+    public class ExternalExecutionTests
+    {
+        [Fact]
+        public void CreateRunnableExternalProcess()
+        {
+            var actual = KubernetesClientConfiguration.CreateRunnableExternalProcess(new ExternalExecution
+                {
+                    ApiVersion = "testingversion",
+                    Command = "command",
+                    Arguments = new List<string> {"arg1", "arg2"},
+                    EnvironmentVariables = new List<Dictionary<string, string>> 
+                        { new Dictionary<string, string> { { "name", "testkey" }, { "value", "testvalue" } } }
+                });
+
+            var actualExecInfo = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
+            Assert.Equal("testingversion", actualExecInfo["apiVersion"]);
+            Assert.Equal("ExecCredentials", actualExecInfo["kind"]);
+
+            Assert.Equal("command", actual.StartInfo.FileName);
+            Assert.Equal("arg1 arg2", actual.StartInfo.Arguments);
+            Assert.Equal("testvalue", actual.StartInfo.EnvironmentVariables["testkey"]);
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using k8s.KubeConfigModels;
 using Xunit;
-using System;
 
 namespace k8s.Tests
 {
@@ -12,13 +11,13 @@ namespace k8s.Tests
         public void CreateRunnableExternalProcess()
         {
             var actual = KubernetesClientConfiguration.CreateRunnableExternalProcess(new ExternalExecution
-                {
-                    ApiVersion = "testingversion",
-                    Command = "command",
-                    Arguments = new List<string> {"arg1", "arg2"},
-                    EnvironmentVariables = new List<Dictionary<string, string>> 
+            {
+                ApiVersion = "testingversion",
+                Command = "command",
+                Arguments = new List<string> { "arg1", "arg2" },
+                EnvironmentVariables = new List<Dictionary<string, string>>
                         { new Dictionary<string, string> { { "name", "testkey" }, { "value", "testvalue" } } }
-                });
+            });
 
             var actualExecInfo = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
             Assert.Equal("testingversion", actualExecInfo["apiVersion"]);

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -16,7 +16,7 @@ namespace k8s.Tests
                 Command = "command",
                 Arguments = new List<string> { "arg1", "arg2" },
                 EnvironmentVariables = new List<Dictionary<string, string>>
-                        { new Dictionary<string, string> { { "name", "testkey" }, { "value", "testvalue" } } }
+                    { new Dictionary<string, string> { { "name", "testkey" }, { "value", "testvalue" } } }
             });
 
             var actualExecInfo = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);


### PR DESCRIPTION
Fixes #396 

Environment variables are actually a list of dictionary of the format:

env:
   - name: name1
     value: value1
   - name: name2
     value: value2

This PR corrects the model to read environment variables without throwing. Reference docs:

https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration

Also adds a test.

Best reviewed in Split Mode as I've separated out a method to make it testable.