### PR TITLE
Conditionally redirect stderr for exec auth provider

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -494,7 +494,7 @@ namespace k8s
             throw new KubeConfigException("Refresh not supported.");
         }
 
-        public static Process CreateRunnableExternalProcess(ExternalExecution config)
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null)
         {
             if (config == null)
             {
@@ -535,7 +535,7 @@ namespace k8s
             }
 
             process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.RedirectStandardError = captureStdError != null;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;
 
@@ -560,14 +560,15 @@ namespace k8s
                 throw new ArgumentNullException(nameof(config));
             }
 
-            var process = CreateRunnableExternalProcess(config);
+            var captureStdError = ExecStdError;
+            var process = CreateRunnableExternalProcess(config, captureStdError);
 
             try
             {
                 process.Start();
-                if (ExecStdError != null)
+                if (captureStdError != null)
                 {
-                    process.ErrorDataReceived += (s, e) => ExecStdError.Invoke(s, e);
+                    process.ErrorDataReceived += captureStdError.Invoke;
                     process.BeginErrorReadLine();
                 }
             }


### PR DESCRIPTION
External command authentication provider may prompt user interaction in stderr (e.g. [Azure/kubelogin device code flow](https://github.com/Azure/kubelogin/blob/e5dd8912ed0b6e4a4f0eda8f8cc8012c26d66b6c/pkg/token/devicecode.go#L46C55-L46C55)).
If stderr is redirected, users won't be able to see the prompt in the console.

Globally searching for `ExecStdError` didn't yield any meaningful result, so I would just remove that event handler and disable stderr redirection.