### PR TITLE
fix #842, dont inc delay

### DIFF
--- a/src/KubernetesClient/LeaderElection/LeaderElector.cs
+++ b/src/KubernetesClient/LeaderElection/LeaderElector.cs
@@ -195,7 +195,7 @@ namespace k8s.LeaderElection
                 {
                     var acq = TryAcquireOrRenew(cancellationToken);
 
-                    if (await Task.WhenAny(acq, Task.Delay(delay, cancellationToken))
+                    if (await Task.WhenAny(acq, Task.Delay((int)(delay * JitterFactor * (new Random().NextDouble() + 1)), cancellationToken))
                         .ConfigureAwait(false) == acq)
                     {
                         if (await acq.ConfigureAwait(false))
@@ -208,8 +208,6 @@ namespace k8s.LeaderElection
                     }
 
                     // else timeout
-
-                    delay = (int)(delay * JitterFactor);
                 }
                 finally
                 {


### PR DESCRIPTION
make it same behavior as java

```
            Double.valueOf(retryPeriodMillis * (JITTER_FACTOR * Math.random() + 1)).longValue(),
```

https://github.com/kubernetes-client/java/blob/201b88a105284d8ea9ad3310bb6ac964cf4007de/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java#L176