### PR TITLE
fix(StringQuotingEmitter): add missing patterns for double quoting

### DIFF
--- a/src/KubernetesClient.Models/StringQuotingEmitter.cs
+++ b/src/KubernetesClient.Models/StringQuotingEmitter.cs
@@ -8,7 +8,7 @@ namespace k8s
     // adapted from https://github.com/cloudbase/powershell-yaml/blob/master/powershell-yaml.psm1
     public class StringQuotingEmitter : ChainedEventEmitter
     {
-        // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356
+        // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356 and https://yaml.org/type/bool.html (spec v1.1)
         private static readonly Regex QuotedRegex =
             new Regex(@"^(\~|null|Null|NULL|true|True|TRUE|false|False|FALSE|y|Y|yes|Yes|YES|on|On|ON|n|N|no|No|NO|off|Off|OFF|-?(0|[0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
 

--- a/src/KubernetesClient.Models/StringQuotingEmitter.cs
+++ b/src/KubernetesClient.Models/StringQuotingEmitter.cs
@@ -10,7 +10,7 @@ namespace k8s
     {
         // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356
         private static readonly Regex QuotedRegex =
-            new Regex(@"^(\~|null|true|false|-?(0|[0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
+            new Regex(@"^(\~|null|Null|NULL|true|True|TRUE|false|False|FALSE|y|Y|n|N|-?(0|[0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
 
         public StringQuotingEmitter(IEventEmitter next)
             : base(next)

--- a/src/KubernetesClient.Models/StringQuotingEmitter.cs
+++ b/src/KubernetesClient.Models/StringQuotingEmitter.cs
@@ -10,7 +10,7 @@ namespace k8s
     {
         // Patterns from https://yaml.org/spec/1.2/spec.html#id2804356
         private static readonly Regex QuotedRegex =
-            new Regex(@"^(\~|null|Null|NULL|true|True|TRUE|false|False|FALSE|y|Y|n|N|-?(0|[0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
+            new Regex(@"^(\~|null|Null|NULL|true|True|TRUE|false|False|FALSE|y|Y|yes|Yes|YES|on|On|ON|n|N|no|No|NO|off|Off|OFF|-?(0|[0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?)?$");
 
         public StringQuotingEmitter(IEventEmitter next)
             : base(next)

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -564,6 +564,146 @@ spec:
         }
 
         [Fact]
+        public void CertainPatternsShouldBeSerializedWithDoubleQuotes()
+        {
+            var content = @"apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    custom.annotation: ""True""
+  name: foo
+  namespace: bar
+spec:
+  containers:
+  - env:
+    - name: NullLowerCase
+      value: ""null""
+    - name: NullCamelCase
+      value: ""Null""
+    - name: NullUpperCase
+      value: ""NULL""
+    - name: TrueLowerCase
+      value: ""true""
+    - name: TrueCamelCase
+      value: ""True""
+    - name: ""TRUE""
+      value: ""TRUE""
+    - name: ""false""
+      value: ""false""
+    - name: ""False""
+      value: ""False""
+    - name: ""FALSE""
+      value: ""FALSE""
+    - name: ""y""
+      value: ""y""
+    - name: ""Y""
+      value: ""Y""
+    - name: ""n""
+      value: ""n""
+    - name: ""N""
+      value: ""N""
+    image: nginx
+    name: foo";
+
+            var pod = new V1Pod()
+            {
+                ApiVersion = "v1",
+                Kind = "Pod",
+                Metadata = new V1ObjectMeta()
+                {
+                    Name = "foo",
+                    NamespaceProperty = "bar",
+                    Annotations = new Dictionary<string, string>
+                    {
+                        { "custom.annotation", "True" },
+                    },
+                },
+                Spec = new V1PodSpec()
+                {
+                    Containers = new[]
+                    {
+                        new V1Container()
+                        {
+                            Image = "nginx",
+                            Env = new List<V1EnvVar>
+                            {
+                                new V1EnvVar
+                                {
+                                    Name = "NullLowerCase",
+                                    Value = "null",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "NullCamelCase",
+                                    Value = "Null",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "NullUpperCase",
+                                    Value = "NULL",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "TrueLowerCase",
+                                    Value = "true",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "TrueCamelCase",
+                                    Value = "True",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "TRUE",
+                                    Value = "TRUE",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "false",
+                                    Value = "false",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "False",
+                                    Value = "False",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "FALSE",
+                                    Value = "FALSE",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "y",
+                                    Value = "y",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "Y",
+                                    Value = "Y",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "n",
+                                    Value = "n",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "N",
+                                    Value = "N",
+                                },
+                            },
+                            Name = "foo",
+                        },
+                    },
+                },
+            };
+
+            var objStr = KubernetesYaml.Serialize(pod);
+            Assert.Equal(content.Replace("\r\n", "\n"), objStr.Replace("\r\n", "\n"));
+        }
+
+        [Fact]
         public void LoadSecret()
         {
             var kManifest = @"

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -571,6 +571,7 @@ kind: Pod
 metadata:
   annotations:
     custom.annotation: ""True""
+    second.custom.annotation: ""~""
   name: foo
   namespace: bar
 spec:
@@ -598,10 +599,34 @@ spec:
       value: ""y""
     - name: ""Y""
       value: ""Y""
+    - name: ""yes""
+      value: ""yes""
+    - name: ""Yes""
+      value: ""Yes""
+    - name: ""YES""
+      value: ""YES""
     - name: ""n""
       value: ""n""
     - name: ""N""
       value: ""N""
+    - name: ""no""
+      value: ""no""
+    - name: ""No""
+      value: ""No""
+    - name: ""NO""
+      value: ""NO""
+    - name: ""on""
+      value: ""on""
+    - name: ""On""
+      value: ""On""
+    - name: ""ON""
+      value: ""ON""
+    - name: ""off""
+      value: ""off""
+    - name: ""Off""
+      value: ""Off""
+    - name: ""OFF""
+      value: ""OFF""
     image: nginx
     name: foo";
 
@@ -616,6 +641,7 @@ spec:
                     Annotations = new Dictionary<string, string>
                     {
                         { "custom.annotation", "True" },
+                        { "second.custom.annotation", "~" },
                     },
                 },
                 Spec = new V1PodSpec()
@@ -684,6 +710,21 @@ spec:
                                 },
                                 new V1EnvVar
                                 {
+                                    Name = "yes",
+                                    Value = "yes",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "Yes",
+                                    Value = "Yes",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "YES",
+                                    Value = "YES",
+                                },
+                                new V1EnvVar
+                                {
                                     Name = "n",
                                     Value = "n",
                                 },
@@ -691,6 +732,51 @@ spec:
                                 {
                                     Name = "N",
                                     Value = "N",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "no",
+                                    Value = "no",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "No",
+                                    Value = "No",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "NO",
+                                    Value = "NO",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "on",
+                                    Value = "on",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "On",
+                                    Value = "On",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "ON",
+                                    Value = "ON",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "off",
+                                    Value = "off",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "Off",
+                                    Value = "Off",
+                                },
+                                new V1EnvVar
+                                {
+                                    Name = "OFF",
+                                    Value = "OFF",
                                 },
                             },
                             Name = "foo",


### PR DESCRIPTION
Fixes #953  
**Added the missing patterns to the StringQuotingEmmiter** class to ensure that these values are double quoted when serializing to yaml.
Added a complementary Unit Test.