### PR TITLE
remove the dependency of unprocessed swagger file

### DIFF
--- a/gen/KubernetesGenerator/GeneralNameHelper.cs
+++ b/gen/KubernetesGenerator/GeneralNameHelper.cs
@@ -57,7 +57,7 @@ namespace KubernetesGenerator
             if (definition.Properties.TryGetValue("spec", out var specProperty))
             {
                 // ignore empty spec placeholder
-                if (specProperty.Reference.ActualProperties.Any())
+                if (specProperty.Reference?.ActualProperties.Any() == true)
                 {
                     interfaces.Add($"ISpec<{classNameHelper.GetClassNameForSchemaDefinition(specProperty.Reference)}>");
                 }

--- a/gen/KubernetesGenerator/ModelGenerator.cs
+++ b/gen/KubernetesGenerator/ModelGenerator.cs
@@ -13,11 +13,11 @@ namespace KubernetesGenerator
             this.classNameHelper = classNameHelper;
         }
 
-        public void Generate(OpenApiDocument swaggercooked, string outputDirectory)
+        public void Generate(OpenApiDocument swagger, string outputDirectory)
         {
             Directory.CreateDirectory(Path.Combine(outputDirectory, "Models"));
 
-            foreach (var (_, def) in swaggercooked.Definitions)
+            foreach (var (_, def) in swagger.Definitions)
             {
                 var clz = classNameHelper.GetClassNameForSchemaDefinition(def);
                 Render.FileToFile(

--- a/gen/KubernetesGenerator/PluralHelper.cs
+++ b/gen/KubernetesGenerator/PluralHelper.cs
@@ -11,6 +11,11 @@ namespace KubernetesGenerator
     {
         private readonly Dictionary<string, string> _classNameToPluralMap;
         private readonly ClassNameHelper classNameHelper;
+        private HashSet<string> opblackList = new HashSet<string>()
+        {
+            "listClusterCustomObject",
+            "listNamespacedCustomObject",
+        };
 
         public PluralHelper(ClassNameHelper classNameHelper, OpenApiDocument swagger)
         {
@@ -50,6 +55,7 @@ namespace KubernetesGenerator
         {
             var classNameToPluralMap = swagger.Operations
                 .Where(x => x.Operation.OperationId.StartsWith("list", StringComparison.InvariantCulture))
+                .Where(x => !opblackList.Contains(x.Operation.OperationId))
                 .Select(x => new
                 {
                     PluralName = x.Path.Split("/").Last(),


### PR DESCRIPTION
code generator no long requires `swagger.json.unprocessed`
swagger.json from `kubernetes-client/gen` only