### PR TITLE
Fix ObjectDisposedException thrown when calling LoadAllFromFileAsync

### DIFF
--- a/src/KubernetesClient/Yaml.cs
+++ b/src/KubernetesClient/Yaml.cs
@@ -80,11 +80,11 @@ namespace k8s
         /// <param name="fileName">The name of the file to load from.</param>
         /// <param name="typeMap">A map from apiVersion/kind to Type. For example "v1/Pod" -> typeof(V1Pod)</param>
         /// <returns>collection of objects</returns>
-        public static Task<List<object>> LoadAllFromFileAsync(string fileName, Dictionary<string, Type> typeMap)
+        public static async Task<List<object>> LoadAllFromFileAsync(string fileName, Dictionary<string, Type> typeMap)
         {
-            using (var reader = File.OpenRead(fileName))
+            using (var fileStream = File.OpenRead(fileName))
             {
-                return LoadAllFromStreamAsync(reader, typeMap);
+                return await LoadAllFromStreamAsync(fileStream, typeMap).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
This PR fixes #572 by ensuring the `FileStream` created in `LoadAllFromFileAsync` is not disposed before the `LoadAllFromStreamAsync` method has finished using it.

I have added unit tests for the `Yaml.LoadAllFromFile` and `Yaml.LoadFromFile` methods. This does introduce file operations into the unit tests, but the low overhead of around 11ms and 3ms seems acceptable.

I also renamed the `FileStream` variable in `LoadAllFromFileAsync` from `reader` to `fileStream` to improve readability.