### PR TITLE
Move to net8.0

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -17,6 +17,7 @@ jobs:
           dotnet-version: |
            6.0.x
            7.0.x
+           8.0.x
       # - name: Check Format
       #   # don't check formatting on Windows b/c of CRLF issues.
       #   if: matrix.os == 'ubuntu-latest'
@@ -68,6 +69,7 @@ jobs:
           dotnet-version: |
            6.0.x
            7.0.x
+           8.0.x
       - name: Minikube
         run: minikube start
       - name: Test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,7 @@ jobs:
           3.1.x
           6.0.x
           7.0.x
+          8.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,8 +44,16 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    # Currently .NET8.0 isn't supported
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v2
+
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Debug --no-restore
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -35,6 +35,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
 
     - name: Build
       run: dotnet build

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -20,6 +20,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
 
     - name: dotnet restore
       run: dotnet restore --verbosity minimal --configfile nuget.config

--- a/.github/workflows/nuget.yaml
+++ b/.github/workflows/nuget.yaml
@@ -20,6 +20,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
 
     - name: dotnet restore
       run: dotnet restore --verbosity minimal --configfile nuget.config

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,12 +1,24 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" >
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Visible="false" />
-  </ItemGroup>
+    <ItemGroup>
+        <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Visible="false" />
+    </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/examples/openTelemetryConsole/openTelemetryConsole.csproj
+++ b/examples/openTelemetryConsole/openTelemetryConsole.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.6.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,9 @@
-
 {
-  "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestMajor"
-  },
-  "msbuild-sdks": {
-    "Microsoft.Build.Traversal" : "4.1.0"
-  }
+    "sdk": {
+        "version": "8.0.100",
+        "rollForward": "latestMajor"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Build.Traversal": "4.1.0"
+    }
 }

--- a/kubernetes-client.sln
+++ b/kubernetes-client.sln
@@ -1,4 +1,4 @@
-﻿3D1864AA-1FFC-4512-BB13-46055E410F73
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -64,6 +64,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cp", "examples\cp\cp.csproj", "{CC41E248-2139-427E-8DD4-B047A8924FD2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KubernetesClient.ModelConverter", "src\KubernetesClient.ModelConverter\KubernetesClient.ModelConverter.csproj", "{F1C8276A-8A60-4362-96B8-A006314446AE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibKubernetesGenerator", "src\LibKubernetesGenerator\generators\LibKubernetesGenerator\LibKubernetesGenerator.csproj", "{5EBC9C3E-855A-4757-800A-CC038DB491CF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibKubernetesGenerator.Automapper", "src\LibKubernetesGenerator\generators\LibKubernetesGenerator.Automapper\LibKubernetesGenerator.Automapper.csproj", "{999C6150-4EC7-44E1-B4B9-77556F8A3B93}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -255,18 +259,6 @@ Global
 		{F06D4C3A-7825-43A8-832B-6BDE3D355486}.Release|x64.Build.0 = Release|Any CPU
 		{F06D4C3A-7825-43A8-832B-6BDE3D355486}.Release|x86.ActiveCfg = Release|Any CPU
 		{F06D4C3A-7825-43A8-832B-6BDE3D355486}.Release|x86.Build.0 = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|x64.Build.0 = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Debug|x86.Build.0 = Debug|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|x64.ActiveCfg = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|x64.Build.0 = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|x86.ActiveCfg = Release|Any CPU
-		{64C71596-B916-46EF-8115-B53E238F79D4}.Release|x86.Build.0 = Release|Any CPU
 		{DFBB1025-BD22-459D-A04D-E2AB31E129E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DFBB1025-BD22-459D-A04D-E2AB31E129E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFBB1025-BD22-459D-A04D-E2AB31E129E2}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -435,6 +427,30 @@ Global
 		{F1C8276A-8A60-4362-96B8-A006314446AE}.Release|x64.Build.0 = Release|Any CPU
 		{F1C8276A-8A60-4362-96B8-A006314446AE}.Release|x86.ActiveCfg = Release|Any CPU
 		{F1C8276A-8A60-4362-96B8-A006314446AE}.Release|x86.Build.0 = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|x64.Build.0 = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Debug|x86.Build.0 = Debug|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|x64.Build.0 = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|x86.ActiveCfg = Release|Any CPU
+		{5EBC9C3E-855A-4757-800A-CC038DB491CF}.Release|x86.Build.0 = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|x64.Build.0 = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Debug|x86.Build.0 = Debug|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|x64.ActiveCfg = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|x64.Build.0 = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|x86.ActiveCfg = Release|Any CPU
+		{999C6150-4EC7-44E1-B4B9-77556F8A3B93}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/KubernetesClient.Kubectl/KubernetesClient.Kubectl.csproj
+++ b/src/KubernetesClient.Kubectl/KubernetesClient.Kubectl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>k8s.kubectl</RootNamespace>

--- a/src/KubernetesClient.ModelConverter/KubernetesClient.ModelConverter.csproj
+++ b/src/KubernetesClient.ModelConverter/KubernetesClient.ModelConverter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>k8s.ModelConverter</RootNamespace>
   </PropertyGroup>
 

--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <RootNamespace>k8s</RootNamespace>
         <!-- seems bug in net7 json generator, some types missing in its result
             net8 is still in preview, will enable it after net8 release -->

--- a/tests/E2E.Tests/E2E.Tests.csproj
+++ b/tests/E2E.Tests/E2E.Tests.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <RootNamespace>k8s.E2E</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Kubectl.Tests/Kubectl.Tests.csproj
+++ b/tests/Kubectl.Tests/Kubectl.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/KubernetesClient.Classic.Tests/KubernetesClient.Classic.Tests.csproj
+++ b/tests/KubernetesClient.Classic.Tests/KubernetesClient.Classic.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>k8s.Tests</RootNamespace>
-    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net8.0;net48</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/KubernetesClient.Classic.Tests/KubernetesClient.Classic.Tests.csproj
+++ b/tests/KubernetesClient.Classic.Tests/KubernetesClient.Classic.Tests.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>k8s.Tests</RootNamespace>
-    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net48</TargetFrameworks>
+    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net6.0;net7.0;net8.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
+++ b/tests/KubernetesClient.Tests/KubernetesClient.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>k8s.Tests</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/KubernetesClient.Tests/WatchTests.cs
+++ b/tests/KubernetesClient.Tests/WatchTests.cs
@@ -409,7 +409,12 @@ namespace k8s.Tests
                 await Task.WhenAny(waitForClosed.WaitAsync(), Task.Delay(TestTimeout)).ConfigureAwait(false);
                 Assert.True(waitForClosed.IsSet);
                 Assert.False(watcher.Watching);
+
+#if NET8_0_OR_GREATER
+                Assert.IsType<HttpIOException>(exceptionCatched);
+#else
                 Assert.IsType<IOException>(exceptionCatched);
+#endif
             }
         }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "12.1",
+  "version": "12.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
.Net 8.0 was released, in order to start the migration to the newer version of framework i updated the .net version of examples to the latest. I also accorgitly updated actions to build the update projects.