### PR TITLE
Copy to/from pod

### DIFF
--- a/src/KubernetesClient/IKubernetes.Copy.cs
+++ b/src/KubernetesClient/IKubernetes.Copy.cs
@@ -140,10 +140,10 @@ namespace k8s
         /// The container in which the source directory exist.
         /// </param>
         /// <param name="sourceFolderPath">
-        /// The source file path.
+        /// The source directory path.
         /// </param>
         /// <param name="destinationFolderPath">
-        /// The destination file path.
+        /// The destination directory path.
         /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -152,5 +152,54 @@ namespace k8s
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
         Task<int> CopyDirectoryFromPodAsync(string name, string @namespace, string container, string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a directory from the local machine into a pod's container.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod object which contains the container in which the directory will be copy.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the directory will be copy.
+        /// </param>
+        /// <param name="sourceFolderPath">
+        /// The source directory path.
+        /// </param>
+        /// <param name="destinationFolderPath">
+        /// The destination directory path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyDirectoryToPodAsync(V1Pod pod, string container, string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a directory from the local machine into a pod's container.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the pod which contains the container in which the directory will be copy.
+        /// </param>
+        /// <param name="namespace">
+        /// The namespace of the container.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the directory will be copy.
+        /// </param>
+        /// <param name="sourceFolderPath">
+        /// The source directory path.
+        /// </param>
+        /// <param name="destinationFolderPath">
+        /// The destination directory path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyDirectoryToPodAsync(string name, string @namespace, string container, string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/KubernetesClient/IKubernetes.Copy.cs
+++ b/src/KubernetesClient/IKubernetes.Copy.cs
@@ -7,7 +7,7 @@ namespace k8s
     public partial interface IKubernetes
     {
         /// <summary>
-        /// Copy a file from a node into the local machine.
+        /// Copy a file from a pod's container into the local machine.
         /// </summary>
         /// <param name="pod">
         /// The pod object which contains the container in which the source file exist.
@@ -30,7 +30,7 @@ namespace k8s
         Task<int> CopyFileFromPodAsync(V1Pod pod, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Copy a file from a node into the local machine.
+        /// Copy a file from a pod's container into the local machine.
         /// </summary>
         /// <param name="name">
         /// The name of the pod which contains the container in which the source file exist.
@@ -56,13 +56,13 @@ namespace k8s
         Task<int> CopyFileFromPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Copy a file from a node into the local machine.
+        /// Copy a file from the local machine into a pod's container.
         /// </summary>
         /// <param name="pod">
-        /// The pod object which contains the container in which the source file exist.
+        /// The pod object which contains the container in which the file will be copy.
         /// </param>
         /// <param name="container">
-        /// The container in which the source file exist.
+        /// The container in which the file will be copy.
         /// </param>
         /// <param name="sourceFilePath">
         /// The source file path.
@@ -79,16 +79,16 @@ namespace k8s
         Task<int> CopyFileToPodAsync(V1Pod pod, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Copy a file from a node into the local machine.
+        /// Copy a file from the local machine into a pod's container.
         /// </summary>
         /// <param name="name">
-        /// The name of the pod which contains the container in which the source file exist.
+        /// The name of the pod which contains the container in which the file will be copy.
         /// </param>
         /// <param name="namespace">
         /// The namespace of the container.
         /// </param>
         /// <param name="container">
-        /// The container in which the source file exist.
+        /// The container in which the file will be copy.
         /// </param>
         /// <param name="sourceFilePath">
         /// The source file path.
@@ -103,5 +103,54 @@ namespace k8s
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
         Task<int> CopyFileToPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a directory from a pod's container into the local machine.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod object which contains the container in which the source directory exist.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source directory exist.
+        /// </param>
+        /// <param name="sourceFolderPath">
+        /// The source directory path.
+        /// </param>
+        /// <param name="destinationFolderPath">
+        /// The destination directory path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyDirectoryFromPodAsync(V1Pod pod, string container, string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a directory from a pod's container into the local machine.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the pod which contains the container in which the source directory exist.
+        /// </param>
+        /// <param name="namespace">
+        /// The namespace of the container.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source directory exist.
+        /// </param>
+        /// <param name="sourceFolderPath">
+        /// The source file path.
+        /// </param>
+        /// <param name="destinationFolderPath">
+        /// The destination file path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyDirectoryFromPodAsync(string name, string @namespace, string container, string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/KubernetesClient/IKubernetes.Copy.cs
+++ b/src/KubernetesClient/IKubernetes.Copy.cs
@@ -1,0 +1,58 @@
+using k8s.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    public partial interface IKubernetes
+    {
+        /// <summary>
+        /// Copy a file from a node into the local machine.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod object which contains the container in which the source file exist.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source file exist.
+        /// </param>
+        /// <param name="sourcePath">
+        /// The source file path.
+        /// </param>
+        /// <param name="destinationPath">
+        /// The destination file path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task CopyFileFromPod(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a file from a node into the local machine.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the pod which contains the container in which the source file exist.
+        /// </param>
+        /// <param name="namespace">
+        /// The namespace of the container.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source file exist.
+        /// </param>
+        /// <param name="sourcePath">
+        /// The source file path.
+        /// </param>
+        /// <param name="destinationPath">
+        /// The destination file path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task CopyFileFromPod(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/KubernetesClient/IKubernetes.Copy.cs
+++ b/src/KubernetesClient/IKubernetes.Copy.cs
@@ -15,10 +15,10 @@ namespace k8s
         /// <param name="container">
         /// The container in which the source file exist.
         /// </param>
-        /// <param name="sourcePath">
+        /// <param name="sourceFilePath">
         /// The source file path.
         /// </param>
-        /// <param name="destinationPath">
+        /// <param name="destinationFilePath">
         /// The destination file path.
         /// </param>
         /// <param name="cancellationToken">
@@ -27,7 +27,7 @@ namespace k8s
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        Task CopyFileFromPod(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> CopyFileFromPodAsync(V1Pod pod, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Copy a file from a node into the local machine.
@@ -41,10 +41,10 @@ namespace k8s
         /// <param name="container">
         /// The container in which the source file exist.
         /// </param>
-        /// <param name="sourcePath">
+        /// <param name="sourceFilePath">
         /// The source file path.
         /// </param>
-        /// <param name="destinationPath">
+        /// <param name="destinationFilePath">
         /// The destination file path.
         /// </param>
         /// <param name="cancellationToken">
@@ -53,6 +53,6 @@ namespace k8s
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        Task CopyFileFromPod(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> CopyFileFromPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/KubernetesClient/IKubernetes.Copy.cs
+++ b/src/KubernetesClient/IKubernetes.Copy.cs
@@ -54,5 +54,54 @@ namespace k8s
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
         Task<int> CopyFileFromPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a file from a node into the local machine.
+        /// </summary>
+        /// <param name="pod">
+        /// The pod object which contains the container in which the source file exist.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source file exist.
+        /// </param>
+        /// <param name="sourceFilePath">
+        /// The source file path.
+        /// </param>
+        /// <param name="destinationFilePath">
+        /// The destination file path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyFileToPodAsync(V1Pod pod, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Copy a file from a node into the local machine.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the pod which contains the container in which the source file exist.
+        /// </param>
+        /// <param name="namespace">
+        /// The namespace of the container.
+        /// </param>
+        /// <param name="container">
+        /// The container in which the source file exist.
+        /// </param>
+        /// <param name="sourceFilePath">
+        /// The source file path.
+        /// </param>
+        /// <param name="destinationFilePath">
+        /// The destination file path.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        Task<int> CopyFileToPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/KubernetesClient/Kubernetes.Copy.cs
+++ b/src/KubernetesClient/Kubernetes.Copy.cs
@@ -1,62 +1,82 @@
-using k8s.Models;
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+using k8s.Models;
 
 namespace k8s
 {
     public partial class Kubernetes
     {
-        public async Task CopyFileFromPod(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken))
+        /*******************************************************************
+        ** /!\ Requires that the 'tar' binary is present in your container
+        ** image. If 'tar' is not present, the copy will fail. /!\
+        *******************************************************************/
+        public async Task<int> CopyFileFromPodAsync(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await CopyFileFromPod(pod.Metadata.Name, pod.Metadata.NamespaceProperty, container, sourcePath, destinationPath, cancellationToken).ConfigureAwait(false);
+            if (pod == null)
+            {
+                throw new ArgumentNullException(nameof(pod));
+            }
+
+            return await CopyFileFromPodAsync(pod.Metadata.Name, pod.Metadata.NamespaceProperty, container, sourcePath, destinationPath, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task CopyFileFromPod(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<int> CopyFileFromPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var handler = GetCopyFileFromPodHandler(destinationFilePath);
-
             // All other parameters are being validated by MuxedStreamNamespacedPodExecAsync called by NamespacedPodExecAsync
             if (string.IsNullOrWhiteSpace(sourceFilePath))
             {
                 throw new ArgumentException($"{nameof(sourceFilePath)} cannot be null or whitespace");
             }
+
             if (string.IsNullOrWhiteSpace(destinationFilePath))
             {
                 throw new ArgumentException($"{nameof(destinationFilePath)} cannot be null or whitespace");
             }
 
-            await NamespacedPodExecAsync(name, @namespace, container, new string[] { "sh", "-c", $"cat {sourceFilePath} | base64" }, false, handler, cancellationToken).ConfigureAwait(false);
-        }
-
-        private ExecAsyncCallback GetCopyFileFromPodHandler(string destinationFilePath)
-        {
-            return new ExecAsyncCallback((stdIn, stdOut, stdError) =>
+            // The callback which processes the standard input, standard output and standard error of exec method
+            var handler = new ExecAsyncCallback(async (stdIn, stdOut, stdError) =>
             {
-                StreamReader errorReader = new StreamReader(stdError);
-
-                if (errorReader.Peek() != -1)
+                using (var errorReader = new StreamReader(stdError))
                 {
-                    var error = errorReader.ReadToEnd();
-                    throw new IOException($"Copy command failed: {error}");
+                    if (errorReader.Peek() != -1)
+                    {
+                        var error = await errorReader.ReadToEndAsync().ConfigureAwait(false);
+                        throw new IOException($"Copy command failed: {error}");
+                    }
                 }
 
-                StreamReader outReader = new StreamReader(stdOut);
-                var encodedData = outReader.ReadToEnd();
-
-                using (FileStream output = new FileStream(destinationFilePath, FileMode.Create))
+                try
                 {
-                    var data = Convert.FromBase64String(encodedData);
-                    output.Write(data, 0, data.Length);
-                }
+                    using (var stream = new CryptoStream(stdOut, new FromBase64Transform(), CryptoStreamMode.Read))
+                    using (var gzipStream = new GZipInputStream(stream))
+                    using (var tarInputStream = new TarInputStream(gzipStream))
+                    {
+                        var tarEntry = tarInputStream.GetNextEntry();
+                        var directoryName = Path.GetDirectoryName(destinationFilePath);
 
-#if NET452
-                return Task.FromResult(0);
-#else
-                return Task.CompletedTask;
-#endif
+                        if (!string.IsNullOrEmpty(directoryName))
+                        {
+                            Directory.CreateDirectory(directoryName);
+                        }
+
+                        using (var outputFile = new FileStream(destinationFilePath, FileMode.Create))
+                        {
+                            tarInputStream.CopyEntryContents(outputFile);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"Copy command failed: {ex.Message}");
+                }
             });
+
+            return await NamespacedPodExecAsync(name, @namespace, container, new string[] { "sh", "-c", $"tar cz {sourceFilePath} | base64" }, false, handler, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/KubernetesClient/Kubernetes.Copy.cs
+++ b/src/KubernetesClient/Kubernetes.Copy.cs
@@ -1,8 +1,9 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Threading;
+using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using k8s.Models;
@@ -77,6 +78,107 @@ namespace k8s
             });
 
             return await NamespacedPodExecAsync(name, @namespace, container, new string[] { "sh", "-c", $"tar cz {sourceFilePath} | base64" }, false, handler, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<int> CopyFileToPodAsync(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (pod == null)
+            {
+                throw new ArgumentNullException(nameof(pod));
+            }
+
+            return await CopyFileToPodAsync(pod.Metadata.Name, pod.Metadata.NamespaceProperty, container, sourcePath, destinationPath, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<int> CopyFileToPodAsync(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // All other parameters are being validated by MuxedStreamNamespacedPodExecAsync called by NamespacedPodExecAsync
+            if (string.IsNullOrWhiteSpace(sourceFilePath))
+            {
+                throw new ArgumentException($"{nameof(sourceFilePath)} cannot be null or whitespace");
+            }
+
+            if (string.IsNullOrWhiteSpace(destinationFilePath))
+            {
+                throw new ArgumentException($"{nameof(destinationFilePath)} cannot be null or whitespace");
+            }
+
+            // The callback which processes the standard input, standard output and standard error of exec method
+            var handler = new ExecAsyncCallback(async (stdIn, stdOut, stdError) =>
+            {
+                var fileInfo = new FileInfo(destinationFilePath);
+
+                try
+                {
+                    using (var outputStream = new MemoryStream())
+                    {
+                        using (var inputFileStream = File.OpenRead(sourceFilePath))
+                        using (var gZipOutputStream = new GZipOutputStream(outputStream))
+                        using (var tarOutputStream = new TarOutputStream(gZipOutputStream))
+                        {
+                            // To avoid gZipOutputStream to close the memoryStream
+                            gZipOutputStream.IsStreamOwner = false;
+
+                            var fileSize = inputFileStream.Length;
+                            var entry = TarEntry.CreateTarEntry(fileInfo.Name);
+                            entry.Size = fileSize;
+
+                            tarOutputStream.PutNextEntry(entry);
+
+                            // this is copied from TarArchive.WriteEntryCore
+                            byte[] localBuffer = new byte[32 * 1024];
+                            while (true)
+                            {
+                                int numRead = inputFileStream.Read(localBuffer, 0, localBuffer.Length);
+                                if (numRead <= 0)
+                                {
+                                    break;
+                                }
+
+                                tarOutputStream.Write(localBuffer, 0, numRead);
+                            }
+
+                            tarOutputStream.CloseEntry();
+                        }
+
+                        outputStream.Position = 0;
+                        using (var cryptoStream = new CryptoStream(stdIn, new ToBase64Transform(), CryptoStreamMode.Write))
+                        {
+                            outputStream.CopyTo(cryptoStream);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"Copy command failed: {ex.Message}");
+                }
+
+                using (var errorReader = new StreamReader(stdError))
+                {
+                    if (errorReader.Peek() != -1)
+                    {
+                        var error = await errorReader.ReadToEndAsync().ConfigureAwait(false);
+                        throw new IOException($"Copy command failed: {error}");
+                    }
+                }
+            });
+
+            var destinationFileInfo = new FileInfo(destinationFilePath);
+            var destinationFolder = Path.GetDirectoryName(destinationFilePath);
+
+            if (string.IsNullOrEmpty(destinationFolder))
+            {
+                destinationFolder = ".";
+            }
+
+            return await NamespacedPodExecAsync(
+                name,
+                @namespace,
+                container,
+                new string[] { "sh", "-c", $"base64 -d | tar xzmf - -C {destinationFolder}" },
+                false,
+                handler,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/KubernetesClient/Kubernetes.Copy.cs
+++ b/src/KubernetesClient/Kubernetes.Copy.cs
@@ -1,0 +1,62 @@
+using k8s.Models;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace k8s
+{
+    public partial class Kubernetes
+    {
+        public async Task CopyFileFromPod(V1Pod pod, string container, string sourcePath, string destinationPath, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await CopyFileFromPod(pod.Metadata.Name, pod.Metadata.NamespaceProperty, container, sourcePath, destinationPath, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task CopyFileFromPod(string name, string @namespace, string container, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var handler = GetCopyFileFromPodHandler(destinationFilePath);
+
+            // All other parameters are being validated by MuxedStreamNamespacedPodExecAsync called by NamespacedPodExecAsync
+            if (string.IsNullOrWhiteSpace(sourceFilePath))
+            {
+                throw new ArgumentException($"{nameof(sourceFilePath)} cannot be null or whitespace");
+            }
+            if (string.IsNullOrWhiteSpace(destinationFilePath))
+            {
+                throw new ArgumentException($"{nameof(destinationFilePath)} cannot be null or whitespace");
+            }
+
+            await NamespacedPodExecAsync(name, @namespace, container, new string[] { "sh", "-c", $"cat {sourceFilePath} | base64" }, false, handler, cancellationToken).ConfigureAwait(false);
+        }
+
+        private ExecAsyncCallback GetCopyFileFromPodHandler(string destinationFilePath)
+        {
+            return new ExecAsyncCallback((stdIn, stdOut, stdError) =>
+            {
+                StreamReader errorReader = new StreamReader(stdError);
+
+                if (errorReader.Peek() != -1)
+                {
+                    var error = errorReader.ReadToEnd();
+                    throw new IOException($"Copy command failed: {error}");
+                }
+
+                StreamReader outReader = new StreamReader(stdOut);
+                var encodedData = outReader.ReadToEnd();
+
+                using (FileStream output = new FileStream(destinationFilePath, FileMode.Create))
+                {
+                    var data = Convert.FromBase64String(encodedData);
+                    output.Write(data, 0, data.Length);
+                }
+
+#if NET452
+                return Task.FromResult(0);
+#else
+                return Task.CompletedTask;
+#endif
+            });
+        }
+    }
+}

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -41,8 +41,11 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <Reference Include="System.Net.Http.WebRequest" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implementation for copy from/to a pod.

Important note, to make a copy, it requires that the tar binary is present in your container image, like the kubectl cp command.

This should eventually resolve #464

- [ ] Copy file from a pod
- [ ] Copy directory from a pod
- [ ] Copy file to a pod
- [ ] Copy directory to a pod