### PR TITLE
CStatus should be status otherwise it doesn't work at all to load 'st…

### DIFF
--- a/examples/customResource/CustomResourceDefinition.cs
+++ b/examples/customResource/CustomResourceDefinition.cs
@@ -32,8 +32,8 @@ namespace customResource
         [JsonPropertyName("spec")]
         public TSpec Spec { get; set; }
 
-        [JsonPropertyName("CStatus")]
-        public TStatus CStatus { get; set; }
+        [JsonPropertyName("status")]
+        public TStatus Status { get; set; }
     }
 
     public class CustomResourceList<T> : KubernetesObject


### PR DESCRIPTION
When trying to load some 'status' items for the first time realized 'CStatus' in the provided example CustomResourceDefinition should have actually been 'status'.  After correcting the typo status items were then available.