### PR TITLE
Expose kube config default location

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -19,7 +19,7 @@ namespace k8s
         /// <summary>
         ///     kubeconfig Default Location
         /// </summary>
-        private static readonly string KubeConfigDefaultLocation =
+        public static readonly string KubeConfigDefaultLocation =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), @".kube\config")
                 : Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".kube/config");


### PR DESCRIPTION
Expose `KubeConfigDefaultLocation` so that user could use directly
Relate issue: #634 