### PR TITLE
System.Text.Json support for YamlDotNet

### DIFF
--- a/src/KubernetesClient.Models/KubernetesClient.Models.csproj
+++ b/src/KubernetesClient.Models/KubernetesClient.Models.csproj
@@ -15,5 +15,6 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Fractions" Version="7.1.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
+    <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/KubernetesClient.Models/KubernetesClient.Models.csproj
+++ b/src/KubernetesClient.Models/KubernetesClient.Models.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Fractions" Version="7.1.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
-    <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.0.0" />
+    <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/KubernetesClient.Models/KubernetesClient.Models.csproj
+++ b/src/KubernetesClient.Models/KubernetesClient.Models.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Fractions" Version="7.1.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
-    <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.1.0" />
+    <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -23,7 +23,7 @@ namespace k8s
                 .WithTypeConverter(new ByteArrayStringYamlConverter())
                 .WithTypeConverter(new ResourceQuantityYamlConverter())
                 .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
-                .WithTypeInspector(x => new SystemTextJsonTypeInspector(x))
+                .WithTypeInspector(x => new SystemTextJsonTypeInspector(x, true))
                 .IgnoreUnmatchedProperties()
                 .Build();
 
@@ -36,7 +36,7 @@ namespace k8s
                 .WithTypeConverter(new ResourceQuantityYamlConverter())
                 .WithEventEmitter(e => new StringQuotingEmitter(e))
                 .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
-                .WithTypeInspector(x => new SystemTextJsonTypeInspector(x))
+                .WithTypeInspector(x => new SystemTextJsonTypeInspector(x, true))
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
                 .BuildValueSerializer();
 

--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -7,6 +7,7 @@ using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using k8s.Models;
+using YamlDotNet.System.Text.Json;
 
 namespace k8s
 {
@@ -21,6 +22,7 @@ namespace k8s
                 .WithTypeConverter(new IntOrStringYamlConverter())
                 .WithTypeConverter(new ByteArrayStringYamlConverter())
                 .WithTypeConverter(new ResourceQuantityYamlConverter())
+                .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
                 .WithOverridesFromJsonPropertyAttributes()
                 .IgnoreUnmatchedProperties()
                 .Build();
@@ -33,6 +35,7 @@ namespace k8s
                 .WithTypeConverter(new ByteArrayStringYamlConverter())
                 .WithTypeConverter(new ResourceQuantityYamlConverter())
                 .WithEventEmitter(e => new StringQuotingEmitter(e))
+                .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
                 .WithOverridesFromJsonPropertyAttributes()
                 .BuildValueSerializer();


### PR DESCRIPTION
This PR integrates a new library [YamlDotNet.System.Text.Json](https://github.com/IvanJosipovic/YamlDotNet.System.Text.Json) which allows YamlDotNet to de/serialize System.Text.Json objects and handles its attributes.

- fix: reading JsonPropertyAttributes for external types
  - Currently KubernetesYaml only reads JsonProperyAttributes for types in the [KubernetesClient.Models Assembly](https://github.com/kubernetes-client/csharp/blob/13cc644293afd587556c7b0f07828c940f202fbb/src/KubernetesClient.Models/KubernetesYaml.cs#L256)
- feat: support yaml de/serialization of JsonElement/JsonDocument/JsonObject etc
  - Allows the client to support Generic objects which are needed to support CRDs with XKubernetesPreserveUnknownFields
  ```csharp
  public class GenericObject : IKubernetesObject<V1ObjectMeta>
  {
      public string ApiVersion { get; set; }
      public string Kind { get; set; }
      public V1ObjectMeta Metadata { get; set; }
      public JsonObject Spec { get; set; }
  }
  ```


