### PR TITLE
Fix strict yaml parsing

### DIFF
--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -157,8 +157,8 @@ namespace k8s
             parser.Consume<StreamStart>();
             while (parser.Accept<DocumentStart>(out _))
             {
-                var obj = GetDeserializer(strict).Deserialize<KubernetesObject>(parser);
-                types.Add(mergedTypeMap[obj.ApiVersion + "/" + obj.Kind]);
+                var dict = GetDeserializer(strict).Deserialize<Dictionary<object, object>>(parser);
+                types.Add(mergedTypeMap[dict["apiVersion"] + "/" + dict["kind"]]);
             }
 
             parser = new Parser(new StringReader(content));

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -275,7 +275,7 @@ spec:
         readOnly: false
 ";
 
-            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content, true);
 
             Assert.True(obj.Spec.Containers[0].VolumeMounts[0].ReadOnlyProperty);
             Assert.False(obj.Spec.Containers[0].VolumeMounts[1].ReadOnlyProperty);
@@ -476,7 +476,7 @@ spec:
             - -cpus
             - ""2""";
 
-            var obj = KubernetesYaml.Deserialize<V1Pod>(content);
+            var obj = KubernetesYaml.Deserialize<V1Pod>(content, true);
 
             Assert.NotNull(obj?.Spec?.Containers);
             var container = Assert.Single(obj.Spec.Containers);
@@ -811,7 +811,7 @@ data:
   password: Mzk1MjgkdmRnN0pi
 ";
 
-            var result = KubernetesYaml.Deserialize<V1Secret>(kManifest);
+            var result = KubernetesYaml.Deserialize<V1Secret>(kManifest, true);
             Assert.Equal("bXktYXBw", Encoding.UTF8.GetString(result.Data["username"]));
             Assert.Equal("Mzk1MjgkdmRnN0pi", Encoding.UTF8.GetString(result.Data["password"]));
         }
@@ -890,7 +890,7 @@ spec:
             var objs = KubernetesYaml.LoadAllFromString(content, new Dictionary<string, Type>
             {
                 { $"{V1AlphaFoo.KubeGroup}/{V1AlphaFoo.KubeApiVersion}/Foo", typeof(V1AlphaFoo) },
-            });
+            }, true);
             Assert.Single(objs);
             var v1AlphaFoo = Assert.IsType<V1AlphaFoo>(objs[0]);
             Assert.Equal("foo", v1AlphaFoo.Metadata.Name);


### PR DESCRIPTION
Strict parsing was missing a positive test case that would ensure it's working as expected on a well-formed yaml file.