### PR TITLE
fix obsolete warning about KubernetesYaml

### DIFF
--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -168,7 +168,7 @@ namespace k8s
         {
             var reader = new StreamReader(stream);
             var content = await reader.ReadToEndAsync().ConfigureAwait(false);
-            return LoadFromString<T>(content);
+            return Deserialize<T>(content);
         }
 
         public static async Task<T> LoadFromFileAsync<T>(string file)

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -445,7 +445,7 @@ namespace k8s.Tests
         public void LoadKubeConfigExplicitFilePath()
         {
             var txt = File.ReadAllText("assets/kubeconfig.yml");
-            var expectedCfg = KubernetesYaml.LoadFromString<K8SConfiguration>(txt);
+            var expectedCfg = KubernetesYaml.Deserialize<K8SConfiguration>(txt);
 
             var cfg = KubernetesClientConfiguration.LoadKubeConfig("assets/kubeconfig.yml");
 
@@ -458,7 +458,7 @@ namespace k8s.Tests
         {
             var filePath = "assets/kubeconfig.yml";
             var txt = File.ReadAllText(filePath);
-            var expectedCfg = KubernetesYaml.LoadFromString<K8SConfiguration>(txt);
+            var expectedCfg = KubernetesYaml.Deserialize<K8SConfiguration>(txt);
 
             var fileInfo = new FileInfo(filePath);
             var cfg = KubernetesClientConfiguration.LoadKubeConfig(fileInfo);
@@ -472,7 +472,7 @@ namespace k8s.Tests
         {
             var filePath = "assets/kubeconfig.yml";
             var txt = File.ReadAllText(filePath);
-            var expectedCfg = KubernetesYaml.LoadFromString<K8SConfiguration>(txt);
+            var expectedCfg = KubernetesYaml.Deserialize<K8SConfiguration>(txt);
 
             var fileInfo = new FileInfo(filePath);
             K8SConfiguration cfg;
@@ -524,7 +524,7 @@ namespace k8s.Tests
         public void LoadSameKubeConfigFromEnvironmentVariableUnmodified()
         {
             var txt = File.ReadAllText("assets/kubeconfig.yml");
-            var expectedCfg = KubernetesYaml.LoadFromString<K8SConfiguration>(txt);
+            var expectedCfg = KubernetesYaml.Deserialize<K8SConfiguration>(txt);
 
             var fileInfo = new FileInfo(Path.GetFullPath("assets/kubeconfig.yml"));
 
@@ -537,7 +537,7 @@ namespace k8s.Tests
         public void LoadKubeConfigWithAdditionalProperties()
         {
             var txt = File.ReadAllText("assets/kubeconfig.additional-properties.yml");
-            var expectedCfg = KubernetesYaml.LoadFromString<K8SConfiguration>(txt);
+            var expectedCfg = KubernetesYaml.Deserialize<K8SConfiguration>(txt);
 
             var fileInfo = new FileInfo(Path.GetFullPath("assets/kubeconfig.additional-properties.yml"));
 

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -193,7 +193,7 @@ metadata:
   name: foo
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.Equal("foo", obj.Metadata.Name);
         }
@@ -208,7 +208,7 @@ metadata:
   youDontKnow: Me
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.Equal("foo", obj.Metadata.Name);
         }
@@ -223,7 +223,7 @@ metadata:
   youDontKnow: Me
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.Equal("foo", obj.Metadata.Name);
         }
@@ -238,7 +238,7 @@ metadata:
   name: foo
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.Equal("foo", obj.Metadata.Name);
             Assert.Equal("bar", obj.Metadata.NamespaceProperty);
@@ -264,7 +264,7 @@ spec:
         readOnly: false
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.True(obj.Spec.Containers[0].VolumeMounts[0].ReadOnlyProperty);
             Assert.False(obj.Spec.Containers[0].VolumeMounts[1].ReadOnlyProperty);
@@ -318,10 +318,10 @@ metadata:
         {
             var content = @"namespace: foo";
 
-            var deserialized = KubernetesYaml.LoadFromString<V1ObjectMeta>(content);
+            var deserialized = KubernetesYaml.Deserialize<V1ObjectMeta>(content);
             Assert.Equal("foo", deserialized.NamespaceProperty);
 
-            var serialized = KubernetesYaml.SaveToString(deserialized);
+            var serialized = KubernetesYaml.Serialize(deserialized);
             Assert.Equal(content, serialized);
         }
 
@@ -330,7 +330,7 @@ metadata:
         {
             var pod = new V1Pod() { ApiVersion = "v1", Kind = "Pod", Metadata = new V1ObjectMeta() { Name = "foo" } };
 
-            var yaml = KubernetesYaml.SaveToString(pod);
+            var yaml = KubernetesYaml.Serialize(pod);
             Assert.Equal(
                 ToLines(@"apiVersion: v1
 kind: Pod
@@ -348,7 +348,7 @@ metadata:
                 Metadata = new V1ObjectMeta() { Name = "foo", NamespaceProperty = "bar" },
             };
 
-            var yaml = KubernetesYaml.SaveToString(pod);
+            var yaml = KubernetesYaml.Serialize(pod);
             Assert.Equal(
                 ToLines(@"apiVersion: v1
 kind: Pod
@@ -388,7 +388,7 @@ metadata:
                 },
             };
 
-            var yaml = KubernetesYaml.SaveToString(pod);
+            var yaml = KubernetesYaml.Serialize(pod);
             Assert.Equal(
                 ToLines(@"apiVersion: v1
 kind: Pod
@@ -446,7 +446,7 @@ spec:
             - -cpus
             - ""2""";
 
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
 
             Assert.NotNull(obj?.Spec?.Containers);
             var container = Assert.Single(obj.Spec.Containers);
@@ -476,7 +476,7 @@ spec:
     targetPort: 3000
 ";
 
-            var obj = KubernetesYaml.LoadFromString<V1Service>(content);
+            var obj = KubernetesYaml.Deserialize<V1Service>(content);
 
             Assert.Equal(3000, obj.Spec.Ports[0].Port);
             Assert.Equal(3000, int.Parse(obj.Spec.Ports[0].TargetPort));
@@ -508,7 +508,7 @@ spec:
                 },
             };
 
-            var output = KubernetesYaml.SaveToString(obj);
+            var output = KubernetesYaml.Serialize(obj);
             Assert.Equal(ToLines(output), ToLines(content));
         }
 
@@ -534,11 +534,11 @@ spec:
       value: ""false""
     image: vish/stress
     name: cpu-demo-ctr";
-            var obj = KubernetesYaml.LoadFromString<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
             Assert.NotNull(obj?.Spec?.Containers);
             var container = Assert.Single(obj.Spec.Containers);
             Assert.NotNull(container.Env);
-            var objStr = KubernetesYaml.SaveToString(obj);
+            var objStr = KubernetesYaml.Serialize(obj);
             Assert.Equal(content.Replace("\r\n", "\n"), objStr.Replace("\r\n", "\n"));
         }
 
@@ -555,7 +555,7 @@ data:
   password: Mzk1MjgkdmRnN0pi
 ";
 
-            var result = KubernetesYaml.LoadFromString<V1Secret>(kManifest);
+            var result = KubernetesYaml.Deserialize<V1Secret>(kManifest);
             Assert.Equal("bXktYXBw", Encoding.UTF8.GetString(result.Data["username"]));
             Assert.Equal("Mzk1MjgkdmRnN0pi", Encoding.UTF8.GetString(result.Data["password"]));
         }
@@ -589,7 +589,7 @@ spec:
     served: true
     storage: true
 ";
-            var result = KubernetesYaml.LoadFromString<V1CustomResourceDefinition>(kManifest);
+            var result = KubernetesYaml.Deserialize<V1CustomResourceDefinition>(kManifest);
             Assert.Single(result?.Spec?.Versions);
             var ver = result.Spec.Versions[0];
             Assert.Equal(true, ver?.Schema?.OpenAPIV3Schema?.XKubernetesIntOrString);

--- a/tests/KubernetesClient.Tests/QuantityValueTests.cs
+++ b/tests/KubernetesClient.Tests/QuantityValueTests.cs
@@ -211,14 +211,14 @@ namespace k8s.Tests
         [Fact]
         public void DeserializeYaml()
         {
-            var value = KubernetesYaml.LoadFromString<ResourceQuantity>("\"1\"");
+            var value = KubernetesYaml.Deserialize<ResourceQuantity>("\"1\"");
             Assert.Equal(new ResourceQuantity(1, 0, DecimalSI), value);
         }
 
         [Fact]
         public void SerializeYaml()
         {
-            var value = KubernetesYaml.SaveToString(new ResourceQuantity(1, -1, DecimalSI));
+            var value = KubernetesYaml.Serialize(new ResourceQuantity(1, -1, DecimalSI));
             Assert.Equal("100m", value);
         }
     }


### PR DESCRIPTION
Fix obsolete warning about KubernetesYaml which appears in build and PR review page, replace with new method.