### PR TITLE
Specify container to fix bad request error

### DIFF
--- a/examples/logs/Logs.cs
+++ b/examples/logs/Logs.cs
@@ -23,7 +23,7 @@ namespace logs
 
             var response = await client.CoreV1.ReadNamespacedPodLogWithHttpMessagesAsync(
                 pod.Metadata.Name,
-                pod.Metadata.NamespaceProperty, follow: true).ConfigureAwait(false);
+                pod.Metadata.NamespaceProperty, container: pod.Spec.Containers[0].Name, follow: true).ConfigureAwait(false);
             var stream = response.Body;
             stream.CopyTo(Console.OpenStandardOutput());
         }


### PR DESCRIPTION
The existing sample will fail with a bad request for any pod containing more than 1 container. Changing code to always use the first container in the pod.