### PR TITLE
YamlDotNot is not thread-safe

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -14,6 +14,8 @@
         <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
         <PackageReference Include="Fractions" Version="7.3.0" />
         <PackageReference Include="YamlDotNet" Version="15.1.0" />
+        <!--Same issue with the latest version of YamlDotNet-->
+        <!--<PackageReference Include="YamlDotNet" Version="15.1.2" />-->
     </ItemGroup>
 
     <ItemGroup>

--- a/src/KubernetesClient/KubernetesYaml.cs
+++ b/src/KubernetesClient/KubernetesYaml.cs
@@ -12,6 +12,27 @@ namespace k8s
     /// </summary>
     public static class KubernetesYaml
     {
+        //private static DeserializerBuilder GetCommonDeserializerBuilder() =>
+        //    new DeserializerBuilder()
+        //        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        //        .WithTypeConverter(new IntOrStringYamlConverter())
+        //        .WithTypeConverter(new ByteArrayStringYamlConverter())
+        //        .WithTypeConverter(new ResourceQuantityYamlConverter())
+        //        .WithAttemptingUnquotedStringTypeDeserialization()
+        //        .WithOverridesFromJsonPropertyAttributes();
+
+        //private static IDeserializer GetStrictDeserializer() =>
+        //    GetCommonDeserializerBuilder()
+        //    .WithDuplicateKeyChecking()
+        //    .Build();
+
+        //private static IDeserializer GetDeserializer() =>
+        //    GetCommonDeserializerBuilder()
+        //    .IgnoreUnmatchedProperties()
+        //    .Build();
+
+        //private static IDeserializer GetDeserializer(bool strict) => strict ? GetStrictDeserializer() : GetDeserializer();
+
         private static DeserializerBuilder CommonDeserializerBuilder =>
             new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
@@ -23,12 +44,12 @@ namespace k8s
 
         private static readonly IDeserializer StrictDeserializer =
             CommonDeserializerBuilder
-            .WithDuplicateKeyChecking()
-            .Build();
+                .WithDuplicateKeyChecking()
+                .Build();
         private static readonly IDeserializer Deserializer =
             CommonDeserializerBuilder
-            .IgnoreUnmatchedProperties()
-            .Build();
+                .IgnoreUnmatchedProperties()
+                .Build();
         private static IDeserializer GetDeserializer(bool strict) => strict ? StrictDeserializer : Deserializer;
 
         private static readonly IValueSerializer Serializer =


### PR DESCRIPTION
This PR demonstrates that `KubernetesClientConfiguration.LoadKubeConfig` is not thread-safe due to YamlDotNot Deserializers.

```
   Exception during deserialization
   
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.ValueDeserializers.AliasValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
   at YamlDotNet.Serialization.Deserializer.Deserialize(IParser parser, Type type)
   at YamlDotNet.Serialization.Deserializer.Deserialize[T](IParser parser)
   at k8s.KubernetesYaml.Deserialize[TValue](String yaml, Boolean strict) in F:\Code\kubernetes-client\src\KubernetesClient\KubernetesYaml.cs:line 207
   at k8s.KubernetesYaml.<LoadFromStreamAsync>d__11`1.MoveNext() in F:\Code\kubernetes-client\src\KubernetesClient\KubernetesYaml.cs:line 181
   at k8s.KubernetesClientConfiguration.<LoadKubeConfigAsync>d__31.MoveNext() in F:\Code\kubernetes-client\src\KubernetesClient\KubernetesClientConfiguration.ConfigFile.cs:line 639
   at k8s.KubernetesClientConfiguration.<LoadKubeConfigAsync>d__36.MoveNext() in F:\Code\kubernetes-client\src\KubernetesClient\KubernetesClientConfiguration.ConfigFile.cs:line 713
   at k8s.KubernetesClientConfiguration.LoadKubeConfig(FileInfo[] kubeConfigs, Boolean useRelativePaths) in F:\Code\kubernetes-client\src\KubernetesClient\KubernetesClientConfiguration.ConfigFile.cs:line 695
   at k8s.Tests.KubernetesClientConfigurationTests.<>c__DisplayClass48_0.<LoadKubeConfigShouldBeThreadSafe>g__LoadKubeConfig|3() in F:\Code\kubernetes-client\tests\KubernetesClient.Tests\KubernetesClientConfigurationTests.cs:line 691

   # INNER EXCEPTION

   Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.

      at System.ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported()
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)
   at YamlDotNet.Serialization.ObjectFactories.DefaultObjectFactory.GetStateMethods(Type attributeType, Type valueType)
   at YamlDotNet.Serialization.ObjectFactories.DefaultObjectFactory.ExecuteState(Type attributeType, Object value)
   at YamlDotNet.Serialization.ObjectFactories.DefaultObjectFactory.ExecuteOnDeserializing(Object value)
   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.Deserialize(IParser parser, Type expectedType, Func`3 nestedObjectDeserializer, Object& value)
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
```