### PR TITLE
Fix x-kubernetes-int-or-string in CRD can not be desterilized correctly.

### DIFF
--- a/src/KubernetesClient/Yaml.cs
+++ b/src/KubernetesClient/Yaml.cs
@@ -225,7 +225,7 @@ namespace k8s
                         continue;
                     }
 
-                    var yamlAttribute = new YamlMemberAttribute { Alias = jsonAttribute.PropertyName };
+                    var yamlAttribute = new YamlMemberAttribute { Alias = jsonAttribute.PropertyName, ApplyNamingConventions = false };
                     builder.WithAttributeOverride(type, property.Name, yamlAttribute);
                 }
             }

--- a/tests/KubernetesClient.Tests/YamlTests.cs
+++ b/tests/KubernetesClient.Tests/YamlTests.cs
@@ -559,5 +559,40 @@ data:
             Assert.Equal("bXktYXBw", Encoding.UTF8.GetString(result.Data["username"]));
             Assert.Equal("Mzk1MjgkdmRnN0pi", Encoding.UTF8.GetString(result.Data["password"]));
         }
+
+        [Fact]
+        public void DeserializeWithJsonPropertyName()
+        {
+            var kManifest = @"
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test-crd
+spec:
+  group: test.crd
+  names:
+    kind: Crd
+    listKind: CrdList
+    plural: crds
+    singular: crd
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: This is a test crd.
+        x-kubernetes-int-or-string: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+";
+            var result = Yaml.LoadFromString<V1CustomResourceDefinition>(kManifest);
+            Assert.Single(result?.Spec?.Versions);
+            var ver = result.Spec.Versions[0];
+            Assert.Equal(true, ver?.Schema?.OpenAPIV3Schema?.XKubernetesIntOrString);
+        }
     }
 }


### PR DESCRIPTION
If CRD contains:
```yaml
  versions:
  - name: v1alpha1
    schema:
      openAPIV3Schema:
        description: Middleware is a specification for a Middleware resource.
        x-kubernetes-int-or-string: true
        required:
        - metadata
        - spec
        type: object
```
The `x-kubernetes-int-or-string` field can not be desterilized  to `XKubernetesIntOrString ` in `V1JSONSchemaProps` correctly. This because we use `CamelCaseNamingConvention` .This will match the field name with `CamelCase` style not exact as json Property name.

Disable naming conventions for this case