### PR TITLE
enable websocket on netstandard

### DIFF
--- a/src/KubernetesClient.Classic/Kubernetes.Websocket.Netstandard.cs
+++ b/src/KubernetesClient.Classic/Kubernetes.Websocket.Netstandard.cs
@@ -1,0 +1,28 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace k8s;
+
+public partial class Kubernetes
+{
+    private partial void BeforeRequest()
+    {
+        System.Net.ServicePointManager.ServerCertificateValidationCallback += ServerCertificateValidationCallback;
+    }
+
+    private partial void AfterRequest()
+    {
+        System.Net.ServicePointManager.ServerCertificateValidationCallback -= ServerCertificateValidationCallback;
+    }
+
+    private bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain,
+        SslPolicyErrors sslPolicyErrors)
+    {
+        if (SkipTlsVerify)
+        {
+            return true;
+        }
+
+        return CertificateValidationCallBack(sender, CaCerts, certificate, chain, sslPolicyErrors);
+    }
+}

--- a/src/KubernetesClient.Classic/Kubernetes.Websocket.Netstandard.cs
+++ b/src/KubernetesClient.Classic/Kubernetes.Websocket.Netstandard.cs
@@ -5,12 +5,12 @@ namespace k8s;
 
 public partial class Kubernetes
 {
-    private partial void BeforeRequest()
+    partial void BeforeRequest()
     {
         System.Net.ServicePointManager.ServerCertificateValidationCallback += ServerCertificateValidationCallback;
     }
 
-    private partial void AfterRequest()
+    partial void AfterRequest()
     {
         System.Net.ServicePointManager.ServerCertificateValidationCallback -= ServerCertificateValidationCallback;
     }

--- a/src/KubernetesClient.Classic/KubernetesClient.Classic.csproj
+++ b/src/KubernetesClient.Classic/KubernetesClient.Classic.csproj
@@ -28,6 +28,18 @@
     <Compile Include="..\KubernetesClient\KubernetesClientConfiguration.cs" />
     <Compile Include="..\KubernetesClient\KubernetesException.cs" />
 
+    <Compile Include="..\KubernetesClient\ChannelIndex.cs" />
+    <Compile Include="..\KubernetesClient\IStreamDemuxer.cs" />
+    <Compile Include="..\KubernetesClient\ByteBuffer.cs" />
+    <Compile Include="..\KubernetesClient\StreamDemuxer.cs" />
+    <Compile Include="..\KubernetesClient\MuxedStream.cs" />
+    <Compile Include="..\KubernetesClient\StreamType.cs" />
+    <Compile Include="..\KubernetesClient\IKubernetes.WebSocket.cs" />
+    <Compile Include="..\KubernetesClient\Kubernetes.WebSocket.cs" />
+    <Compile Include="..\KubernetesClient\WebSocketBuilder.cs" />
+    <Compile Include="..\KubernetesClient\WebSocketProtocol.cs" />
+    <Compile Include="..\KubernetesClient\Utilities.cs" />
+
     <Compile Include="..\KubernetesClient\Exceptions\KubeConfigException.cs" />
     <Compile Include="..\KubernetesClient\Exceptions\KubernetesClientException.cs" />
 

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -23,9 +23,7 @@ namespace k8s
             Initialize();
             ValidateConfig(config);
             CaCerts = config.SslCaCerts;
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             SkipTlsVerify = config.SkipTlsVerify;
-#endif
             CreateHttpClient(handlers, config);
             InitializeFromConfig(config);
             HttpClientTimeout = config.HttpClientTimeout;
@@ -102,11 +100,9 @@ namespace k8s
 
         private X509Certificate2Collection CaCerts { get; }
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         private X509Certificate2 ClientCert { get; }
 
         private bool SkipTlsVerify { get; }
-#endif
 
         // NOTE: this method replicates the logic that the base ServiceClient uses except that it doesn't insert the RetryDelegatingHandler
         // and it does insert the WatcherDelegatingHandler. we don't want the RetryDelegatingHandler because it has a very broad definition

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -210,6 +210,9 @@ namespace k8s
                 cancellationToken);
         }
 
+        private partial void BeforeRequest();
+        private partial void AfterRequest();
+
         protected async Task<WebSocket> StreamConnectAsync(Uri uri, string webSocketSubProtocol = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
         {
             if (uri == null)
@@ -280,6 +283,7 @@ namespace k8s
             WebSocket webSocket = null;
             try
             {
+                BeforeRequest();
                 webSocket = await webSocketBuilder.BuildAndConnectAsync(uri, CancellationToken.None)
                     .ConfigureAwait(false);
             }
@@ -334,6 +338,10 @@ namespace k8s
             catch (Exception)
             {
                 throw;
+            }
+            finally
+            {
+                AfterRequest();
             }
 
             return webSocket;

--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -210,8 +210,8 @@ namespace k8s
                 cancellationToken);
         }
 
-        private partial void BeforeRequest();
-        private partial void AfterRequest();
+        partial void BeforeRequest();
+        partial void AfterRequest();
 
         protected async Task<WebSocket> StreamConnectAsync(Uri uri, string webSocketSubProtocol = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
         {

--- a/src/KubernetesClient/WebSocketBuilder.cs
+++ b/src/KubernetesClient/WebSocketBuilder.cs
@@ -36,20 +36,23 @@ namespace k8s
 
         public WebSocketBuilder ExpectServerCertificate(X509Certificate2Collection serverCertificate)
         {
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
             Options.RemoteCertificateValidationCallback
  = (sender, certificate, chain, sslPolicyErrors) =>
             {
                 return Kubernetes.CertificateValidationCallBack(sender, serverCertificate, certificate, chain, sslPolicyErrors);
             };
-
+#endif
             return this;
         }
 
         public WebSocketBuilder SkipServerCertificateValidation()
         {
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
             Options.RemoteCertificateValidationCallback
  = (sender, certificate, chain, sslPolicyErrors) => true;
 
+#endif
             return this;
         }
 


### PR DESCRIPTION
fix #889

the cert verification impl is somewhat unacceptable to me by setting a global static field `ServicePointManager.ServerCertificateValidationCallback`
the way to handle cert verification is not thread safe, but there is no way to do so in old netstandard api, see thread https://github.com/dotnet/runtime/issues/18696


However, better bug than never
