### PR TITLE
Adding new properties in ExternalExecution model.

### DIFF
--- a/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
+++ b/src/KubernetesClient/KubeConfigModels/ExternalExecution.cs
@@ -25,5 +25,18 @@ namespace k8s.KubeConfigModels
         /// </summary>
         [YamlMember(Alias = "args")]
         public IList<string> Arguments { get; set; }
+
+        /// <summary>
+        /// Text shown to the user when the executable doesn't seem to be present. Optional.
+        /// </summary>
+        [YamlMember(Alias = "installHint")]
+        public string InstallHint { get; set; }
+
+        /// <summary>
+        /// Whether or not to provide cluster information to this exec plugin as a part of
+        /// the KUBERNETES_EXEC_INFO environment variable. Optional.
+        /// </summary>
+        [YamlMember(Alias = "provideClusterInfo")]
+        public bool ProvideClusterInfo { get; set; }
     }
 }


### PR DESCRIPTION
**Overview**
Kubernetes added support for these two new parameters in ExternalExecution.
Which denotes whether to pass cluster data to newly created process as part of environment variables or not.
reference : https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration

**Requirement**
Bug #618 

**Changes**
Added these two new fields as part of kubeconfig.

**ToDo**
Make changes to pass Cluster info to new process if ProvideClusterInfo is true.