### PR TITLE
BugFix: Wrong path in codegen section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ git clone https://github.com/kubernetes-client/gen
 ```bash
 # Where REPO_DIR points to the root of the csharp repository
 cd ${REPO_DIR}/csharp/src/KubernetesClient
-${GEN_DIR}/openapi/csharp.sh generated ../csharp.settings
+${GEN_DIR}/openapi/csharp.sh generated ../../csharp.settings
 ```
 
 # Version Compatibility 


### PR DESCRIPTION
The correct command should be ```${GEN_DIR}/openapi/csharp.sh generated ../../csharp.settings```