### PR TITLE
Fix json deserialize error when watch without any result

### DIFF
--- a/src/KubernetesClient/LineSeparatedHttpContent.cs
+++ b/src/KubernetesClient/LineSeparatedHttpContent.cs
@@ -175,6 +175,11 @@ namespace k8s
             public async Task<string> PeekLineAsync()
             {
                 var line = await ReadLineAsync().ConfigureAwait(false);
+                if (line == null)
+                {
+                    throw new EndOfStreamException();
+                }
+
                 _buffer.Enqueue(line);
                 return line;
             }


### PR DESCRIPTION
When watch without any result, the api server closes connection from server side after one hour since connection established.  In current logic you get json deserialize exception because kubernetes-client try to deserialize from emtpy stream.

This change throw EndOfStreamException in this case, make the exception more clear for the watch caller.

Fixes https://github.com/kubernetes-client/csharp/issues/828