### PR TITLE
Change X509Certificate2 constructor to fix KB5025823 

### DIFF
--- a/src/KubernetesClient/CertUtils.cs
+++ b/src/KubernetesClient/CertUtils.cs
@@ -36,7 +36,10 @@ namespace k8s
                 //
                 foreach (Org.BouncyCastle.X509.X509Certificate cert in certs)
                 {
-                    certCollection.Add(new X509Certificate2(cert.GetEncoded()));
+                    // This null password is to change the constructor to fix this KB:
+                    // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
+                    string nullPassword = null;
+                    certCollection.Add(new X509Certificate2(cert.GetEncoded(), nullPassword));
                 }
 #endif
             }
@@ -96,13 +99,17 @@ namespace k8s
             // see https://github.com/kubernetes-client/csharp/issues/737
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                // This null password is to change the constructor to fix this KB:
+                // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
+                string nullPassword = null;
+
                 if (config.ClientCertificateKeyStoreFlags.HasValue)
                 {
-                    cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12), "", config.ClientCertificateKeyStoreFlags.Value);
+                    cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12), nullPassword, config.ClientCertificateKeyStoreFlags.Value);
                 }
                 else
                 {
-                    cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12));
+                    cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12), nullPassword);
                 }
             }
 
@@ -172,13 +179,17 @@ namespace k8s
 
             store.Save(pkcs, new char[0], new SecureRandom());
 
+            // This null password is to change the constructor to fix this KB:
+            // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
+            string nullPassword = null;
+
             if (config.ClientCertificateKeyStoreFlags.HasValue)
             {
-                return new X509Certificate2(pkcs.ToArray(), "", config.ClientCertificateKeyStoreFlags.Value);
+                return new X509Certificate2(pkcs.ToArray(), nullPassword, config.ClientCertificateKeyStoreFlags.Value);
             }
             else
             {
-                return new X509Certificate2(pkcs.ToArray());
+                return new X509Certificate2(pkcs.ToArray(), nullPassword);
             }
 #endif
         }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -308,8 +308,11 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
+                    // This null password is to change the constructor to fix this KB:
+                    // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
+                    string nullPassword = null;
                     var data = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(data)));
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(data), nullPassword));
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {


### PR DESCRIPTION
Change X509Certificate2 constructor to fix [KB5025823](https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b). The framework is adding some extra **heuristic** check for certificate raw data. This issue might only happen for about 1% of certificates (very rough number).

From the KB:
This additional validation performs a series of **heuristic** checks to determine if the incoming certificate would maliciously exhaust resourcese upon import. Since this is additional validation beyond what the underlying OS would normally perform, it may block certificate blobs which would have successfully imported prior to the June 13, 2023, change.

# Example exception
---> System.Security.Cryptography.CryptographicException: PKCS12 (PFX) without a supplied password has exceeded maximum allowed iterations. See https://go.microsoft.com/fwlink/?linkid=2233907 for more information.
---> System.Formats.Asn1.AsnContentException: The encoded length exceeds the maximum supported by this library (Int32.MaxValue).
at System.Formats.Asn1.AsnDecoder.ReadSequence(ReadOnlySpan`1 source, AsnEncodingRules ruleSet, Int32& contentOffset, Int32& contentLength, Int32& bytesConsumed, Nullable`1 expectedTag)
at System.Security.Cryptography.Asn1.Pkcs12.PfxAsn.CountTotalIterations()
at System.Security.Cryptography.X509Certificates.X509Certificate.GetIterationCount(ReadOnlySpan`1 pkcs12)
at System.Security.Cryptography.X509Certificates.X509Certificate.EnforceIterationCountLimit(ReadOnlySpan`1 pkcs12, Boolean readingFromFile, Boolean passwordProvided)
--- End of inner exception stack trace ---
at System.Security.Cryptography.X509Certificates.X509Certificate.EnforceIterationCountLimit(ReadOnlySpan`1 pkcs12, Boolean readingFromFile, Boolean passwordProvided)
at Internal.Cryptography.Pal.PkcsFormatReader.TryReadPkcs12(ReadOnlySpan`1 rawData, OpenSslPkcs12Reader pfx, SafePasswordHandle password, Boolean single, Boolean ephemeralSpecified, Boolean readingFromFile, ICertificatePal& readPal, List`1& readCerts)
at Internal.Cryptography.Pal.PkcsFormatReader.TryReadPkcs12(ReadOnlySpan`1 rawData, SafePasswordHandle password, Boolean single, Boolean ephemeralSpecified, Boolean readingFromFile, ICertificatePal& readPal, List`1& readCerts, Exception& openSslException)
at Internal.Cryptography.Pal.OpenSslX509CertificateReader.FromBlob(ReadOnlySpan`1 rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(ReadOnlySpan`1 data)