### PR TITLE
Nodes and pods metrics tests

### DIFF
--- a/tests/KubernetesClient.Tests/Kubernetes.Metrics.Tests.cs
+++ b/tests/KubernetesClient.Tests/Kubernetes.Metrics.Tests.cs
@@ -14,6 +14,8 @@ namespace k8s.Tests
         public const string NodeMetricsResponse = "{\n  \"kind\": \"NodeMetricsList\",\n  \"apiVersion\": \"metrics.k8s.io/v1beta1\",\n  \"metadata\": {\n    \"selfLink\": \"/apis/metrics.k8s.io/v1beta1/nodes/\"\n  },\n  \"items\": [\n    {\n      \"metadata\": {\n        \"name\": \"minikube\",\n        \"selfLink\": \"/apis/metrics.k8s.io/v1beta1/nodes/minikube\",\n        \"creationTimestamp\": \"2020-07-28T20:01:05Z\"\n      },\n      \"timestamp\": \"2020-07-28T20:01:00Z\",\n      \"window\": \"1m0s\",\n      \"usage\": {\n        \"cpu\": \"394m\",\n        \"memory\": \"1948140Ki\"\n      }\n    }\n  ]\n}";
         // Copy / Paste from metrics server minikube
         public const string PodMetricsResponse = "{\n  \"kind\": \"PodMetricsList\",\n  \"apiVersion\": \"metrics.k8s.io/v1beta1\",\n  \"metadata\": {\n    \"selfLink\": \"/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/\"\n  },\n  \"items\": [\n    {\n      \"metadata\": {\n        \"name\": \"dotnet-test-d4894bfbd-2q2dw\",\n        \"namespace\": \"default\",\n        \"selfLink\": \"/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/dotnet-test-d4894bfbd-2q2dw\",\n        \"creationTimestamp\": \"2020-08-01T07:40:05Z\"\n      },\n      \"timestamp\": \"2020-08-01T07:40:00Z\",\n      \"window\": \"1m0s\",\n      \"containers\": [\n        {\n          \"name\": \"dotnet-test\",\n          \"usage\": {\n            \"cpu\": \"0\",\n            \"memory\": \"14512Ki\"\n          }\n        }\n      ]\n    }\n  ]\n}";
+        // Copy / Paste from metrics server minikube
+        public const string EmptyPodMetricsResponse = "{\n  \"kind\": \"PodMetricsList\",\n  \"apiVersion\": \"metrics.k8s.io/v1beta1\",\n  \"metadata\": {\n    \"selfLink\": \"/apis/metrics.k8s.io/v1beta1/namespaces/empty/pods/\"\n  },\n  \"items\": []\n}";
 
         public const string DefaultNodeName = "minikube";
         public const string DefaultPodName = "dotnet-test";
@@ -66,6 +68,19 @@ namespace k8s.Tests
                 Assert.Equal(2, containerMetrics.Usage.Count);
                 Assert.True(containerMetrics.Usage.ContainsKey(DefaultCpuKey));
                 Assert.True(containerMetrics.Usage.ContainsKey(DefaultMemoryKey));
+            }
+        }
+
+        [Fact(DisplayName = "Pod metrics empty response")]
+        public async Task PodsMetricsEmptyResponse()
+        {
+            using (var server = new MockKubeApiServer(testOutput, resp: EmptyPodMetricsResponse))
+            {
+                var client = new Kubernetes(new KubernetesClientConfiguration { Host = server.Uri.ToString() });
+
+                var podsMetricsList = await client.GetKubernetesPodsMetricsByNamespaceAsync("empty").ConfigureAwait(false);
+
+                Assert.Empty(podsMetricsList.Items);
             }
         }
     }


### PR DESCRIPTION
Add more tests for nodes and pods metrics as discussed with @brendandburns.

Use of `MockKubeApiServer` and copy payload response form `minikube`.

See #466 