### PR TITLE
small external auth fix

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -442,9 +442,8 @@ namespace k8s
                 {
                     if (configEnvironmentVariable.ContainsKey("name") && configEnvironmentVariable.ContainsKey("value"))
                     {
-                        process.StartInfo.EnvironmentVariables.Add(
-                            configEnvironmentVariable["name"],
-                            configEnvironmentVariable["value"]);
+                        var name = configEnvironmentVariable["name"];
+                        process.StartInfo.EnvironmentVariables[name] = configEnvironmentVariable["value"];
                     }
                     else
                     {


### PR DESCRIPTION
I'm using external auth with aws, the way I setup my configuration included the environment var `AWS_PROFILE` in the command 

```
- name: arn:aws:eks:us-east-1:0000000000:cluster/my-cluster
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args:
      - --region
      - us-east-1
      - eks
      - get-token
      - --cluster-name
      - clustername
      command: aws
      env:
      - name: AWS_PROFILE
        value: profile-name
```

When creating the configuration

```cs
var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(currentContext: "ci");
``` 

If `AWS_PROFILE` was already set for the parent process, it would already be present inside `process.StartInfo.EnvironmentVariables` and throw this error

```
Unhandled Exception: System.ArgumentException: Value does not fall within the expected range.
   at System.Collections.Specialized.StringDictionaryWrapper.Add(String key, String value)
   at k8s.KubernetesClientConfiguration.CreateRunnableExternalProcess(ExternalExecution config)
   at k8s.KubernetesClientConfiguration.ExecuteExternalCommand(ExternalExecution config)
   at k8s.KubernetesClientConfiguration.SetUserDetails(K8SConfiguration k8SConfig, Context activeContext)
   at k8s.KubernetesClientConfiguration.InitializeContext(K8SConfiguration k8SConfig, String currentContext)
   at k8s.KubernetesClientConfiguration.GetKubernetesClientConfiguration(String currentContext, String masterUrl, K8SConfiguration k8SConfig)
   at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths)
   at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFile(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths)
```

overwrite existing external process environment variables to prevent throwing when a key is present that is already set