### PR TITLE
Update CustomResource example + Upgrade Nuget packages versions

### DIFF
--- a/examples/customResource/CustomResourceDefinition.cs
+++ b/examples/customResource/CustomResourceDefinition.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using k8s;
 using k8s.Models;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "CA1724:TypeNamesShouldNotMatchNamespaces", Justification = "This is just an example.")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "This is just an example.")]

--- a/examples/customResource/Program.cs
+++ b/examples/customResource/Program.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
 using k8s;
 using k8s.Models;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.JsonPatch;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 
 namespace customResource
@@ -12,7 +12,7 @@ namespace customResource
     {
         private static async Task Main(string[] args)
         {
-            Console.WriteLine("strating main()...");
+            Console.WriteLine("starting main()...");
 
             // creating the k8s client
             var k8SClientConfig = KubernetesClientConfiguration.BuildConfigFromConfigFile();
@@ -21,7 +21,7 @@ namespace customResource
             // creating a K8s client for the CRD
             var myCRD = Utils.MakeCRD();
             Console.WriteLine("working with CRD: {0}.{1}", myCRD.PluralName, myCRD.Group);
-            var generic = new GenericClient(k8SClientConfig, myCRD.Group, myCRD.Version, myCRD.PluralName);
+            var generic = new GenericClient(client, myCRD.Group, myCRD.Version, myCRD.PluralName);
 
             // creating a sample custom resource content
             var myCr = Utils.MakeCResource();

--- a/examples/customResource/cResource.cs
+++ b/examples/customResource/cResource.cs
@@ -1,6 +1,4 @@
 using k8s.Models;
-using System.Collections.Generic;
-using k8s;
 using Newtonsoft.Json;
 
 namespace customResource

--- a/examples/customResource/config/crd.yaml
+++ b/examples/customResource/config/crd.yaml
@@ -1,10 +1,22 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: customresources.csharp.com
 spec:
   group: csharp.com
-  version: v1alpha1
+  versions: 
+    - name: v1alpha1
+      storage: true
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cityName:
+                  type: string
   names:
     kind: CResource
     plural: customresources

--- a/examples/customResource/customResource.csproj
+++ b/examples/customResource/customResource.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="KubernetesClient" Version="3.0.16" />
-    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <ProjectReference Include="..\..\src\KubernetesClient\KubernetesClient.csproj" />
+        <PackageReference Include="Microsoft.Build" Version="16.11.0" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.10" />
+    </ItemGroup>
 
 </Project>

--- a/examples/httpClientFactory/httpClientFactory.csproj
+++ b/examples/httpClientFactory/httpClientFactory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KubernetesClient/Authentication/OidcTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/OidcTokenProvider.cs
@@ -1,11 +1,11 @@
+using IdentityModel.OidcClient;
+using k8s.Exceptions;
+using Microsoft.Rest;
 using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.Rest;
-using IdentityModel.OidcClient;
-using k8s.Exceptions;
 
 namespace k8s.Authentication
 {
@@ -14,7 +14,7 @@ namespace k8s.Authentication
         private OidcClient _oidcClient;
         private string _idToken;
         private string _refreshToken;
-        private DateTime _expiry;
+        private DateTimeOffset _expiry;
 
         public OidcTokenProvider(string clientId, string clientSecret, string idpIssuerUrl, string idToken, string refreshToken)
         {

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -30,18 +30,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="Fractions" Version="4.0.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="Fractions" Version="7.0.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240" PrivateAssets="all" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="prometheus-net" Version="5.0.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.13.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/E2E.Tests/E2E.Tests.csproj
+++ b/tests/E2E.Tests/E2E.Tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.10" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
+++ b/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
@@ -8,29 +8,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.2" />
-      <PackageReference Include="FluentAssertions" Version="5.10.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-      <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.33" />
-      <PackageReference Include="System.Reactive" Version="4.3.2" />
-      <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
+      <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
+      <PackageReference Include="FluentAssertions" Version="6.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+      <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.47" />
+      <PackageReference Include="System.Reactive" Version="5.0.0" />
+      <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>
 
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
 
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/tests/SkipTestLogger/SkipTestLogger.csproj
+++ b/tests/SkipTestLogger/SkipTestLogger.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.8.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The CustomResource example were referencing KubernetesClient version 3.0.16 so I updated it to current latest version (6.0.11) and updated it to match the Kubernetes API v1.22. 
Then I took the oportunity to upgrade all other Nuget packages, for security and futur maintenability purpose. 
However, I didn't upgrade packages of KubernetesGenerator project because it involves breaking changes. Moreover, if I understood correctly, this version may have been chosen on purpose according to the PR #669 because NSwag version 13.12.x was already available at the time but KubernetesGenerator uses version 11.17.21. 
Tell me if you still want me to do that NSwag upgrade, but it seems a very sensitive part of the project and I don't really know much about NSwag and Nustache templates.  