### PR TITLE
Yaml deserializer strictness: disallow key duplicates

### DIFF
--- a/src/KubernetesClient.Models/KubernetesYaml.cs
+++ b/src/KubernetesClient.Models/KubernetesYaml.cs
@@ -25,6 +25,7 @@ namespace k8s
                 .WithOverridesFromJsonPropertyAttributes();
         private static readonly IDeserializer StrictDeserializer =
             CommonDeserializerBuilder
+            .WithDuplicateKeyChecking()
             .Build();
         private static readonly IDeserializer Deserializer =
             CommonDeserializerBuilder


### PR DESCRIPTION
[YamlDotNet 12.2.1](https://github.com/aaubry/YamlDotNet/releases/tag/v12.2.1) brought in a new yaml strictness check: no duplicate keys

A follow up to #1142