### PR TITLE
fix docfx build

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -38,7 +38,7 @@ jobs:
           8.0.x
 
     - name: Build
-      run: dotnet build
+      run: dotnet build -c Release
 
     - uses: nunit/docfx-action@v3.1.0
       name: Build Documentation


### PR DESCRIPTION
use `dotnet build -c Release` for the build step

action run: https://github.com/WeihanLi/kubernetes-client-csharp/actions/runs/8074136853