### PR TITLE
Fix possible resource leak on `KubernetesClientConfiguration` without introducing `IDisposable`

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -4,7 +4,6 @@ using k8s.KubeConfigModels;
 using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 
 namespace k8s
 {
@@ -306,17 +305,11 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
-                    // This null password is to change the constructor to fix this KB:
-                    // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
-                    string nullPassword = null;
-                    var data = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(data), nullPassword));
+                    CaCertificateData = Convert.FromBase64String(clusterDetails.ClusterEndpoint.CertificateAuthorityData);
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(GetFullPath(
-                        k8SConfig,
-                        clusterDetails.ClusterEndpoint.CertificateAuthority)));
+                    CaCertificateFullFilePath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
                 }
             }
         }

--- a/src/KubernetesClient/KubernetesClientConfiguration.InCluster.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.InCluster.cs
@@ -63,7 +63,7 @@ namespace k8s
             {
                 Host = new UriBuilder("https", host, Convert.ToInt32(port)).ToString(),
                 TokenProvider = new TokenFileAuth(Path.Combine(ServiceAccountPath, ServiceAccountTokenKeyFileName)),
-                SslCaCerts = CertUtils.LoadPemFileCert(rootCAFile),
+                CaCertificateFullFilePath = rootCAFile,
             };
 
             var namespaceFile = Path.Combine(ServiceAccountPath, ServiceAccountNamespaceFileName);


### PR DESCRIPTION
Fix #1446 without introducing `IDisposable` on `KubernetesClientConfiguration`

Breaking Changes:
  * Using `KubernetesClientConfiguration.SslCaCerts` or `KubernetesClientConfiguration.LoadSslCaCerts()` requires the user to dispose the returned `X509Certificate2Collection` after usage.
  * Setter of `KubernetesClientConfiguration.SslCaCerts` was removed.