### PR TITLE
Parse clientCertificateData/clientKeyData from auth plugins

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -495,22 +495,22 @@ namespace k8s
                         $"external exec failed because api version {responseObject.ApiVersion} does not match {config.ApiVersion}");
                 }
 
-                if (responseObject.Status.ContainsKey("token")) 
+                if (responseObject.Status.ContainsKey("token"))
                 {
                     clientCertificateData = clientKeyData = null;
                     token = responseObject.Status["token"];
-                } 
-                else if (responseObject.Status.ContainsKey("clientCertificateData")) 
+                }
+                else if (responseObject.Status.ContainsKey("clientCertificateData"))
                 {
-                    if (!responseObject.Status.ContainsKey("clientKeyData")) 
+                    if (!responseObject.Status.ContainsKey("clientKeyData"))
                     {
                         throw new KubeConfigException($"external exec failed missing clientKeyData field in plugin output");
                     }
                     token = null;
                     clientCertificateData = responseObject.Status["clientCertificateData"];
                     clientKeyData = responseObject.Status["clientKeyData"];
-                } 
-                else 
+                }
+                else
                 {
                     throw new KubeConfigException($"external exec failed missing token or clientCertificateData field in plugin output");
                 }


### PR DESCRIPTION
Currently ExecuteExternalCommand crashes with a key not found error if
it runs a certificate based (rather than token based) plugin. This
commit will now return either the token string, or the certificate and
key strings which are then used to set the relevant fields on the
configuration object.