### PR TITLE
Support .net 6 for tcp keep alive

### DIFF
--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -176,7 +176,7 @@ namespace k8s
             FirstMessageHandler = HttpClientHandler = CreateRootHandler();
 
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             // https://github.com/kubernetes-client/csharp/issues/587
             // let user control if tcp keep alive until better fix
             if (config.TcpKeepAlive)

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -300,7 +300,7 @@ namespace k8s
                 }
                 else
                 {
-#if NET5_0
+#if NET5_0_OR_GREATER
                     var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
                     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
The tcp keep alive only work for .net 5 now, it should work for .net 6 too.