### PR TITLE
KubernetesException: Add an constructor overload which takes a V1Status and an inner exception.

### DIFF
--- a/src/KubernetesClient/Kubernetes.Exec.cs
+++ b/src/KubernetesClient/Kubernetes.Exec.cs
@@ -47,7 +47,7 @@ namespace k8s
             }
             catch (HttpOperationException httpEx) when (httpEx.Body is V1Status)
             {
-                throw new KubernetesException((V1Status)httpEx.Body);
+                throw new KubernetesException((V1Status)httpEx.Body, httpEx);
             }
         }
 

--- a/src/KubernetesClient/KubernetesException.cs
+++ b/src/KubernetesClient/KubernetesException.cs
@@ -17,8 +17,7 @@ namespace k8s
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="KubernetesException"/> class.
-        /// Initializes a ne winstance of the <see cref="KubernetesException"/> class using
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class using
         /// the data from a <see cref="V1Status"/> object.
         /// </summary>
         /// <param name="status">
@@ -26,6 +25,24 @@ namespace k8s
         /// </param>
         public KubernetesException(V1Status status)
             : this(status?.Message)
+        {
+            Status = status;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KubernetesException"/> class using
+        /// the data from a <see cref="V1Status"/> object and a reference to the inner exception
+        /// that is the cause of this exception..
+        /// </summary>
+        /// <param name="status">
+        /// A status message which triggered this exception to be thrown.
+        /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or <see langword="null"/>
+        /// if no inner exception is specified.
+        /// </param>
+        public KubernetesException(V1Status status, Exception innerException)
+            : this(status?.Message, innerException)
         {
             Status = status;
         }


### PR DESCRIPTION
It may be interesting to keep track of the original exception from which the `V1Status` was read.

For example, you may want make sure the original stack trace is available to the calling code.