### PR TITLE
Support TLS Server Name overrides in kubeconfig

### DIFF
--- a/src/KubernetesClient.Models/KubeConfigModels/ClusterEndpoint.cs
+++ b/src/KubernetesClient.Models/KubeConfigModels/ClusterEndpoint.cs
@@ -26,6 +26,12 @@ namespace k8s.KubeConfigModels
         public string Server { get; set; }
 
         /// <summary>
+        /// Gets or sets a value to override the TLS server name.
+        /// </summary>
+        [YamlMember(Alias = "tls-server-name", ApplyNamingConventions = false)]
+        public string TlsServerName { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to skip the validity check for the server's certificate.
         /// This will make your HTTPS connections insecure.
         /// </summary>

--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -26,6 +26,7 @@ namespace k8s
             ValidateConfig(config);
             CaCerts = config.SslCaCerts;
             SkipTlsVerify = config.SkipTlsVerify;
+            TlsServerName = config.TlsServerName;
             CreateHttpClient(handlers, config);
             InitializeFromConfig(config);
             HttpClientTimeout = config.HttpClientTimeout;
@@ -114,6 +115,8 @@ namespace k8s
         private X509Certificate2 ClientCert { get; set; }
 
         private bool SkipTlsVerify { get; }
+
+        private string TlsServerName { get; }
 
         // NOTE: this method replicates the logic that the base ServiceClient uses except that it doesn't insert the RetryDelegatingHandler
         // and it does insert the WatcherDelegatingHandler. we don't want the RetryDelegatingHandler because it has a very broad definition

--- a/src/KubernetesClient/Kubernetes.cs
+++ b/src/KubernetesClient/Kubernetes.cs
@@ -149,6 +149,11 @@ namespace k8s
                 await Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
             }
 
+            if (!string.IsNullOrWhiteSpace(TlsServerName))
+            {
+                httpRequest.Headers.Host = TlsServerName;
+            }
+
             // Send Request
             cancellationToken.ThrowIfCancellationRequested();
             var httpResponse = await HttpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -267,6 +267,7 @@ namespace k8s
 
             Host = clusterDetails.ClusterEndpoint.Server;
             SkipTlsVerify = clusterDetails.ClusterEndpoint.SkipTlsVerify;
+            TlsServerName = clusterDetails.ClusterEndpoint.TlsServerName;
 
             if (!Uri.TryCreate(Host, UriKind.Absolute, out var uri))
             {

--- a/src/KubernetesClient/KubernetesClientConfiguration.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.cs
@@ -57,6 +57,11 @@ namespace k8s
         public bool SkipTlsVerify { get; set; }
 
         /// <summary>
+        ///     Option to override the TLS server name
+        /// </summary>
+        public string TlsServerName { get; set; }
+
+        /// <summary>
         ///     Gets or sets the HTTP user agent.
         /// </summary>
         /// <value>Http user agent.</value>

--- a/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesClientConfigurationTests.cs
@@ -342,6 +342,17 @@ namespace k8s.Tests
         }
 
         /// <summary>
+        ///     Make sure that TlsServerName is present
+        /// </summary>
+        [Fact]
+        public void TlsServerName()
+        {
+            var fi = new FileInfo("assets/kubeconfig.tls-servername.yml");
+            var cfg = KubernetesClientConfiguration.BuildConfigFromConfigFile(fi);
+            Assert.Equal("pony", cfg.TlsServerName);
+        }
+
+        /// <summary>
         ///     Checks config could work well when current-context is not set but masterUrl is set. #issue 24
         /// </summary>
         [Fact]

--- a/tests/KubernetesClient.Tests/assets/kubeconfig.tls-servername.yml
+++ b/tests/KubernetesClient.Tests/assets/kubeconfig.tls-servername.yml
@@ -1,0 +1,22 @@
+# Sample file based on https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/
+# WARNING: File includes minor fixes
+---
+current-context: federal-context
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://horse.org:443
+    tls-server-name: pony
+  name: horse-cluster
+contexts:
+- context:
+    cluster: horse-cluster
+    namespace: chisel-ns
+    user: green-user
+  name: federal-context
+kind: Config
+users:
+- name: green-user
+  user:
+    password: secret
+    username: admin


### PR DESCRIPTION
The client should support tls-server-name just like client-go and kubectl.  See https://github.com/kubernetes/kubernetes/pull/88769