### PR TITLE
Code Enhancements

### DIFF
--- a/src/KubernetesClient/Autorest/StringTokenProvider.cs
+++ b/src/KubernetesClient/Autorest/StringTokenProvider.cs
@@ -12,8 +12,8 @@ namespace k8s.Autorest
     /// </summary>
     public sealed class StringTokenProvider : ITokenProvider
     {
-        private string _accessToken;
-        private string _type;
+        private readonly string _accessToken;
+        private readonly string _type;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StringTokenProvider"/> class.
@@ -31,10 +31,7 @@ namespace k8s.Autorest
         /// <summary>
         /// Gets the token type of this access token.
         /// </summary>
-        public string TokenType
-        {
-            get { return _type; }
-        }
+        public string TokenType => _type;
 
         /// <summary>
         /// Returns the static access token.

--- a/src/KubernetesClient/IntOrStringConverter.cs
+++ b/src/KubernetesClient/IntOrStringConverter.cs
@@ -21,7 +21,7 @@ namespace k8s.Models
         {
             var s = value?.Value;
 
-            if (int.TryParse(s, out var intv))
+            if (long.TryParse(s, out var intv))
             {
                 writer.WriteNumberValue(intv);
                 return;

--- a/src/KubernetesClient/IntOrStringConverter.cs
+++ b/src/KubernetesClient/IntOrStringConverter.cs
@@ -1,6 +1,6 @@
 namespace k8s.Models
 {
-    internal class IntOrStringConverter : JsonConverter<IntstrIntOrString>
+    internal sealed class IntOrStringConverter : JsonConverter<IntstrIntOrString>
     {
         public override IntstrIntOrString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/KubernetesClient/Kubernetes.cs
+++ b/src/KubernetesClient/Kubernetes.cs
@@ -102,7 +102,7 @@ namespace k8s
             return result;
         }
 
-        private class QueryBuilder
+        private sealed class QueryBuilder
         {
             private List<string> parameters = new List<string>();
 

--- a/src/KubernetesClient/KubernetesJson.cs
+++ b/src/KubernetesClient/KubernetesJson.cs
@@ -9,7 +9,7 @@ namespace k8s
     {
         private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions();
 
-        private class Iso8601TimeSpanConverter : JsonConverter<TimeSpan>
+        private sealed class Iso8601TimeSpanConverter : JsonConverter<TimeSpan>
         {
             public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
@@ -24,7 +24,7 @@ namespace k8s
             }
         }
 
-        private class KubernetesDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+        private sealed class KubernetesDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
         {
             private const string SerializeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffK";
             private const string Iso8601Format = "yyyy'-'MM'-'dd'T'HH':'mm':'ssK";
@@ -41,7 +41,7 @@ namespace k8s
             }
         }
 
-        private class KubernetesDateTimeConverter : JsonConverter<DateTime>
+        private sealed class KubernetesDateTimeConverter : JsonConverter<DateTime>
         {
             private static readonly JsonConverter<DateTimeOffset> UtcConverter = new KubernetesDateTimeOffsetConverter();
             public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/KubernetesClient/LineSeparatedHttpContent.cs
+++ b/src/KubernetesClient/LineSeparatedHttpContent.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace k8s
 {
-    internal class LineSeparatedHttpContent : HttpContent
+    internal sealed class LineSeparatedHttpContent : HttpContent
     {
         private readonly HttpContent _originContent;
         private readonly CancellationToken _cancellationToken;
@@ -41,7 +41,7 @@ namespace k8s
             return false;
         }
 
-        internal class CancelableStream : Stream
+        internal sealed class CancelableStream : Stream
         {
             private readonly Stream _innerStream;
             private readonly CancellationToken _cancellationToken;
@@ -149,7 +149,7 @@ namespace k8s
             }
         }
 
-        internal class PeekableStreamReader : TextReader
+        internal sealed class PeekableStreamReader : TextReader
         {
             private readonly Queue<string> _buffer;
             private readonly StreamReader _inner;

--- a/src/KubernetesClient/QuantityConverter.cs
+++ b/src/KubernetesClient/QuantityConverter.cs
@@ -1,6 +1,6 @@
 namespace k8s.Models
 {
-    internal class QuantityConverter : JsonConverter<ResourceQuantity>
+    internal sealed class QuantityConverter : JsonConverter<ResourceQuantity>
     {
         public override ResourceQuantity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/KubernetesClient/ResourceQuantity.cs
+++ b/src/KubernetesClient/ResourceQuantity.cs
@@ -233,7 +233,7 @@ namespace k8s.Models
             return new ResourceQuantity(v, 0, SuffixFormat.DecimalExponent);
         }
 
-        private class Suffixer
+        private sealed class Suffixer
         {
             private static readonly IReadOnlyDictionary<string, (int, int)> BinSuffixes =
                 new Dictionary<string, (int, int)>

--- a/src/KubernetesClient/V1PatchJsonConverter.cs
+++ b/src/KubernetesClient/V1PatchJsonConverter.cs
@@ -1,6 +1,6 @@
 namespace k8s.Models
 {
-    internal class V1PatchJsonConverter : JsonConverter<V1Patch>
+    internal sealed class V1PatchJsonConverter : JsonConverter<V1Patch>
     {
         public override V1Patch Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/KubernetesClient/V1Status.ObjectView.cs
+++ b/src/KubernetesClient/V1Status.ObjectView.cs
@@ -2,7 +2,7 @@ namespace k8s.Models
 {
     public partial class V1Status
     {
-        internal class V1StatusObjectViewConverter : JsonConverter<V1Status>
+        internal sealed class V1StatusObjectViewConverter : JsonConverter<V1Status>
         {
             public override V1Status Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {


### PR DESCRIPTION
- Keep private members readonly in `StringTokenProvider`
- Use `long.TryParse` instead of `int.TryParse`
- Sealed internal types(maybe we could enforce this with some analyzer)