### PR TITLE
new release strategy 

### DIFF
--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -1,0 +1,47 @@
+name: Nuget
+
+on:
+  push:
+    branches: [ master ]
+    
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: .NET Core 3.1.x SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
+    - name: .NET 5.x SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    - name: .NET 6.x SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
+    - name: dotnet restore
+      run: dotnet restore --verbosity minimal --configfile nuget.config
+
+    - name: dotnet test
+      run: dotnet test
+
+    - name: dotnet pack
+      run: dotnet pack -c Release src/KubernetesClient -o pkg --include-symbols
+
+    - name: create release
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d+.\d+.\d+' | foreach {$_.Matches.Value}
+        gh release create -d --generate-notes $VERSION

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     
 jobs:
-  build:
+  draft:
 
     runs-on: windows-latest
 

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -40,11 +40,3 @@ jobs:
 
     - name: dotnet nuget push
       run: dotnet nuget push pkg\*.nupkg -s https://www.nuget.org/ -k ${{ secrets.nuget_api_key }}
-
-    - name: create release
-      shell: pwsh
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        $VERSION = Get-ChildItem -Path pkg/*.nupkg -Name | Select-String -Pattern '\d+.\d+.\d+' | foreach {$_.Matches.Value}
-        gh release create --generate-notes $VERSION

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -1,11 +1,11 @@
 name: Nuget
 
 on:
-  push:
-    branches: [ master ]
+  release:
+    types: [ released ]
     
 jobs:
-  build:
+  nuget:
 
     runs-on: windows-latest
 


### PR DESCRIPTION
stop creating a new release every commit to master
instead, creating a draft only. the admin will need to approve it in order to get nuget published

to take control of minor change nuget packages and breaking change nuget package being published