### PR TITLE
Revert "Bump Microsoft.CodeAnalysis.CSharp from 4.2.0 to 4.3.0"

### DIFF
--- a/src/LibKubernetesGenerator/LibKubernetesGenerator.csproj
+++ b/src/LibKubernetesGenerator/LibKubernetesGenerator.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     </ItemGroup>
 


### PR DESCRIPTION
Reverts kubernetes-client/csharp#993

**I'm unable to build the project in visual studio 2022 (tested with vs professional 17.3.3, 17.3.4, 17.4.0 Preview 1.0) , source generator is broken in main branch**
There is an open issue in dotnet/roslyn repo: https://github.com/dotnet/roslyn/issues/63919
Broken commit: a763810ae30e721d1ffbd2b53065f0369f1ff2ac