### PR TITLE
Fix: Exec provider potential deadlock

### DIFF
--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -553,6 +553,12 @@ namespace k8s
                     throw new KubeConfigException("external exec failed due to timeout");
                 }
 
+                // Force flush the output buffer to avoid case of missing data
+                if (ExecTimeout != Timeout.InfiniteTimeSpan)
+                {
+                    process.WaitForExit();
+                }
+
                 var responseObject = KubernetesJson.Deserialize<ExecCredentialResponse>(output.ToString());
 
                 if (responseObject == null || responseObject.ApiVersion != config.ApiVersion)

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -537,12 +537,13 @@ namespace k8s
 
             try
             {
-                if (!process.WaitForExit((int)(ExecTimeout.TotalMilliseconds)))
+                var responseObject = KubernetesJson.Deserialize<ExecCredentialResponse>(process.StandardOutput.ReadToEnd());
+
+                if (!process.WaitForExit((int)ExecTimeout.TotalMilliseconds))
                 {
                     throw new KubeConfigException("external exec failed due to timeout");
                 }
 
-                var responseObject = KubernetesJson.Deserialize<ExecCredentialResponse>(process.StandardOutput.ReadToEnd());
                 if (responseObject == null || responseObject.ApiVersion != config.ApiVersion)
                 {
                     throw new KubeConfigException(


### PR DESCRIPTION
The current use of `WaitForExit()` _before_ trying to read standard output stream is problematic and may cause deadlock scenario. `WaitForExit()` should be generally called after all other methods have been called on Process ([ref](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netstandard-2.0)).

In existing scenario, if the child process has already written enough output to the stream, the parent process will be keep on waiting for the child process to exit and the child process would not exit as the stream has not been read from completely. 


