### PR TITLE
Pass CancellationToken from StreamConnectAsync to webSocketBuilder.BuildAndConnectAsync

### DIFF
--- a/src/KubernetesClient/Kubernetes.WebSocket.cs
+++ b/src/KubernetesClient/Kubernetes.WebSocket.cs
@@ -281,8 +281,7 @@ namespace k8s
             try
             {
                 BeforeRequest();
-                webSocket = await webSocketBuilder.BuildAndConnectAsync(uri, CancellationToken.None)
-                    .ConfigureAwait(false);
+                webSocket = await webSocketBuilder.BuildAndConnectAsync(uri, cancellationToken).ConfigureAwait(false);
             }
             catch (WebSocketException wse) when (wse.WebSocketErrorCode == WebSocketError.HeaderError ||
                                                  (wse.InnerException is WebSocketException &&


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/csharp/issues/1503

Pass CancellationToken from StreamConnectAsync to webSocketBuilder.BuildAndConnectAsync to allow an in-progress connection attempt to be cancelled.