### PR TITLE
Exec set CreateNoWindow to true

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -523,7 +523,8 @@ namespace k8s
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;
-
+            process.StartInfo.CreateNoWindow = true;
+            
             return process;
         }
 


### PR DESCRIPTION
Currently, when exec is ran for kubelogin etc, a new window is spawned. This PR should hide that window.