### PR TITLE
Use camelCase policy when serializing enums

### DIFF
--- a/src/KubernetesClient.Models/KubernetesJson.cs
+++ b/src/KubernetesClient.Models/KubernetesJson.cs
@@ -63,7 +63,7 @@ namespace k8s
             JsonSerializerOptions.Converters.Add(new KubernetesDateTimeConverter());
             JsonSerializerOptions.Converters.Add(new KubernetesDateTimeOffsetConverter());
             JsonSerializerOptions.Converters.Add(new V1Status.V1StatusObjectViewConverter());
-            JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         }
 
         public static TValue Deserialize<TValue>(string json)


### PR DESCRIPTION
The KubernetesJson class currently uses CamelCase as PropertyNamingPolicy. For enums it uses JsonStringEnumConverter, however, without the CamelCase policy. This results in invalid serialization (e.g. PascalCase).

This PR fixes this issue.