### PR TITLE
Fix format of ClientCertificate[Key]Data from auth plugins

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -391,8 +391,11 @@ namespace k8s
 
                 var (accessToken, clientCertificateData, clientCertificateKeyData) = ExecuteExternalCommand(userDetails.UserCredentials.ExternalExecution);
                 AccessToken = accessToken;
-                ClientCertificateData = clientCertificateData;
-                ClientCertificateKeyData = clientCertificateKeyData;
+                // When reading ClientCertificateData from a config file it will be base64 encoded, and code later in the system (see CertUtils.GeneratePfx)
+                // expects ClientCertificateData and ClientCertificateKeyData to be base64 encoded because of this. However the string returned by external
+                // auth providers is the raw certificate and key PEM text, so we need to take that and base64 encoded it here so it can be decoded later.
+                ClientCertificateData = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateData));
+                ClientCertificateKeyData = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateKeyData));
 
                 userCredentialsFound = true;
             }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -394,8 +394,8 @@ namespace k8s
                 // When reading ClientCertificateData from a config file it will be base64 encoded, and code later in the system (see CertUtils.GeneratePfx)
                 // expects ClientCertificateData and ClientCertificateKeyData to be base64 encoded because of this. However the string returned by external
                 // auth providers is the raw certificate and key PEM text, so we need to take that and base64 encoded it here so it can be decoded later.
-                ClientCertificateData = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateData));
-                ClientCertificateKeyData = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateKeyData));
+                ClientCertificateData = clientCertificateData == null ? null : Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateData));
+                ClientCertificateKeyData = clientCertificateKeyData == null ? null : Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(clientCertificateKeyData));
 
                 userCredentialsFound = true;
             }

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -349,7 +349,7 @@ namespace k8s.Tests
 
                 if (header != expect)
                 {
-                    cxt.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
+                    cxt.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                     return Task.FromResult(false);
                 }
 
@@ -494,7 +494,7 @@ namespace k8s.Tests
                 var arguments = new string[] { };
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    arguments = new [] { "/c", "echo", responseJson };
+                    arguments = new[] { "/c", "echo", responseJson };
                 }
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||


### PR DESCRIPTION
ClientCertificateData and ClientCertificateKeyData are expected to be base64 encoded strings by CertUtils.GeneratePfx. However auth plugins return the actual "--BEGIN X---...---END X---" strings, this commit base64 encodes that to match as if it was read from the config file.