### PR TITLE
Fixed bug in methods which hit "apis/{group}/..." url

### DIFF
--- a/gen/KubernetesGenerator/templates/Kubernetes.cs.template
+++ b/gen/KubernetesGenerator/templates/Kubernetes.cs.template
@@ -61,12 +61,12 @@ namespace k8s
             // Construct URL
             var _baseUrl = BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "{{path}}").ToString();
-            _url = _url.Replace("/apis//", "/api/");
             {{#operation.parameters}}
             {{#IfKindIs . "path"}}
             _url = _url.Replace("{{AddCurly name}}", {{GetDotNetName name}});
             {{/IfKindIs . "path"}}
             {{/operation.parameters}}
+            _url = _url.Replace("/apis//", "/api/");
             List<string> _queryParameters = new List<string>();
             {{#operation.parameters}}
             {{#IfKindIs . "query"}}


### PR DESCRIPTION
I've noticed that ListClusterCustomObjectWithHttpMessagesAsync and ListNamespacedCustomObjectWithHttpMessagesAsync return HTTP 404 (Not found) if group parameter is an empty string.

From the code:
```CSharp
            // Construct URL
            var _baseUrl = BaseUri.AbsoluteUri;
            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "apis/{group}/{version}/namespaces/{namespace}/{plural}").ToString();
            _url = _url.Replace("/apis//", "/api/");
            _url = _url.Replace("{group}", group);
            _url = _url.Replace("{version}", version);
            _url = _url.Replace("{namespace}", namespaceParameter);
            _url = _url.Replace("{plural}", plural);
```
We need to move "_url = _url.Replace("/apis//", "/api/");" down several lines, so that it goes after url.Replace("{group}", group).
