### PR TITLE
Let `Microsoft.VisualStudio.SlnGen` dependency development only

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SlnGen" Version="11.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SlnGen" Version="11.1.0" PrivateAssets="all" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
This seemed should be a development dependency only, currently, it would be a dependency for the packages

![image](https://github.com/kubernetes-client/csharp/assets/7604648/4603b3bd-3255-42f2-a72c-4ca4af975f93)


Configure `Microsoft.VisualStudio.SlnGen` `PrivateAssets` to let it be development only

https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets