### PR TITLE
Improve docs and naming of `LeaderElector` methods.

### DIFF
--- a/src/KubernetesClient/LeaderElection/LeaderElector.cs
+++ b/src/KubernetesClient/LeaderElection/LeaderElector.cs
@@ -122,7 +122,7 @@ namespace k8s.LeaderElection
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                await RunUntilLeadershipLostAsync(cancellationToken);
+                await RunUntilLeadershipLostAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -71,7 +71,7 @@ namespace k8s.Tests.LeaderElection
                     countdown.Signal();
                 };
 
-                leaderElector.RunAsync().Wait();
+                leaderElector.RunUntilLeadershipLostAsync().Wait();
             });
 
             countdown.Wait(TimeSpan.FromSeconds(10));
@@ -164,7 +164,7 @@ namespace k8s.Tests.LeaderElection
                     lockAStopLeading.Set();
                 };
 
-                leaderElector.RunAsync().Wait();
+                leaderElector.RunUntilLeadershipLostAsync().Wait();
             });
 
 
@@ -186,7 +186,7 @@ namespace k8s.Tests.LeaderElection
                     testLeaderElectionLatch.Signal();
                 };
 
-                leaderElector.RunAsync().Wait();
+                leaderElector.RunUntilLeadershipLostAsync().Wait();
             });
 
             testLeaderElectionLatch.Wait(TimeSpan.FromSeconds(15));
@@ -272,7 +272,7 @@ namespace k8s.Tests.LeaderElection
                     countdown.Signal();
                 };
 
-                leaderElector.RunAsync().Wait();
+                leaderElector.RunUntilLeadershipLostAsync().Wait();
             });
 
             countdown.Wait(TimeSpan.FromSeconds(15));
@@ -305,7 +305,7 @@ namespace k8s.Tests.LeaderElection
 
             try
             {
-                leaderElector.RunAsync().Wait();
+                leaderElector.RunUntilLeadershipLostAsync().Wait();
             }
             catch (Exception e)
             {
@@ -362,7 +362,7 @@ namespace k8s.Tests.LeaderElection
                 countdown.Signal();
             };
 
-            Task.Run(() => leaderElector.RunAsync());
+            Task.Run(() => leaderElector.RunUntilLeadershipLostAsync());
             countdown.Wait(TimeSpan.FromSeconds(10));
 
             Assert.True(notifications.SequenceEqual(new[]
@@ -403,7 +403,7 @@ namespace k8s.Tests.LeaderElection
                 countdown.Signal();
             };
 
-            Task.Run(() => leaderElector.RunAsync());
+            Task.Run(() => leaderElector.RunUntilLeadershipLostAsync());
             countdown.Wait(TimeSpan.FromSeconds(10));
 
             Assert.True(notifications.SequenceEqual(new[] { "foo1" }));


### PR DESCRIPTION
Improves docs and naming of `LeaderElector` methods. Also introduces `LeaderElector.AcquireLeadershipForever()`.

Fixes https://github.com/kubernetes-client/csharp/issues/1467