### PR TITLE
Updated OpenTelemetry.Instrumentation.Http from version 1.0.0-rc9.14 to 1.6.0-beta.3

### DIFF
--- a/examples/openTelemetryConsole/openTelemetryConsole.csproj
+++ b/examples/openTelemetryConsole/openTelemetryConsole.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="OpenTelemetry" Version="1.6.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.3" />
     </ItemGroup>
     
 </Project>


### PR DESCRIPTION
Package updated to the latest version, there is currently no stable release.