### PR TITLE
Prevent UnobservedTaskException  in LeaderElector

### DIFF
--- a/src/KubernetesClient/LeaderElection/LeaderElector.cs
+++ b/src/KubernetesClient/LeaderElection/LeaderElector.cs
@@ -214,7 +214,7 @@ namespace k8s.LeaderElection
                     else
                     {
                         // else timeout
-                        _ = acq.ContinueWith(t => _ = t.Exception /* prevent UnobservedTaskException */, TaskContinuationOptions.OnlyOnFaulted);
+                        _ = acq.ContinueWith(t => OnError?.Invoke(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
                     }
                 }
                 finally

--- a/src/KubernetesClient/LeaderElection/LeaderElector.cs
+++ b/src/KubernetesClient/LeaderElection/LeaderElector.cs
@@ -211,8 +211,11 @@ namespace k8s.LeaderElection
                         // wait RetryPeriod since acq return immediately
                         await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     }
-
-                    // else timeout
+                    else
+                    {
+                        // else timeout
+                        _ = acq.ContinueWith(t => _ = t.Exception /* prevent UnobservedTaskException */, TaskContinuationOptions.OnlyOnFaulted);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
We have noticed that LeaderElector can produce UnobservedTaskException, this PR aims  to 'observe' this exception so UnobservedTaskException handler is not invoked.