### PR TITLE
OIDC support

### DIFF
--- a/kubernetes-client.ruleset
+++ b/kubernetes-client.ruleset
@@ -301,6 +301,6 @@
     <Rule Id="CS1573" Action="None" />
     <Rule Id="CS1574" Action="None" />
     <!-- Rename k8s.Extensions type to mitigate conflict with Microsoft.Extensions namespace https://github.com/kubernetes-client/csharp/pull/544#issuecomment-759230655-->
-    <Rule Id="CA1723" Action="None" />
+    <Rule Id="CA1724" Action="None" />
   </Rules>
 </RuleSet>

--- a/kubernetes-client.ruleset
+++ b/kubernetes-client.ruleset
@@ -300,6 +300,7 @@
     <Rule Id="CS1591" Action="None" />
     <Rule Id="CS1573" Action="None" />
     <Rule Id="CS1574" Action="None" />
-
+    <!-- Rename k8s.Extensions type to mitigate conflict with Microsoft.Extensions namespace https://github.com/kubernetes-client/csharp/pull/544#issuecomment-759230655-->
+    <Rule Id="CA1723" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -32,7 +32,7 @@ namespace k8s.Authentication
 
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
         {
-            if (_expiry == null || DateTime.UtcNow.AddSeconds(30) > _expiry)
+            if (_expiry == null || _accessToken == null || DateTime.UtcNow.AddSeconds(30) > _expiry)
             {
                 await RefreshToken().ConfigureAwait(false);
             }

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -58,7 +58,7 @@ namespace k8s.Authentication
             }
             catch (Exception ex)
             {
-                throw new KubernetesClientException($"Unable to refresh OIDC token. \n {ex.Message}");
+                throw new KubernetesClientException($"Unable to refresh OIDC token. \n {ex.Message}", e);
             }
         }
     }

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.Rest;
+using IdentityModel.OidcClient;
+using System.Security.Claims;
+
+namespace k8s.Authentication
+{
+    public class OidcTokenProvider : ITokenProvider
+    {
+        private OidcClient _oidcClient;
+        private string _idToken;
+        private string _refreshToken;
+        private string _accessToken;
+        private DateTime _expiry;
+
+        public OidcTokenProvider(string clientId, string clientSecret, string idpIssuerUrl, string idToken, string refreshToken)
+        {
+            _idToken = idToken;
+            _refreshToken = refreshToken;
+            OidcClientOptions options = new OidcClientOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret,
+                Authority = idpIssuerUrl,
+            };
+            _oidcClient = new OidcClient(options);
+        }
+
+        public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
+        {
+            if (_expiry == null || DateTime.UtcNow.AddSeconds(30) > _expiry)
+            {
+                await RefreshToken().ConfigureAwait(false);
+            }
+
+            return new AuthenticationHeaderValue("Bearer", _accessToken);
+        }
+
+        private async Task RefreshToken()
+        {
+            Console.WriteLine("refreshing Token");
+            IdentityModel.OidcClient.Results.RefreshTokenResult result = await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
+            _accessToken = result.AccessToken;
+            _idToken = result.IdentityToken;
+            _refreshToken = result.RefreshToken;
+            _expiry = result.AccessTokenExpiration;
+            Console.WriteLine("idToken");
+            Console.WriteLine(_idToken);
+            Console.WriteLine("accessToken");
+            Console.WriteLine(_accessToken);
+            Console.WriteLine("refreshToken");
+            Console.WriteLine(_refreshToken);
+            Console.WriteLine("expiry");
+            Console.WriteLine(_expiry);
+        }
+    }
+}

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -56,9 +56,9 @@ namespace k8s.Authentication
                 _refreshToken = result.RefreshToken;
                 _expiry = result.AccessTokenExpiration;
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                throw new KubernetesClientException($"Unable to refresh OIDC token. \n {ex.Message}", e);
+                throw new KubernetesClientException($"Unable to refresh OIDC token. \n {e.Message}", e);
             }
         }
     }

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -2,10 +2,9 @@ using System;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Linq;
 using Microsoft.Rest;
 using IdentityModel.OidcClient;
-using System.Security.Claims;
+using k8s.Exceptions;
 
 namespace k8s.Authentication
 {
@@ -48,20 +47,19 @@ namespace k8s.Authentication
 
         private async Task RefreshToken()
         {
-            Console.WriteLine("refreshing Token");
-            IdentityModel.OidcClient.Results.RefreshTokenResult result = await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
-            _accessToken = result.AccessToken;
-            _idToken = result.IdentityToken;
-            _refreshToken = result.RefreshToken;
-            _expiry = result.AccessTokenExpiration;
-            Console.WriteLine("idToken");
-            Console.WriteLine(_idToken);
-            Console.WriteLine("accessToken");
-            Console.WriteLine(_accessToken);
-            Console.WriteLine("refreshToken");
-            Console.WriteLine(_refreshToken);
-            Console.WriteLine("expiry");
-            Console.WriteLine(_expiry);
+            try
+            {
+                IdentityModel.OidcClient.Results.RefreshTokenResult result =
+                    await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
+                _accessToken = result.AccessToken;
+                _idToken = result.IdentityToken;
+                _refreshToken = result.RefreshToken;
+                _expiry = result.AccessTokenExpiration;
+            }
+            catch (Exception ex)
+            {
+                throw new KubernetesClientException($"Unable to refresh OIDC token. \n {ex.Message}");
+            }
         }
     }
 }

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -21,13 +21,7 @@ namespace k8s.Authentication
         {
             _idToken = idToken;
             _refreshToken = refreshToken;
-            OidcClientOptions options = new OidcClientOptions
-            {
-                ClientId = clientId,
-                ClientSecret = clientSecret,
-                Authority = idpIssuerUrl,
-            };
-            _oidcClient = new OidcClient(options);
+            _oidcClient = getClient(clientId, clientSecret, idpIssuerUrl);
         }
 
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
@@ -38,6 +32,18 @@ namespace k8s.Authentication
             }
 
             return new AuthenticationHeaderValue("Bearer", _accessToken);
+        }
+
+        private OidcClient getClient(string clientId, string clientSecret, string idpIssuerUrl)
+        {
+            OidcClientOptions options = new OidcClientOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret ?? "",
+                Authority = idpIssuerUrl,
+            };
+
+            return new OidcClient(options);
         }
 
         private async Task RefreshToken()

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -49,7 +49,7 @@ namespace k8s.Authentication
         {
             try
             {
-                IdentityModel.OidcClient.Results.RefreshTokenResult result =
+                var result =
                     await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
                 _accessToken = result.AccessToken;
                 _idToken = result.IdentityToken;

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -31,5 +31,6 @@
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
   </ItemGroup>
 </Project>

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -40,7 +40,7 @@ namespace k8s
         /// </summary>
         /// <remarks>
         ///     If multiple kubeconfig files are specified in the KUBECONFIG environment variable,
-        ///     merges the files, where first occurence wins. See https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files.
+        ///     merges the files, where first occurrence wins. See https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files.
         /// </remarks>
         /// <returns>Instance of the<see cref="KubernetesClientConfiguration"/> class</returns>
         public static KubernetesClientConfiguration BuildDefaultConfig()
@@ -214,7 +214,7 @@ namespace k8s
         }
 
         /// <summary>
-        ///     Validates and Intializes Client Configuration
+        ///     Validates and Initializes Client Configuration
         /// </summary>
         /// <param name="k8SConfig">Kubernetes Configuration</param>
         /// <param name="currentContext">Current Context</param>
@@ -346,7 +346,8 @@ namespace k8s
             if (userDetails.UserCredentials.AuthProvider != null)
             {
                 if (userDetails.UserCredentials.AuthProvider.Config != null
-                    && (userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token") || userDetails.UserCredentials.AuthProvider.Config.ContainsKey("id-token")))
+                    && (userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token")
+                        || userDetails.UserCredentials.AuthProvider.Config.ContainsKey("id-token")))
                 {
                     switch (userDetails.UserCredentials.AuthProvider.Name)
                     {
@@ -394,12 +395,13 @@ namespace k8s
                         case "oidc":
                             {
                                 var config = userDetails.UserCredentials.AuthProvider.Config;
-                                if (config.ContainsKey("client-id") && config.ContainsKey("idp-issuer-url") && config.ContainsKey("id-token") && config.ContainsKey("refresh-token"))
+                                if (config.ContainsKey("client-id")
+                                    && config.ContainsKey("idp-issuer-url")
+                                    && config.ContainsKey("id-token")
+                                    && config.ContainsKey("refresh-token"))
                                 {
-                                    Console.WriteLine("config complete");
-
                                     string clientId = config["client-id"];
-                                    string clientSecret = config.ContainsKey("client-secret") ? config["client-secret"] : '';
+                                    string clientSecret = config.ContainsKey("client-secret") ? config["client-secret"] : null;
                                     string idpIssuerUrl = config["idp-issuer-url"];
                                     string idToken = config["id-token"];
                                     string refreshToken = config["refresh-token"];
@@ -678,7 +680,7 @@ namespace k8s
         /// file is located. When <see langword="false"/>, the paths will be considered to be relative to the current working directory.</param>
         /// <returns>Instance of the <see cref="K8SConfiguration"/> class</returns>
         /// <remarks>
-        ///     The kube config files will be merges into a single <see cref="K8SConfiguration"/>, where first occurence wins.
+        ///     The kube config files will be merges into a single <see cref="K8SConfiguration"/>, where first occurrence wins.
         ///     See https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files.
         /// </remarks>
         internal static K8SConfiguration LoadKubeConfig(FileInfo[] kubeConfigs, bool useRelativePaths = true)
@@ -694,7 +696,7 @@ namespace k8s
         /// file is located. When <see langword="false"/>, the paths will be considered to be relative to the current working directory.</param>
         /// <returns>Instance of the <see cref="K8SConfiguration"/> class</returns>
         /// <remarks>
-        ///     The kube config files will be merges into a single <see cref="K8SConfiguration"/>, where first occurence wins.
+        ///     The kube config files will be merges into a single <see cref="K8SConfiguration"/>, where first occurrence wins.
         ///     See https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files.
         /// </remarks>
         internal static async Task<K8SConfiguration> LoadKubeConfigAsync(

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -394,10 +394,18 @@ namespace k8s
                         case "oidc":
                             {
                                 var config = userDetails.UserCredentials.AuthProvider.Config;
-                                if (config.ContainsKey("client-id") && config.ContainsKey("client-secret") && config.ContainsKey("idp-issuer-url") && config.ContainsKey("id-token") && config.ContainsKey("refresh-token"))
+                                if (config.ContainsKey("client-id") && config.ContainsKey("idp-issuer-url") && config.ContainsKey("id-token") && config.ContainsKey("refresh-token"))
                                 {
                                     Console.WriteLine("config complete");
-                                    TokenProvider = new OidcTokenProvider(config["client-id"], config["client-secret"], config["idp-issuer-url"], config["id-token"], config["refresh-token"]);
+
+                                    string clientId = config["client-id"];
+                                    string clientSecret = config.ContainsKey("client-secret") ? config["client-secret"] : '';
+                                    string idpIssuerUrl = config["idp-issuer-url"];
+                                    string idToken = config["id-token"];
+                                    string refreshToken = config["refresh-token"];
+
+                                    TokenProvider = new OidcTokenProvider(clientId, clientSecret, idpIssuerUrl, idToken, refreshToken);
+
                                     // AccessToken = config["id-token"];
                                     userCredentialsFound = true;
                                 }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -346,7 +346,7 @@ namespace k8s
             if (userDetails.UserCredentials.AuthProvider != null)
             {
                 if (userDetails.UserCredentials.AuthProvider.Config != null
-                    && userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token"))
+                    && userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token") || userDetails.UserCredentials.AuthProvider.Config.ContainsKey("id-token"))
                 {
                     switch (userDetails.UserCredentials.AuthProvider.Name)
                     {
@@ -388,6 +388,20 @@ namespace k8s
                                 var config = userDetails.UserCredentials.AuthProvider.Config;
                                 TokenProvider = new GcpTokenProvider(config["cmd-path"]);
                                 userCredentialsFound = true;
+                                break;
+                            }
+
+                        case "oidc":
+                            {
+                                Console.WriteLine("OIDC");
+                                var config = userDetails.UserCredentials.AuthProvider.Config;
+                                if (config.ContainsKey("id-token"))
+                                {
+                                    Console.WriteLine("id-token present");
+                                    AccessToken = config["id-token"];
+                                    userCredentialsFound = true;
+                                }
+
                                 break;
                             }
                     }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -395,6 +395,7 @@ namespace k8s
                         case "oidc":
                             {
                                 var config = userDetails.UserCredentials.AuthProvider.Config;
+                                AccessToken = config["id-token"];
                                 if (config.ContainsKey("client-id")
                                     && config.ContainsKey("idp-issuer-url")
                                     && config.ContainsKey("id-token")
@@ -408,7 +409,6 @@ namespace k8s
 
                                     TokenProvider = new OidcTokenProvider(clientId, clientSecret, idpIssuerUrl, idToken, refreshToken);
 
-                                    // AccessToken = config["id-token"];
                                     userCredentialsFound = true;
                                 }
 

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -346,7 +346,7 @@ namespace k8s
             if (userDetails.UserCredentials.AuthProvider != null)
             {
                 if (userDetails.UserCredentials.AuthProvider.Config != null
-                    && userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token") || userDetails.UserCredentials.AuthProvider.Config.ContainsKey("id-token"))
+                    && (userDetails.UserCredentials.AuthProvider.Config.ContainsKey("access-token") || userDetails.UserCredentials.AuthProvider.Config.ContainsKey("id-token")))
                 {
                     switch (userDetails.UserCredentials.AuthProvider.Name)
                     {
@@ -393,12 +393,12 @@ namespace k8s
 
                         case "oidc":
                             {
-                                Console.WriteLine("OIDC");
                                 var config = userDetails.UserCredentials.AuthProvider.Config;
-                                if (config.ContainsKey("id-token"))
+                                if (config.ContainsKey("client-id") && config.ContainsKey("client-secret") && config.ContainsKey("idp-issuer-url") && config.ContainsKey("id-token") && config.ContainsKey("refresh-token"))
                                 {
-                                    Console.WriteLine("id-token present");
-                                    AccessToken = config["id-token"];
+                                    Console.WriteLine("config complete");
+                                    TokenProvider = new OidcTokenProvider(config["client-id"], config["client-secret"], config["idp-issuer-url"], config["id-token"], config["refresh-token"]);
+                                    // AccessToken = config["id-token"];
                                     userCredentialsFound = true;
                                 }
 


### PR DESCRIPTION
**Feature**
Add support for OpenID Connect. This includes a new OidcTokenProvider which is able to refresh tokens. A new dependency is introduced in the form of [IdentityModel.OidcClient](https://github.com/IdentityModel/IdentityModel.OidcClient).
While at it, I fixed a few typos in comments in src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs

**Motivation**
At my company we are avid users of [Bridge-To-Kubernetes](https://github.com/microsoft/mindaro) which uses the C# K8S Client under the hood. We currently have multiple teams that are blocked from using Bridge-To-Kubernetes since the [C# K8S client currently does not support OIDC](https://github.com/kubernetes-client/csharp/issues/524). I therefore created this PR with the intent of adding OIDC support to C# K8S client so it can be integrated into Bridge-To-Kubernetes.

**Disclaimer**
I am not a C# developer. In fact this is the first C# code I have ever written. I therefore would like to ask for a thorough review; I am more than happy to update the PR to conform with any best practices, style guides and testing coverage as you see fit. I would be very grateful for any feedback!

I am also currently seeing the following warning and due to my unfamiliarity with C# I am unsure how to solve it optimally: 

> csharp/src/KubernetesClient/Extensions.cs(8,25): warning CA1724: The type name Extensions conflicts in whole or in part with the namespace name 'Microsoft.Extensions'. Change either name to eliminate the conflict.


**Thank you for taking the time to review and consider this PR!** 
My team is very much looking forward to seeing this feature downstream in Bridge-To-Kubernetes as soon as possible, as this will significantly reduce our development efforts on multiple projects.