### PR TITLE
fix flaky leader election tests

### DIFF
--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -7,16 +7,25 @@ using System.Threading.Tasks;
 using k8s.LeaderElection;
 using Moq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace k8s.Tests.LeaderElection
 {
     public class LeaderElectionTests
     {
-        public LeaderElectionTests()
+        private static ITestOutputHelper xoutput;
+
+        public LeaderElectionTests(ITestOutputHelper output)
+            : base()
         {
-            ThreadPool.SetMaxThreads(32, 32);
+            xoutput = output;
             MockResourceLock.ResetGloablRecord();
         }
+
+        //public LeaderElectionTests()
+        //{
+        //    MockResourceLock.ResetGloablRecord();
+        //}
 
         [Fact]
         public void SimpleLeaderElection()
@@ -442,6 +451,7 @@ namespace k8s.Tests.LeaderElection
 
             public Task<bool> UpdateAsync(LeaderElectionRecord record, CancellationToken cancellationToken = default)
             {
+                xoutput.WriteLine(DateTime.Now.ToString("hh:mm:ss.fff") + " call update");
                 lock (Lockobj)
                 {
                     OnTryUpdate?.Invoke(record);

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -13,8 +13,11 @@ namespace k8s.Tests.LeaderElection
 {
     public class LeaderElectionTests
     {
-        public LeaderElectionTests()
+        private readonly ITestOutputHelper output;
+
+        public LeaderElectionTests(ITestOutputHelper output)
         {
+            this.output = output;
             MockResourceLock.ResetGloablRecord();
         }
 
@@ -273,6 +276,8 @@ namespace k8s.Tests.LeaderElection
 
             countdown.Wait(TimeSpan.FromSeconds(15));
             electionHistoryCountdown.Wait(TimeSpan.FromSeconds(15));
+
+            output.WriteLine(string.Join(",", electionHistory));
 
             Assert.True(electionHistory.Take(9).SequenceEqual(new[]
             {

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -14,6 +14,7 @@ namespace k8s.Tests.LeaderElection
     {
         public LeaderElectionTests()
         {
+            ThreadPool.SetMaxThreads(32, 32);
             MockResourceLock.ResetGloablRecord();
         }
 
@@ -256,13 +257,13 @@ namespace k8s.Tests.LeaderElection
             countdown.Wait(TimeSpan.FromSeconds(10));
 
             // TODO flasky
-            // Assert.Equal(9, electionHistory.Count);
+            Assert.Equal(9, electionHistory.Count);
 
-            // Assert.True(electionHistory.SequenceEqual(new[]
-            // {
-            //     "create record", "try update record", "update record", "try update record", "update record",
-            //     "try update record", "try update record", "try update record", "try update record",
-            // }));
+            Assert.True(electionHistory.SequenceEqual(new[]
+            {
+                 "create record", "try update record", "update record", "try update record", "update record",
+                 "try update record", "try update record", "try update record", "try update record",
+            }));
 
             Assert.True(electionHistory.Take(7).SequenceEqual(new[]
             {

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -13,19 +13,10 @@ namespace k8s.Tests.LeaderElection
 {
     public class LeaderElectionTests
     {
-        private static ITestOutputHelper xoutput;
-
-        public LeaderElectionTests(ITestOutputHelper output)
-            : base()
+        public LeaderElectionTests()
         {
-            xoutput = output;
             MockResourceLock.ResetGloablRecord();
         }
-
-        //public LeaderElectionTests()
-        //{
-        //    MockResourceLock.ResetGloablRecord();
-        //}
 
         [Fact]
         public void SimpleLeaderElection()
@@ -91,6 +82,7 @@ namespace k8s.Tests.LeaderElection
         {
             var electionHistory = new List<string>();
             var leadershipHistory = new List<string>();
+            var electionHistoryCountdown = new CountdownEvent(7);
 
             var renewCountA = 3;
             var mockLockA = new MockResourceLock("mockA") { UpdateWillFail = () => renewCountA <= 0 };
@@ -101,12 +93,14 @@ namespace k8s.Tests.LeaderElection
 
                 electionHistory.Add("A creates record");
                 leadershipHistory.Add("A gets leadership");
+                electionHistoryCountdown.Signal();
             };
 
             mockLockA.OnUpdate += (_) =>
             {
                 renewCountA--;
                 electionHistory.Add("A updates record");
+                electionHistoryCountdown.Signal();
             };
 
             mockLockA.OnChange += (_) => { leadershipHistory.Add("A gets leadership"); };
@@ -126,6 +120,7 @@ namespace k8s.Tests.LeaderElection
                 renewCountB--;
 
                 electionHistory.Add("B creates record");
+                electionHistoryCountdown.Signal();
                 leadershipHistory.Add("B gets leadership");
             };
 
@@ -133,6 +128,7 @@ namespace k8s.Tests.LeaderElection
             {
                 renewCountB--;
                 electionHistory.Add("B updates record");
+                electionHistoryCountdown.Signal();
             };
 
             mockLockB.OnChange += (_) => { leadershipHistory.Add("B gets leadership"); };
@@ -189,7 +185,8 @@ namespace k8s.Tests.LeaderElection
                 leaderElector.RunAsync().Wait();
             });
 
-            testLeaderElectionLatch.Wait(TimeSpan.FromSeconds(10));
+            testLeaderElectionLatch.Wait(TimeSpan.FromSeconds(15));
+            electionHistoryCountdown.Wait(TimeSpan.FromSeconds(15));
 
             Assert.Equal(7, electionHistory.Count);
 
@@ -214,6 +211,7 @@ namespace k8s.Tests.LeaderElection
         {
             var electionHistory = new List<string>();
             var leadershipHistory = new List<string>();
+            var electionHistoryCountdown = new CountdownEvent(9);
 
             var renewCount = 3;
             var mockLock = new MockResourceLock("mock") { UpdateWillFail = () => renewCount <= 0, };
@@ -223,17 +221,27 @@ namespace k8s.Tests.LeaderElection
                 renewCount--;
                 electionHistory.Add("create record");
                 leadershipHistory.Add("get leadership");
+                electionHistoryCountdown.Signal();
             };
 
             mockLock.OnUpdate += _ =>
             {
                 renewCount--;
                 electionHistory.Add("update record");
+                electionHistoryCountdown.Signal();
             };
 
-            mockLock.OnChange += _ => { electionHistory.Add("change record"); };
+            mockLock.OnChange += _ =>
+            {
+                electionHistory.Add("change record");
+                electionHistoryCountdown.Signal();
+            };
 
-            mockLock.OnTryUpdate += _ => { electionHistory.Add("try update record"); };
+            mockLock.OnTryUpdate += _ =>
+            {
+                electionHistory.Add("try update record");
+                electionHistoryCountdown.Signal();
+            };
 
 
             var leaderElectionConfig = new LeaderElectionConfig(mockLock)
@@ -263,21 +271,13 @@ namespace k8s.Tests.LeaderElection
                 leaderElector.RunAsync().Wait();
             });
 
-            countdown.Wait(TimeSpan.FromSeconds(10));
+            countdown.Wait(TimeSpan.FromSeconds(15));
+            electionHistoryCountdown.Wait(TimeSpan.FromSeconds(15));
 
-            // TODO flasky
-            Assert.Equal(9, electionHistory.Count);
-
-            Assert.True(electionHistory.SequenceEqual(new[]
+            Assert.True(electionHistory.Take(9).SequenceEqual(new[]
             {
                  "create record", "try update record", "update record", "try update record", "update record",
                  "try update record", "try update record", "try update record", "try update record",
-            }));
-
-            Assert.True(electionHistory.Take(7).SequenceEqual(new[]
-            {
-                "create record", "try update record", "update record", "try update record", "update record",
-                "try update record", "try update record",
             }));
 
             Assert.True(leadershipHistory.SequenceEqual(new[] { "get leadership", "start leading", "stop leading" }));
@@ -451,7 +451,6 @@ namespace k8s.Tests.LeaderElection
 
             public Task<bool> UpdateAsync(LeaderElectionRecord record, CancellationToken cancellationToken = default)
             {
-                xoutput.WriteLine(DateTime.Now.ToString("hh:mm:ss.fff") + " call update");
                 lock (Lockobj)
                 {
                     OnTryUpdate?.Invoke(record);

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -17,6 +17,8 @@ namespace k8s.Tests.LeaderElection
 
         public LeaderElectionTests(ITestOutputHelper output)
         {
+            ThreadPool.SetMaxThreads(32, 32);
+            ThreadPool.SetMinThreads(32, 32);
             this.output = output;
             MockResourceLock.ResetGloablRecord();
         }


### PR DESCRIPTION
#675

reason the test is flaky is that the test env task scheduler is not stable

how fix works?
- force 32 threads to ensure tasks switch smoothly
- use countdown latch to sync in case of task switch too slow

verify
re-run manually, got 10 successful runs in a row


