### PR TITLE
Enhance AbstractKubernetes SendRequest extensibility

### DIFF
--- a/src/KubernetesClient.Basic/AbstractKubernetes.cs
+++ b/src/KubernetesClient.Basic/AbstractKubernetes.cs
@@ -54,19 +54,6 @@ public abstract partial class AbstractKubernetes
         }
     }
 
-    private Task<HttpResponseMessage> SendRequest<T>(T body, HttpRequestMessage httpRequest, CancellationToken cancellationToken)
-    {
-        if (body != null)
-        {
-            var requestContent = KubernetesJson.Serialize(body);
-            httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-            httpRequest.Content.Headers.ContentType = GetHeader(body);
-            return SendRequestRaw(requestContent, httpRequest, cancellationToken);
-        }
-
-        return SendRequestRaw("", httpRequest, cancellationToken);
-    }
-
     public virtual TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromSeconds(100);
 
     protected virtual MediaTypeHeaderValue GetHeader(object body)
@@ -108,7 +95,7 @@ public abstract partial class AbstractKubernetes
 
     protected abstract Task<HttpOperationResponse<T>> CreateResultAsync<T>(HttpRequestMessage httpRequest, HttpResponseMessage httpResponse, bool? watch, CancellationToken cancellationToken);
 
-    protected abstract HttpRequestMessage CreateRequest(string relativeUri, HttpMethod method, IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders);
+    protected abstract Task<HttpResponseMessage> SendRequest<T>(string relativeUri, HttpMethod method, IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders, T body, CancellationToken cancellationToken);
 
     protected abstract Task<HttpResponseMessage> SendRequestRaw(string requestContent, HttpRequestMessage httpRequest, CancellationToken cancellationToken);
 }

--- a/src/KubernetesClient/Kubernetes.cs
+++ b/src/KubernetesClient/Kubernetes.cs
@@ -99,7 +99,7 @@ namespace k8s
             return result;
         }
 
-        protected override HttpRequestMessage CreateRequest(string relativeUri, HttpMethod method, IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders)
+        protected override Task<HttpResponseMessage> SendRequest<T>(string relativeUri, HttpMethod method, IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders, T body, CancellationToken cancellationToken)
         {
             var httpRequest = new HttpRequestMessage();
             httpRequest.Method = method;
@@ -117,7 +117,15 @@ namespace k8s
                 }
             }
 
-            return httpRequest;
+            if (body != null)
+            {
+                var requestContent = KubernetesJson.Serialize(body);
+                httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                httpRequest.Content.Headers.ContentType = GetHeader(body);
+                return SendRequestRaw(requestContent, httpRequest, cancellationToken);
+            }
+
+            return SendRequestRaw("", httpRequest, cancellationToken);
         }
 
         protected override async Task<HttpResponseMessage> SendRequestRaw(string requestContent, HttpRequestMessage httpRequest, CancellationToken cancellationToken)

--- a/src/LibKubernetesGenerator/templates/Operations.cs.template
+++ b/src/LibKubernetesGenerator/templates/Operations.cs.template
@@ -52,19 +52,20 @@ public partial class AbstractKubernetes : I{{name}}Operations
         {{/IfListNotEmpty operation.parameters}}
 
         // Create HTTP transport
-        var httpRequest = CreateRequest(url, HttpMethods.{{Method}}, customHeaders);
         {{#IfParamContains operation "body"}}
-        var httpResponse = await SendRequest(body, httpRequest, cancellationToken);
+        var httpResponse = await SendRequest(url, HttpMethods.{{Method}}, customHeaders, body, cancellationToken);
         {{/IfParamContains operation "body"}}
         {{#IfParamDoesNotContain operation "body"}}
-        var httpResponse = await SendRequestRaw("", httpRequest, cancellationToken);
+        var httpResponse = await SendRequest<object>(url, HttpMethods.{{Method}}, customHeaders, null, cancellationToken);
         {{/IfParamDoesNotContain operation "body"}}
         // Create Result
+        var httpRequest = httpResponse.RequestMessage;
         {{#IfReturnType operation "void"}}
         HttpOperationResponse result = new HttpOperationResponse() { Request = httpRequest, Response =  httpResponse };
         {{/IfReturnType operation "void"}}
         {{#IfReturnType operation "obj"}}
-        var result = await CreateResultAsync{{GetReturnType operation "<>"}}(httpRequest,
+        var result = await CreateResultAsync{{GetReturnType operation "<>"}}(
+            httpRequest,
             httpResponse,
             {{#IfParamContains operation "watch"}}
             watch,


### PR DESCRIPTION
We want to use a Polly to handle retries in the KubernetesClient send request code path. HttpRequestMessage and HttpContent objects can only be passed in once to an HttpClient.SendAsync call. On each retry, a new HttpRequestMessage needs to be constructed; the previous HttpRequestMessage cannot be reused. We want the send request extensibility point in KubernetesClient to provide the underlying data used to construct the HttpRequestMessage instead of providing the HttpRequestMessage itself.

This PR generalizes the existing send request extensibility without making the contract more complicated.