### PR TITLE
feat: enable multiple http2 connections

### DIFF
--- a/src/KubernetesClient/Kubernetes.ConfigInit.cs
+++ b/src/KubernetesClient/Kubernetes.ConfigInit.cs
@@ -130,6 +130,7 @@ namespace k8s
                 KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
                 KeepAlivePingDelay = TimeSpan.FromMinutes(3),
                 KeepAlivePingTimeout = TimeSpan.FromSeconds(30),
+                EnableMultipleHttp2Connections = true,
             };
 
             HttpClientHandler.SslOptions.ClientCertificates = new X509Certificate2Collection();


### PR DESCRIPTION
In my KubeUI project, I create hundreds of Informers (Lists + Watches), one for each resource type. After a period of time, the Informers would stop working and start throwing errors that wouldn't recover. See https://github.com/IvanJosipovic/KubeUI/issues/458. In my testing enabling EnableMultipleHttp2Connections solved this problem.

Docs for this property, https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.enablemultiplehttp2connections