### PR TITLE
Adding back PrometheusHandler to avoid breaking change

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
         <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
         <PackageReference Include="Fractions" Version="7.3.0" />

--- a/src/KubernetesClient/PrometheusHandler.cs
+++ b/src/KubernetesClient/PrometheusHandler.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Net.Http;
+
+namespace k8s
+{
+    /// <summary>
+    /// Implements legacy Prometheus metrics
+    /// </summary>
+    /// <remarks>Provided for compatibility for existing usages of PrometheusHandler. It is recommended
+    /// to transition to using OpenTelemetry and the default HttpClient metrics.
+    ///
+    /// Note that the tags/labels are not appropriately named for some metrics. This
+    /// incorrect naming is retained to maintain compatibility and won't be fixed on this implementation.
+    /// Use OpenTelemetry and the standard HttpClient metrics instead.</remarks>
+    public class PrometheusHandler : DelegatingHandler
+    {
+        private const string Prefix = "k8s_dotnet";
+        private static readonly Meter Meter = new Meter("k8s.dotnet");
+
+        private static readonly Counter<int> RequestsSent = Meter.CreateCounter<int>(
+            $"{Prefix}_request_total",
+            description: "Number of requests sent by this client");
+
+        private static readonly Histogram<double> RequestLatency = Meter.CreateHistogram<double>(
+            $"{Prefix}_request_latency_seconds", unit: "milliseconds",
+            description: "Latency of requests sent by this client");
+
+        private static readonly Counter<int> ResponseCodes = Meter.CreateCounter<int>(
+            $"{Prefix}_response_code_total",
+            description: "Number of response codes received by the client");
+
+        private static readonly UpDownCounter<int> ActiveRequests =
+            Meter.CreateUpDownCounter<int>(
+                $"{Prefix}_active_requests",
+                description: "Number of requests currently in progress");
+
+        /// <inheritdoc />
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var digest = KubernetesRequestDigest.Parse(request);
+            var timer = Stopwatch.StartNew();
+            // Note that this is a tag called "method" but the value is the Verb.
+            // This is incorrect, but existing behavior.
+            var methodWithVerbValue = new KeyValuePair<string, object>("method", digest.Verb);
+            try
+            {
+                ActiveRequests.Add(1, methodWithVerbValue);
+                RequestsSent.Add(1, methodWithVerbValue);
+
+                var resp = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                ResponseCodes.Add(
+                    1,
+                    new KeyValuePair<string, object>("method", request.Method.ToString()),
+                    new KeyValuePair<string, object>("code", (int)resp.StatusCode));
+                return resp;
+            }
+            finally
+            {
+                timer.Stop();
+                ActiveRequests.Add(-1, methodWithVerbValue);
+                var tags = new TagList
+                    {
+                        { "verb", digest.Verb },
+                        { "group", digest.ApiGroup },
+                        { "version", digest.ApiVersion },
+                        { "kind", digest.Kind },
+                    }
+                    ;
+                RequestLatency.Record(timer.Elapsed.TotalMilliseconds, tags);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a PrometheusHandler implementation to mimic the prior prometheus-net based implementation.

Note that the old implementation incorrectly created some labels/tags with a name of "method" but the value as the Verb of the request. This incorrect behavior is maintained and noted.

The end result is that the same named metrics will be produced. The prometheus-net library reads values from System.Diagnostics.Metrics already so these will be picked up by anyone that is already using this handler.

Ultimately, users should migrate to using the built in HttpClient metrics that covers these custom metrics, uses standard semantic conventions for metric names, and has the correct labels/tags added to metrics.