### PR TITLE
Upgrade Microsoft.Rest.ClientRuntime from 2.3.10 to 2.3.23

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Fractions" Version="4.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />


### PR DESCRIPTION
Upgrade Microsoft.Rest.ClientRuntime from 2.3.10 to 2.3.23 to fix security vulnerability CVE-2019-0820.

Fixes #699
