### PR TITLE
fix crd code er

### DIFF
--- a/examples/customResource/Program.cs
+++ b/examples/customResource/Program.cs
@@ -92,11 +92,11 @@ namespace customResource
             // deleting the custom resource
             try
             {
-                myCr = await generic.DeleteNamespacedAsync<CResource>(
+                var status = await generic.DeleteNamespacedAsync<V1Status>(
                    myCr.Metadata.NamespaceProperty ?? "default",
                    myCr.Metadata.Name).ConfigureAwait(false);
 
-                Console.WriteLine("Deleted the CR");
+                Console.WriteLine($"Deleted the CR status: {status}");
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
fix 

```
Unhandled exception. k8s.Autorest.HttpOperationException: Operation returned an invalid status code 'NotFound', response body 404 page not found

   at k8s.Kubernetes.SendRequestRaw(String requestContent, HttpRequestMessage httpRequest, CancellationToken cancellationToken) in C:\workspace\k8scsharp\src\KubernetesClient\Kubernetes.cs:line 180
   at k8s.AbstractKubernetes.ICustomObjectsOperations_ListNamespacedCustomObjectWithHttpMessagesAsync[T](String group, String version, String namespaceParameter, String plural, Nullable`1 allowWatchBookmarks, String continueParameter, String fieldSelector, String labelSelector, Nullable`1 limit, String resourceVersion, String resourceVersionMatch, Nullable`1 timeoutSeconds, Nullable`1 watch, Nullable`1 pretty, IReadOnlyDictionary`2 customHeaders, CancellationToken cancellationToken) in C:\workspace\k8scsharp\src\KubernetesClient\LibKubernetesGenerator\LibKubernetesGenerator.KubernetesClientSourceGenerator\CustomObjectsOperations.g.cs:line 467
   at k8s.AbstractKubernetes.k8s.ICustomObjectsOperations.ListNamespacedCustomObjectWithHttpMessagesAsync[T](String group, String version, String namespaceParameter, String plural, Nullable`1 allowWatchBookmarks, String continueParameter, String fieldSelector, String labelSelector, Nullable`1 limit, String resourceVersion, String resourceVersionMatch, Nullable`1 timeoutSeconds, Nullable`1 watch, Nullable`1 pretty, IReadOnlyDictionary`2 customHeaders, CancellationToken cancellationToken) in C:\workspace\k8scsharp\src\KubernetesClient\LibKubernetesGenerator\LibKubernetesGenerator.KubernetesClientSourceGenerator\CustomObjectsOperations.g.cs:line 535
   at k8s.GenericClient.ListNamespacedAsync[T](String ns, CancellationToken cancel) in C:\workspace\k8scsharp\src\KubernetesClient\GenericClient.cs:line 55
   at customResource.Program.Main(String[] args) in C:\workspace\k8scsharp\examples\customResource\Program.cs:line 53
   at customResource.Program.<Main>(String[] args)

```