### PR TITLE
fix: oidc

### DIFF
--- a/examples/simple/PodList.cs
+++ b/examples/simple/PodList.cs
@@ -1,5 +1,6 @@
 using System;
 using k8s;
+using Microsoft.Rest;
 
 namespace simple
 {
@@ -7,6 +8,7 @@ namespace simple
     {
         private static void Main(string[] args)
         {
+            ServiceClientTracing.IsEnabled = true;
             var config = KubernetesClientConfiguration.BuildDefaultConfig();
             IKubernetes client = new Kubernetes(config);
             Console.WriteLine("Starting Request!");

--- a/examples/simple/PodList.cs
+++ b/examples/simple/PodList.cs
@@ -8,7 +8,6 @@ namespace simple
     {
         private static void Main(string[] args)
         {
-            ServiceClientTracing.IsEnabled = true;
             var config = KubernetesClientConfiguration.BuildDefaultConfig();
             IKubernetes client = new Kubernetes(config);
             Console.WriteLine("Starting Request!");

--- a/examples/simple/PodList.cs
+++ b/examples/simple/PodList.cs
@@ -1,6 +1,5 @@
 using System;
 using k8s;
-using Microsoft.Rest;
 
 namespace simple
 {

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -40,8 +40,8 @@ namespace k8s.Authentication
             var handler = new JwtSecurityTokenHandler();
             var token = handler.ReadJwtToken(_accessToken ?? _idToken);
             var expiry = token.Payload.Exp ?? 0;
-            var dateTime = DateTimeOffset.FromUnixTimeSeconds(expiry);
-            return dateTime;
+            var dateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(expiry);
+            return dateTimeOffset;
         }
 
         private OidcClient getClient(string clientId, string clientSecret, string idpIssuerUrl)

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -6,7 +6,6 @@ using System.IdentityModel.Tokens.Jwt;
 using Microsoft.Rest;
 using IdentityModel.OidcClient;
 using k8s.Exceptions;
-using Serilog;
 
 namespace k8s.Authentication
 {
@@ -53,18 +52,6 @@ namespace k8s.Authentication
                 ClientSecret = clientSecret ?? "",
                 Authority = idpIssuerUrl,
             };
-
-            var shouldTrace = ServiceClientTracing.IsEnabled;
-            if (shouldTrace)
-            {
-                var serilog = new LoggerConfiguration()
-                    .MinimumLevel.Verbose()
-                    .Enrich.FromLogContext()
-                    .WriteTo.LiterateConsole(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
-                    .CreateLogger();
-
-                options.LoggerFactory.AddSerilog(serilog);
-            }
 
             return new OidcClient(options);
         }

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -2,9 +2,11 @@ using System;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using System.IdentityModel.Tokens.Jwt;
 using Microsoft.Rest;
 using IdentityModel.OidcClient;
 using k8s.Exceptions;
+using Serilog;
 
 namespace k8s.Authentication
 {
@@ -14,23 +16,33 @@ namespace k8s.Authentication
         private string _idToken;
         private string _refreshToken;
         private string _accessToken;
-        private DateTime _expiry;
+        private DateTimeOffset _expiry;
 
         public OidcTokenProvider(string clientId, string clientSecret, string idpIssuerUrl, string idToken, string refreshToken)
         {
             _idToken = idToken;
             _refreshToken = refreshToken;
             _oidcClient = getClient(clientId, clientSecret, idpIssuerUrl);
+            _expiry = getExpiryFromToken();
         }
 
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
         {
-            if (_accessToken == null || DateTime.UtcNow.AddSeconds(30) > _expiry)
+            if ((_accessToken == null && _idToken == null) || DateTimeOffset.UtcNow.AddSeconds(30) > _expiry)
             {
                 await RefreshToken().ConfigureAwait(false);
             }
 
-            return new AuthenticationHeaderValue("Bearer", _accessToken);
+            return new AuthenticationHeaderValue("Bearer", _accessToken ?? _idToken);
+        }
+
+        private DateTimeOffset getExpiryFromToken()
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.ReadJwtToken(_accessToken ?? _idToken);
+            var expiry = token.Payload.Exp ?? 0;
+            var dateTime = DateTimeOffset.FromUnixTimeSeconds(expiry);
+            return dateTime;
         }
 
         private OidcClient getClient(string clientId, string clientSecret, string idpIssuerUrl)
@@ -42,6 +54,18 @@ namespace k8s.Authentication
                 Authority = idpIssuerUrl,
             };
 
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            if (shouldTrace)
+            {
+                var serilog = new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .Enrich.FromLogContext()
+                    .WriteTo.LiterateConsole(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
+                    .CreateLogger();
+
+                options.LoggerFactory.AddSerilog(serilog);
+            }
+
             return new OidcClient(options);
         }
 
@@ -49,8 +73,13 @@ namespace k8s.Authentication
         {
             try
             {
-                var result =
-                    await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
+                var result = await _oidcClient.RefreshTokenAsync(_refreshToken).ConfigureAwait(false);
+
+                if (result.IsError)
+                {
+                    throw new Exception($"{result.Error}: {result.ErrorDescription}");
+                }
+
                 _accessToken = result.AccessToken;
                 _idToken = result.IdentityToken;
                 _refreshToken = result.RefreshToken;

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -36,8 +36,6 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -36,10 +36,13 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -36,11 +36,11 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="IdentityModel.OidcClient" Version="4.0.0" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -1,3 +1,4 @@
+using k8s.Authentication;
 using k8s.Exceptions;
 using k8s.KubeConfigModels;
 using System;
@@ -243,6 +244,18 @@ namespace k8s.Tests
             var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, useRelativePaths: false);
             Assert.Equal("admin", cfg.Username);
             Assert.Equal("secret", cfg.Password);
+        }
+
+        /// <summary>
+        ///     Checks oidc authentication provider information is read properly
+        /// </summary>
+        [Fact]
+        public void UserOidcAuthentication()
+        {
+            var fi = new FileInfo("assets/kubeconfig.user-oidc.yml");
+            var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(fi, useRelativePaths: false);
+            Assert.Equal("ID_TOKEN", cfg.AccessToken);
+            Assert.IsType<OidcTokenProvider>(cfg.TokenProvider);
         }
 
         /// <summary>

--- a/tests/KubernetesClient.Tests/OidcAuthTests.cs
+++ b/tests/KubernetesClient.Tests/OidcAuthTests.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using k8s.Authentication;
+using k8s.Exceptions;
+using Xunit;
+
+namespace k8s.Tests
+{
+    public class OidcAuthTests
+    {
+        [Fact]
+        public async Task TestOidcAuth()
+        {
+            var clientId = "CLIENT_ID";
+            var clientSecret = "CLIENT_SECRET";
+            var idpIssuerUrl = "https://idp.issuer.url";
+            var unexpiredIdToken = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjAsImV4cCI6MjAwMDAwMDAwMH0.8Ata5uKlrqYfeIaMwS91xVgVFHu7ntHx1sGN95i2Zho";
+            var expiredIdToken = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.f37LFpIw_XIS5TZt3wdtEjjyCNshYy03lOWpyDViRM0";
+            var refreshToken = "REFRESH_TOKEN";
+
+            // use unexpired id token as bearer, do not attempt to refresh
+            var auth = new OidcTokenProvider(clientId, clientSecret, idpIssuerUrl, unexpiredIdToken, refreshToken);
+            var result = await auth.GetAuthenticationHeaderAsync(CancellationToken.None).ConfigureAwait(false);
+            result.Scheme.Should().Be("Bearer");
+            result.Parameter.Should().Be(unexpiredIdToken);
+
+            try
+            {
+                // attempt to refresh id token when expired
+                auth = new OidcTokenProvider(clientId, clientSecret, idpIssuerUrl, expiredIdToken, refreshToken);
+                result = await auth.GetAuthenticationHeaderAsync(CancellationToken.None).ConfigureAwait(false);
+                result.Scheme.Should().Be("Bearer");
+                result.Parameter.Should().Be(expiredIdToken);
+                Assert.True(false, "should not be here");
+            }
+            catch (KubernetesClientException e)
+            {
+                Assert.StartsWith("Unable to refresh OIDC token.", e.Message);
+            }
+
+            try
+            {
+                // attempt to refresh id token when null
+                auth = new OidcTokenProvider(clientId, clientSecret, idpIssuerUrl, null, refreshToken);
+                result = await auth.GetAuthenticationHeaderAsync(CancellationToken.None).ConfigureAwait(false);
+                result.Scheme.Should().Be("Bearer");
+                result.Parameter.Should().Be(expiredIdToken);
+                Assert.True(false, "should not be here");
+            }
+            catch (KubernetesClientException e)
+            {
+                Assert.StartsWith("Unable to refresh OIDC token.", e.Message);
+            }
+        }
+    }
+}

--- a/tests/KubernetesClient.Tests/TokenFileAuthTests.cs
+++ b/tests/KubernetesClient.Tests/TokenFileAuthTests.cs
@@ -3,11 +3,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using k8s.Authentication;
+using Xunit;
 
 namespace k8s.Tests
 {
     public class TokenFileAuthTests
     {
+        [Fact]
         public async Task TestToken()
         {
             var auth = new TokenFileAuth("assets/token1");
@@ -20,7 +22,7 @@ namespace k8s.Tests
             result.Scheme.Should().Be("Bearer");
             result.Parameter.Should().Be("token1");
 
-            auth.TokenExpiresAt = DateTime.UtcNow;
+            auth.TokenExpiresAt = DateTime.UtcNow.AddSeconds(-1);
             result = await auth.GetAuthenticationHeaderAsync(CancellationToken.None).ConfigureAwait(false);
             result.Scheme.Should().Be("Bearer");
             result.Parameter.Should().Be("token2");

--- a/tests/KubernetesClient.Tests/assets/kubeconfig.user-oidc.yml
+++ b/tests/KubernetesClient.Tests/assets/kubeconfig.user-oidc.yml
@@ -1,0 +1,28 @@
+# Sample file based on https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/
+# WARNING: File includes minor fixes
+---
+current-context: federal-context
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: assets/ca.crt
+    server: https://horse.org:4443
+  name: horse-cluster
+contexts:
+- context:
+    cluster: horse-cluster
+    namespace: chisel-ns
+    user: green-user
+  name: federal-context
+kind: Config
+users:
+- name: green-user
+  user:
+    auth-provider:
+      config:
+        client-id: CLIENT_ID
+        client-secret: CLIENT_SECRET
+        id-token: ID_TOKEN
+        idp-issuer-url: IDP_ISSUER_URL
+        refresh-token: REFRESH_TOKEN
+      name: oidc


### PR DESCRIPTION
this pull request
- fixes an issues where the oicd expiration was not being properly checked causing the token to alway be refreshed
  - for me the issue causes an attempted and failed token refresh that prevents successful oicd authorization
    - some tokens are long lived and unable to be refreshed depending on the type of connector
      - https://github.com/dexidp/dex/#connectors
  - we now look at the expiration from the token and only attempt a refresh when needed similar to the javascript client
    - https://github.com/kubernetes-client/javascript/blob/master/src/oidc_auth.ts
  - we now use the id token instead of the access token for authentication
    - https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
- adds better error for failed token refreshes
  - all i was seeing was `Unauthorized` but the actual error i was facing turned out to be
    - `invalid_request: Refresh token is invalid or has already been claimed by another client.`

related issues
- https://github.com/microsoft/mindaro/issues/80#issuecomment-842406752
- https://github.com/microsoft/mindaro/issues/174
- https://github.com/kubernetes-client/csharp/issues/624
- https://github.com/kubernetes-client/csharp/pull/544