### PR TITLE
Upgrade Microsoft.Rest.ClientRuntime from 2.3.10 to 2.3.23

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Fractions" Version="4.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />

--- a/tests/KubernetesClient.Tests/PodExecTests.cs
+++ b/tests/KubernetesClient.Tests/PodExecTests.cs
@@ -191,7 +191,8 @@ namespace k8s.Tests
                 muxedStream.Setup(m => m.GetStream(ChannelIndex.Error, null)).Returns(errorStream);
 
                 var kubernetesMock = new Moq.Mock<Kubernetes>(
-                    new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } });
+                    new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } })
+                { CallBase = true };
                 var command = new string[] { "/bin/bash", "-c", "echo Hello, World!" };
 
                 kubernetesMock.Setup(m => m.MuxedStreamNamespacedPodExecAsync("pod-name", "pod-namespace", command,
@@ -213,7 +214,8 @@ namespace k8s.Tests
         public async Task NamespacedPodExecAsyncHttpExceptionWithStatus()
         {
             var kubernetesMock = new Moq.Mock<Kubernetes>(
-                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } });
+                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } })
+            { CallBase = true };
             var command = new string[] { "/bin/bash", "-c", "echo Hello, World!" };
             var handler = new ExecAsyncCallback((stdIn, stdOut, stdError) => Task.CompletedTask);
 
@@ -237,7 +239,8 @@ namespace k8s.Tests
         public async Task NamespacedPodExecAsyncHttpExceptionNoStatus()
         {
             var kubernetesMock = new Moq.Mock<Kubernetes>(
-                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } });
+                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } })
+            { CallBase = true };
             var command = new string[] { "/bin/bash", "-c", "echo Hello, World!" };
             var handler = new ExecAsyncCallback((stdIn, stdOut, stdError) => Task.CompletedTask);
 
@@ -260,7 +263,8 @@ namespace k8s.Tests
         public async Task NamespacedPodExecAsyncGenericException()
         {
             var kubernetesMock = new Moq.Mock<Kubernetes>(
-                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } });
+                new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } })
+            { CallBase = true };
             var command = new string[] { "/bin/bash", "-c", "echo Hello, World!" };
             var handler = new ExecAsyncCallback((stdIn, stdOut, stdError) => Task.CompletedTask);
 
@@ -313,7 +317,8 @@ namespace k8s.Tests
                 muxedStream.Setup(m => m.GetStream(ChannelIndex.Error, null)).Returns(errorStream);
 
                 var kubernetesMock = new Moq.Mock<Kubernetes>(
-                    new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } });
+                    new object[] { Moq.Mock.Of<ServiceClientCredentials>(), new DelegatingHandler[] { } })
+                { CallBase = true };
                 var command = new string[] { "/bin/bash", "-c", "echo Hello, World!" };
 
                 var exception = new Exception();


### PR DESCRIPTION
Upgrade Microsoft.Rest.ClientRuntime from 2.3.10 to 2.3.23 to fix security vulnerability CVE-2019-0820.

Fixes #699