### PR TITLE
Automatically create a matching release for every NuGet version

### DIFF
--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -10,14 +10,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: debug
-      run: gh --version
 
+    # Can be removed when GH runner has gh version 2.4.0 (2021-12-21) or higher
     - name: install latest gh cli 
       run: choco install gh
-
-    - name: debug again
-      run: gh --version
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -13,6 +13,12 @@ jobs:
     - name: debug
       run: gh --version
 
+    - name: install latest gh cli 
+      run: choco install gh
+
+    - name: debug again
+      run: gh --version
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -32,8 +32,8 @@ jobs:
     - name: dotnet restore
       run: dotnet restore --verbosity minimal --configfile nuget.config
 
-    - name: dotnet test
-      run: dotnet test
+    #- name: dotnet test
+    #  run: dotnet test
 
     - name: dotnet pack
       run: dotnet pack -c Release src/KubernetesClient -o pkg --include-symbols

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -38,5 +38,11 @@ jobs:
     - name: dotnet pack
       run: dotnet pack -c Release src/KubernetesClient -o pkg --include-symbols
 
-    - name: dotnet nuget push
-      run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
+    # - name: dotnet nuget push
+    #   run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
+
+    - name: fetch version
+      run: echo "VERSION=$(ls -1 pkg/KubernetesClient.*.nupkg | grep -Eo '\d\.\d\.\d')" >> $GITHUB_ENV
+
+    - name: create release
+      run: gh release create --generate-notes $VERSION

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -10,11 +10,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-
-    # Can be removed when GH runner has gh version 2.4.0 (2021-12-21) or higher
-    - name: install latest gh cli 
-      run: choco install gh
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -45,6 +40,11 @@ jobs:
 
     # - name: dotnet nuget push
     #   run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
+
+    # This step can be removed when GH runner has gh version 2.4.0 (2021-12-21) or higher
+    # As of 1/8/2022, runner has 2.3.0 which doesn't support --generate-notes below
+    - name: install latest gh cli 
+      run: choco install gh
 
     - name: create release
       shell: pwsh

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -52,6 +52,8 @@ jobs:
 
     - name: create release
       shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d.\d.\d' | foreach {$_.Matches.Value}
         gh release create --generate-notes $VERSION

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -14,15 +14,15 @@ jobs:
       with:
         fetch-depth: 0
 
-    # - name: .NET Core 3.1.x SDK
-    #   uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: 3.1.x
+    - name: .NET Core 3.1.x SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
 
-    # - name: .NET 5.x SDK
-    #   uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: 5.0.x
+    - name: .NET 5.x SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
 
     - name: .NET 6.x SDK
       uses: actions/setup-dotnet@v1
@@ -32,14 +32,14 @@ jobs:
     - name: dotnet restore
       run: dotnet restore --verbosity minimal --configfile nuget.config
 
-    #- name: dotnet test
-    #  run: dotnet test
+    - name: dotnet test
+     run: dotnet test
 
     - name: dotnet pack
       run: dotnet pack -c Release src/KubernetesClient -o pkg --include-symbols
 
-    # - name: dotnet nuget push
-    #   run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
+    - name: dotnet nuget push
+      run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
 
     # This step can be removed when GH runner has gh version 2.4.0 (2021-12-21) or higher
     # As of 1/8/2022, runner has 2.3.0 which doesn't support --generate-notes below

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: debug
+      run: gh --version
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet restore --verbosity minimal --configfile nuget.config
 
     - name: dotnet test
-     run: dotnet test
+      run: dotnet test
 
     - name: dotnet pack
       run: dotnet pack -c Release src/KubernetesClient -o pkg --include-symbols

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -10,15 +10,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: debug
-      run: gh --version
-
-    - name: install latest gh cli 
-      run: choco install gh
-
-    - name: debug again
-      run: gh --version
-
+ 
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -54,4 +46,4 @@ jobs:
       shell: pwsh
       run: |
         $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d.\d.\d' | foreach {$_.Matches.Value}
-        gh release create --generate-notes $VERSION
+        gh release create $VERSION --notes "v7.0.4"

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -10,7 +10,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
- 
+    - name: debug
+      run: gh --version
+
+    - name: install latest gh cli 
+      run: choco install gh
+
+    - name: debug again
+      run: gh --version
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -46,4 +54,4 @@ jobs:
       shell: pwsh
       run: |
         $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d.\d.\d' | foreach {$_.Matches.Value}
-        gh release create $VERSION --notes "v7.0.4"
+        gh release create --generate-notes $VERSION

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: debug

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: debug

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -14,15 +14,15 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: .NET Core 3.1.x SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
+    # - name: .NET Core 3.1.x SDK
+    #   uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: 3.1.x
 
-    - name: .NET 5.x SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
+    # - name: .NET 5.x SDK
+    #   uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: 5.0.x
 
     - name: .NET 6.x SDK
       uses: actions/setup-dotnet@v1
@@ -41,8 +41,8 @@ jobs:
     # - name: dotnet nuget push
     #   run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
 
-    - name: fetch version
-      run: echo "VERSION=$(ls -1 pkg/KubernetesClient.*.nupkg | grep -Eo '\d\.\d\.\d')" >> $GITHUB_ENV
-
     - name: create release
-      run: gh release create --generate-notes $VERSION
+      shell: pwsh
+      run: |
+        $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d.\d.\d' | foreach {$_.Matches.Value}
+        gh release create --generate-notes $VERSION


### PR DESCRIPTION
Fixes #627: automatically create a matching [release](https://github.com/kubernetes-client/csharp/releases) after every NuGet push.

Uses the recently introduced (https://github.com/cli/cli/pull/4467) `--generate-notes` flag, which populates the release note with a changelog link:

![image](https://user-images.githubusercontent.com/336447/148664594-2285c241-ddd5-4b2c-9fcd-dd080ff3f193.png)
 