### PR TITLE
Provide KubernetesYaml.SerializeAll method

### DIFF
--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -201,6 +201,32 @@ namespace k8s
             return Deserializer.Deserialize<TValue>(new StreamReader(yaml));
         }
 
+        public static string SerializeAll(IEnumerable<object> values)
+        {
+            if (values == null)
+            {
+                return "";
+            }
+
+            var stringBuilder = new StringBuilder();
+            var writer = new StringWriter(stringBuilder);
+            var emitter = new Emitter(writer);
+
+            emitter.Emit(new StreamStart());
+
+            foreach (var value in values)
+            {
+                if (value != null)
+                {
+                    emitter.Emit(new DocumentStart());
+                    Serializer.SerializeValue(emitter, value, value.GetType());
+                    emitter.Emit(new DocumentEnd(true));
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+
         public static string Serialize(object value)
         {
             if (value == null)

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -326,6 +326,27 @@ metadata:
         }
 
         [Fact]
+        public void SerializeAll()
+        {
+            var pods = new List<object>
+            {
+                new V1Pod() { ApiVersion = "v1", Kind = "Pod", Metadata = new V1ObjectMeta() { Name = "foo" } },
+                new V1Pod() { ApiVersion = "v1", Kind = "Pod", Metadata = new V1ObjectMeta() { Name = "bar" } },
+            };
+            var yaml = KubernetesYaml.SerializeAll(pods);
+            Assert.Equal(
+                ToLines(@"apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bar"), ToLines(yaml));
+        }
+
+        [Fact]
         public void WriteToString()
         {
             var pod = new V1Pod() { ApiVersion = "v1", Kind = "Pod", Metadata = new V1ObjectMeta() { Name = "foo" } };


### PR DESCRIPTION
Addressing the issue #912 by adding a ```KubernetesYaml.SerializeAll``` method that serializes multiple kubernetes objects into a single Yaml file.