### PR TITLE
fix : nullable annotations issue

### DIFF
--- a/examples/restart/Program.cs
+++ b/examples/restart/Program.cs
@@ -17,9 +17,9 @@ async Task RestartDaemonSetAsync(string name, string @namespace, IKubernetes cli
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(daemonSet, options);
 
-    var restart = new Dictionary<string, string>
+    var restart = new Dictionary<string, int>
     {
-        ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
+        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
     };
 
     daemonSet.Spec.Template.Metadata.Annotations = restart;
@@ -36,9 +36,9 @@ async Task RestartDeploymentAsync(string name, string @namespace, IKubernetes cl
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
 
-    var restart = new Dictionary<string, string>
+    var restart = new Dictionary<string, int>
     {
-        ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
+        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
     };
 
     deployment.Spec.Template.Metadata.Annotations = restart;
@@ -55,9 +55,9 @@ async Task RestartStatefulSetAsync(string name, string @namespace, IKubernetes c
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
 
-    var restart = new Dictionary<string, string>
+    var restart = new Dictionary<string, int>
     {
-        ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
+        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
     };
 
     deployment.Spec.Template.Metadata.Annotations = restart;

--- a/examples/restart/Program.cs
+++ b/examples/restart/Program.cs
@@ -1,15 +1,7 @@
-﻿using System.Globalization;
-using System.Text.Json;
+﻿using System.Text.Json;
 using Json.Patch;
 using k8s;
 using k8s.Models;
-
-double ConvertToUnixTimestamp(DateTime date)
-{
-    var origin = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-    var diff = date.ToUniversalTime() - origin;
-    return Math.Floor(diff.TotalSeconds);
-}
 
 async Task RestartDaemonSetAsync(string name, string @namespace, IKubernetes client)
 {

--- a/examples/restart/Program.cs
+++ b/examples/restart/Program.cs
@@ -8,10 +8,10 @@ async Task RestartDaemonSetAsync(string name, string @namespace, IKubernetes cli
     var daemonSet = await client.AppsV1.ReadNamespacedDaemonSetAsync(name, @namespace);
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(daemonSet, options);
-
-    var restart = new Dictionary<string, int>
+    var now = DateTimeOffset.Now.ToUnixTimeSeconds();
+    var restart = new Dictionary<string, string>
     {
-        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
+        ["date"] = now.ToString()
     };
 
     daemonSet.Spec.Template.Metadata.Annotations = restart;
@@ -27,10 +27,10 @@ async Task RestartDeploymentAsync(string name, string @namespace, IKubernetes cl
     var deployment = await client.AppsV1.ReadNamespacedDeploymentAsync(name, @namespace);
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
-
-    var restart = new Dictionary<string, int>
+    var now = DateTimeOffset.Now.ToUnixTimeSeconds();
+    var restart = new Dictionary<string, string>
     {
-        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
+        ["date"] = now.ToString()
     };
 
     deployment.Spec.Template.Metadata.Annotations = restart;
@@ -46,10 +46,10 @@ async Task RestartStatefulSetAsync(string name, string @namespace, IKubernetes c
     var deployment = await client.AppsV1.ReadNamespacedStatefulSetAsync(name, @namespace);
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
-
-    var restart = new Dictionary<string, int>
+    var now = DateTimeOffset.Now.ToUnixTimeSeconds();
+    var restart = new Dictionary<string, string>
     {
-        ["date"] = DateTimeOffset.Now.ToUnixTimeSeconds
+        ["date"] = now.ToString()
     };
 
     deployment.Spec.Template.Metadata.Annotations = restart;

--- a/examples/restart/Program.cs
+++ b/examples/restart/Program.cs
@@ -17,7 +17,7 @@ async Task RestartDaemonSetAsync(string name, string @namespace, IKubernetes cli
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(daemonSet, options);
 
-    var restart = new Dictionary<string, string>(daemonSet.Spec.Template.Metadata.Annotations)
+    var restart = new Dictionary<string, string>
     {
         ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
     };
@@ -36,7 +36,7 @@ async Task RestartDeploymentAsync(string name, string @namespace, IKubernetes cl
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
 
-    var restart = new Dictionary<string, string>(deployment.Spec.Template.Metadata.Annotations)
+    var restart = new Dictionary<string, string>
     {
         ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
     };
@@ -55,7 +55,7 @@ async Task RestartStatefulSetAsync(string name, string @namespace, IKubernetes c
     var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
     var old = JsonSerializer.SerializeToDocument(deployment, options);
 
-    var restart = new Dictionary<string, string>(deployment.Spec.Template.Metadata.Annotations)
+    var restart = new Dictionary<string, string>
     {
         ["date"] = ConvertToUnixTimestamp(DateTime.UtcNow).ToString(CultureInfo.InvariantCulture)
     };


### PR DESCRIPTION
If `["date"] `is not represented in yaml file, it will throw null reference exception. So `(daemonSet.Spec.Template.Metadata.Annotations)`
is redundant and below code will work with simple patch.