### PR TITLE
Fix kubeconfig extension handling

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/ClusterEndpoint.cs
+++ b/src/KubernetesClient/KubeConfigModels/ClusterEndpoint.cs
@@ -37,6 +37,6 @@ namespace k8s.KubeConfigModels
         /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
         /// </summary>
         [YamlMember(Alias = "extensions")]
-        public IDictionary<string, dynamic> Extensions { get; set; }
+        public IEnumerable<NamedExtension> Extensions { get; set; }
     }
 }

--- a/src/KubernetesClient/KubeConfigModels/Context.cs
+++ b/src/KubernetesClient/KubeConfigModels/Context.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using YamlDotNet.Serialization;
 
 namespace k8s.KubeConfigModels
@@ -19,6 +20,13 @@ namespace k8s.KubeConfigModels
         /// </summary>
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
+        /// </summary>
+        [YamlMember(Alias = "extensions")]
+        public IEnumerable<NamedExtension> Extensions { get; set; }
+
 
         [Obsolete("This property is not set by the YAML config. Use ContextDetails.Namespace instead.")]
         [YamlMember(Alias = "namespace")]

--- a/src/KubernetesClient/KubeConfigModels/ContextDetails.cs
+++ b/src/KubernetesClient/KubeConfigModels/ContextDetails.cs
@@ -31,6 +31,6 @@ namespace k8s.KubeConfigModels
         /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
         /// </summary>
         [YamlMember(Alias = "extensions")]
-        public IDictionary<string, dynamic> Extensions { get; set; }
+        public IEnumerable<NamedExtension> Extensions { get; set; }
     }
 }

--- a/src/KubernetesClient/KubeConfigModels/K8SConfiguration.cs
+++ b/src/KubernetesClient/KubeConfigModels/K8SConfiguration.cs
@@ -53,7 +53,7 @@ namespace k8s.KubeConfigModels
         /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
         /// </summary>
         [YamlMember(Alias = "extensions")]
-        public IDictionary<string, dynamic> Extensions { get; set; }
+        public IEnumerable<NamedExtension> Extensions { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the Kubernetes configuration file. This property is set only when the configuration

--- a/src/KubernetesClient/KubeConfigModels/NamedExtension.cs
+++ b/src/KubernetesClient/KubeConfigModels/NamedExtension.cs
@@ -1,0 +1,22 @@
+using YamlDotNet.Serialization;
+
+namespace k8s.KubeConfigModels
+{
+    /// <summary>
+    /// <see cref="NamedExtension"/> relates nicknames to extension information
+    /// </summary>
+    public class NamedExtension
+    {
+        /// <summary>
+        /// Gets or sets the nickname for this extension.
+        /// </summary>
+        [YamlMember(Alias = "name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Get or sets the extension information.
+        /// </summary>
+        [YamlMember(Alias = "extension")]
+        public dynamic Extension { get; set; }
+    }
+}

--- a/src/KubernetesClient/KubeConfigModels/UserCredentials.cs
+++ b/src/KubernetesClient/KubeConfigModels/UserCredentials.cs
@@ -78,7 +78,7 @@ namespace k8s.KubeConfigModels
         /// Gets or sets additional information. This is useful for extenders so that reads and writes don't clobber unknown fields.
         /// </summary>
         [YamlMember(Alias = "extensions")]
-        public IDictionary<string, dynamic> Extensions { get; set; }
+        public IEnumerable<NamedExtension> Extensions { get; set; }
 
         /// <summary>
         /// Gets or sets external command and its arguments to receive user credentials

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -773,19 +773,9 @@ namespace k8s
                 }
             }
 
-            if (mergek8SConfig.Extensions != null)
-            {
-                foreach (var extension in mergek8SConfig.Extensions)
-                {
-                    if (basek8SConfig.Extensions?.ContainsKey(extension.Key) == false)
-                    {
-                        basek8SConfig.Extensions[extension.Key] = extension.Value;
-                    }
-                }
-            }
-
             // Note, Clusters, Contexts, and Extensions are map-like in config despite being represented as a list here:
             // https://github.com/kubernetes/client-go/blob/ede92e0fe62deed512d9ceb8bf4186db9f3776ff/tools/clientcmd/api/types.go#L238
+            basek8SConfig.Extensions = MergeLists(basek8SConfig.Extensions, mergek8SConfig.Extensions, (s) => s.Name);
             basek8SConfig.Clusters = MergeLists(basek8SConfig.Clusters, mergek8SConfig.Clusters, (s) => s.Name);
             basek8SConfig.Users = MergeLists(basek8SConfig.Users, mergek8SConfig.Users, (s) => s.Name);
             basek8SConfig.Contexts = MergeLists(basek8SConfig.Contexts, mergek8SConfig.Contexts, (s) => s.Name);

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -1,10 +1,11 @@
+using k8s.Exceptions;
+using k8s.KubeConfigModels;
 using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
-using k8s.Exceptions;
-using k8s.KubeConfigModels;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace k8s.Tests
@@ -372,6 +373,14 @@ namespace k8s.Tests
             Assert.NotNull(cfg.Host);
         }
 
+        [Fact]
+        public async Task ContextWithClusterExtensions()
+        {
+            var path = Path.GetFullPath("assets/kubeconfig.cluster-extensions.yml");
+
+            var cfg = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(new FileInfo(path)).ConfigureAwait(false);
+        }
+
         /// <summary>
         ///     Ensures Kube config file is loaded from explicit file
         /// </summary>
@@ -525,8 +534,8 @@ namespace k8s.Tests
                 new FileInfo(path), new FileInfo(path),
             });
 
-            Assert.Equal(1, cfg.Extensions.Count);
-            Assert.Equal(1, cfg.Preferences.Count);
+            Assert.Single(cfg.Extensions);
+            Assert.Single(cfg.Preferences);
         }
 
         /// <summary>

--- a/tests/KubernetesClient.Tests/assets/kubeconfig.cluster-extensions.yml
+++ b/tests/KubernetesClient.Tests/assets/kubeconfig.cluster-extensions.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    extensions:
+    - extension:
+        last-update: Wed, 27 Jan 2021 11:44:41 UTC
+        provider: minikube.sigs.k8s.io
+        version: v1.17.0
+      name: cluster_info
+    server: https://192.168.49.2:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    extensions:
+    - extension:
+        last-update: Wed, 27 Jan 2021 11:44:41 UTC
+        provider: minikube.sigs.k8s.io
+        version: v1.17.0
+      name: context_info
+    namespace: default
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    password: secret
+    username: admin

--- a/tests/KubernetesClient.Tests/assets/kubeconfig.preferences-extensions.yml
+++ b/tests/KubernetesClient.Tests/assets/kubeconfig.preferences-extensions.yml
@@ -3,4 +3,6 @@ kind: Config
 preferences:
   colors: true
 extensions:
-  foo: bar
+  - name: foo
+    extension:
+      foo: bar


### PR DESCRIPTION
Extensions on kubeconfig files are stored as a list of NamedExtension objects, not a dictionary. 

The incorrect definition causes an exception when loading the kubeconfig:

```
   YamlDotNet.Core.YamlException : (Line: 6, Col: 5, Idx: 113) - (Line: 6, Col: 6, Idx: 114): Expected 'MappingStart', got 'SequenceStart' (at Line: 6, Col: 5, Idx: 113).
  Stack Trace:
     at YamlDotNet.Core.ParserExtensions.Require[T](IParser parser)
   at YamlDotNet.Serialization.NodeDeserializers.DictionaryNodeDeserializer.DeserializeHelper(Type tKey, Type tValue, IParser parser, Func`3 nestedObjectDeserializer, IDictionary result)
   at YamlDotNet.Serialization.NodeDeserializers.DictionaryNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.<>c__DisplayClass3_0.<DeserializeValue>b__0(IParser r, Type t)
   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.<>c__DisplayClass3_0.<DeserializeValue>b__0(IParser r, Type t)
   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.<>c__DisplayClass3_0.<DeserializeValue>b__0(IParser r, Type t)
   at YamlDotNet.Serialization.NodeDeserializers.CollectionNodeDeserializer.DeserializeHelper(Type tItem, IParser parser, Func`3 nestedObjectDeserializer, IList result, Boolean canUpdate)
   at YamlDotNet.Serialization.NodeDeserializers.CollectionNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.<>c__DisplayClass3_0.<DeserializeValue>b__0(IParser r, Type t)
   at YamlDotNet.Serialization.NodeDeserializers.EnumerableNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.<>c__DisplayClass3_0.<DeserializeValue>b__0(IParser r, Type t)
   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.YamlDotNet.Serialization.INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.Deserializer.Deserialize(IParser parser, Type type)
   at YamlDotNet.Serialization.Deserializer.Deserialize[T](IParser parser)
   at YamlDotNet.Serialization.Deserializer.Deserialize[T](TextReader input)
   at YamlDotNet.Serialization.Deserializer.Deserialize[T](String input)
   at k8s.Yaml.LoadFromString[T](String content) in /home/runner/work/csharp/csharp/src/KubernetesClient/Yaml.cs:line 166
   at k8s.Yaml.LoadFromStreamAsync[T](Stream stream) in /home/runner/work/csharp/csharp/src/KubernetesClient/Yaml.cs:line 146
   at k8s.KubernetesClientConfiguration.LoadKubeConfigAsync(FileInfo kubeconfig, Boolean useRelativePaths) in /home/runner/work/csharp/csharp/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs:line 649
   at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths) in /home/runner/work/csharp/csharp/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs:line 125
   at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFile(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths) in /home/runner/work/csharp/csharp/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs:line 103
   at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFile(String kubeconfigPath, String currentContext, String masterUrl, Boolean useRelativePaths) in /home/runner/work/csharp/csharp/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs:line 86
   at k8s.KubernetesClientConfiguration.BuildDefaultConfig() in /home/runner/work/csharp/csharp/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs:line 60
   at k8s.E2E.MnikubeTests.CreateClient() in /home/runner/work/csharp/csharp/tests/E2E.Tests/MnikubeTests.cs:line 331
   at k8s.E2E.MnikubeTests.WatcherIntegrationTest() in /home/runner/work/csharp/csharp/tests/E2E.Tests/MnikubeTests.cs:line 167
```

This now affects CI (see #550) because
- Minikube started adding annotations to kubeconfig (https://github.com/kubernetes/minikube/pull/10126)
- The GitHub action runners has is being upgraded (https://github.com/actions/virtual-environments/pull/2540/files) from [1.15.1](https://github.com/kubernetes-client/csharp/runs/1749106516?check_suite_focus=true#step:6:6) to [1.17.0](https://github.com/kubernetes-client/csharp/runs/1776431866?check_suite_focus=true#step:6:7) in the 20210123 update (rollout is still in progress, it appears)