### PR TITLE
Set http 2.0 for .net 5.0+

### DIFF
--- a/src/KubernetesClient/Kubernetes.cs
+++ b/src/KubernetesClient/Kubernetes.cs
@@ -104,7 +104,7 @@ namespace k8s
             var httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod(method);
             httpRequest.RequestUri = new Uri(BaseUri, relativeUri);
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             httpRequest.Version = HttpVersion.Version20;
 #endif
             // Set Headers


### PR DESCRIPTION
In https://github.com/kubernetes-client/csharp/pull/808, http 2 was omitted on .net 5.0+, this causes watch hang because httpclient keepalive only work on http 2.

