### PR TITLE
Refactor LibKubernetesGenerator code structure

### DIFF
--- a/src/LibKubernetesGenerator/GeneralNameHelper.cs
+++ b/src/LibKubernetesGenerator/GeneralNameHelper.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace LibKubernetesGenerator
 {
-    internal class GeneralNameHelper: IScriptObjectHelper
+    internal class GeneralNameHelper : IScriptObjectHelper
     {
         private readonly ClassNameHelper classNameHelper;
 
@@ -18,13 +18,6 @@ namespace LibKubernetesGenerator
             this.classNameHelper = classNameHelper;
         }
 
-        // public void RegisterHelper()
-        // {
-        //     Helpers.Register(nameof(GetInterfaceName), GetInterfaceName);
-        //     Helpers.Register(nameof(GetMethodName), GetMethodName);
-        //     Helpers.Register(nameof(GetDotNetName), GetDotNetName);
-        // }
-
         public void RegisterHelper(ScriptObject scriptObject)
         {
             scriptObject.Import(nameof(GetInterfaceName), new Func<JsonSchema, string>(GetInterfaceName));
@@ -32,16 +25,6 @@ namespace LibKubernetesGenerator
             scriptObject.Import(nameof(GetDotNetName), new Func<string, string, string>(GetDotNetName));
             scriptObject.Import(nameof(GetDotNetNameOpenApiParameter), new Func<OpenApiParameter, string, string>(GetDotNetNameOpenApiParameter));
         }
-
-
-        //public void GetInterfaceName(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-        //    {
-        //        context.Write(GetInterfaceName(arguments[0] as JsonSchema));
-        //    }
-        //}
 
         private string GetInterfaceName(JsonSchema definition)
         {
@@ -77,46 +60,6 @@ namespace LibKubernetesGenerator
 
             return string.Join(", ", interfaces);
         }
-
-        //public void GetMethodName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiOperation)
-        //    {
-        //        string suffix = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            suffix = arguments[1] as string;
-        //        }
-
-        //        context.Write(GetMethodName(arguments[0] as OpenApiOperation, suffix));
-        //    }
-        //}
-
-        //public void GetDotNetName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
-        //    {
-        //        var parameter = arguments[0] as OpenApiParameter;
-        //        context.Write(GetDotNetName(parameter.Name));
-
-        //        if (arguments.Count > 1 && (arguments[1] as string) == "true" && !parameter.IsRequired)
-        //        {
-        //            context.Write(" = null");
-        //        }
-        //    }
-        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
-        //    {
-        //        var style = "parameter";
-        //        if (arguments.Count > 1)
-        //        {
-        //            style = arguments[1] as string;
-        //        }
-
-        //        context.Write(GetDotNetName((string)arguments[0], style));
-        //    }
-        //}
 
         public string GetDotNetNameOpenApiParameter(OpenApiParameter parameter, string init)
         {

--- a/src/LibKubernetesGenerator/GeneralNameHelper.cs
+++ b/src/LibKubernetesGenerator/GeneralNameHelper.cs
@@ -1,14 +1,15 @@
 using CaseExtensions;
 using NJsonSchema;
 using NSwag;
-using Nustache.Core;
+using Scriban.Runtime;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace LibKubernetesGenerator
 {
-    internal class GeneralNameHelper : INustacheHelper
+    internal class GeneralNameHelper: IScriptObjectHelper
     {
         private readonly ClassNameHelper classNameHelper;
 
@@ -17,21 +18,30 @@ namespace LibKubernetesGenerator
             this.classNameHelper = classNameHelper;
         }
 
-        public void RegisterHelper()
+        // public void RegisterHelper()
+        // {
+        //     Helpers.Register(nameof(GetInterfaceName), GetInterfaceName);
+        //     Helpers.Register(nameof(GetMethodName), GetMethodName);
+        //     Helpers.Register(nameof(GetDotNetName), GetDotNetName);
+        // }
+
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(GetInterfaceName), GetInterfaceName);
-            Helpers.Register(nameof(GetMethodName), GetMethodName);
-            Helpers.Register(nameof(GetDotNetName), GetDotNetName);
+            scriptObject.Import(nameof(GetInterfaceName), new Func<JsonSchema, string>(GetInterfaceName));
+            scriptObject.Import(nameof(GetMethodName), new Func<OpenApiOperation, string, string>(GetMethodName));
+            scriptObject.Import(nameof(GetDotNetName), new Func<string, string, string>(GetDotNetName));
+            scriptObject.Import(nameof(GetDotNetNameOpenApiParameter), new Func<OpenApiParameter, string, string>(GetDotNetNameOpenApiParameter));
         }
 
-        public void GetInterfaceName(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-            {
-                context.Write(GetInterfaceName(arguments[0] as JsonSchema));
-            }
-        }
+
+        //public void GetInterfaceName(RenderContext context, IList<object> arguments,
+        //    IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
+        //    {
+        //        context.Write(GetInterfaceName(arguments[0] as JsonSchema));
+        //    }
+        //}
 
         private string GetInterfaceName(JsonSchema definition)
         {
@@ -68,44 +78,56 @@ namespace LibKubernetesGenerator
             return string.Join(", ", interfaces);
         }
 
-        public void GetMethodName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
+        //public void GetMethodName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiOperation)
+        //    {
+        //        string suffix = null;
+        //        if (arguments.Count > 1)
+        //        {
+        //            suffix = arguments[1] as string;
+        //        }
+
+        //        context.Write(GetMethodName(arguments[0] as OpenApiOperation, suffix));
+        //    }
+        //}
+
+        //public void GetDotNetName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
+        //    {
+        //        var parameter = arguments[0] as OpenApiParameter;
+        //        context.Write(GetDotNetName(parameter.Name));
+
+        //        if (arguments.Count > 1 && (arguments[1] as string) == "true" && !parameter.IsRequired)
+        //        {
+        //            context.Write(" = null");
+        //        }
+        //    }
+        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
+        //    {
+        //        var style = "parameter";
+        //        if (arguments.Count > 1)
+        //        {
+        //            style = arguments[1] as string;
+        //        }
+
+        //        context.Write(GetDotNetName((string)arguments[0], style));
+        //    }
+        //}
+
+        public string GetDotNetNameOpenApiParameter(OpenApiParameter parameter, string init)
         {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiOperation)
+            var name = GetDotNetName(parameter.Name);
+
+            if (init == "true" && !parameter.IsRequired)
             {
-                string suffix = null;
-                if (arguments.Count > 1)
-                {
-                    suffix = arguments[1] as string;
-                }
-
-                context.Write(GetMethodName(arguments[0] as OpenApiOperation, suffix));
+                name += " = null";
             }
-        }
 
-        public void GetDotNetName(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
-            {
-                var parameter = arguments[0] as OpenApiParameter;
-                context.Write(GetDotNetName(parameter.Name));
-
-                if (arguments.Count > 1 && (arguments[1] as string) == "true" && !parameter.IsRequired)
-                {
-                    context.Write(" = null");
-                }
-            }
-            else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
-            {
-                var style = "parameter";
-                if (arguments.Count > 1)
-                {
-                    style = arguments[1] as string;
-                }
-
-                context.Write(GetDotNetName((string)arguments[0], style));
-            }
+            return name;
         }
 
         public string GetDotNetName(string jsonName, string style = "parameter")

--- a/src/LibKubernetesGenerator/GeneratorExecutionContextExt.cs
+++ b/src/LibKubernetesGenerator/GeneratorExecutionContextExt.cs
@@ -1,16 +1,29 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Nustache.Core;
+using Scriban;
+using Scriban.Runtime;
 using System.Text;
 
 namespace LibKubernetesGenerator
 {
     internal static class GeneratorExecutionContextExt
     {
-        public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, object data, string generatedfile)
+        public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, object sc, string generatedfile)
         {
-            var template = EmbedResource.GetResource(templatefile);
-            var generated = Render.StringToString(template, data);
+            // TODO remove
+        }
+
+        public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, ScriptObject sc, string generatedfile)
+        {
+            var tc = new TemplateContext();
+            tc.PushGlobal(sc);
+            context.RenderToContext(templatefile, tc, generatedfile);
+        }
+
+        public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, TemplateContext tc, string generatedfile)
+        {
+            var template = Template.Parse(EmbedResource.GetResource(templatefile));
+            var generated = template.Render(tc);
             context.AddSource(generatedfile, SourceText.From(generated, Encoding.UTF8));
         }
     }

--- a/src/LibKubernetesGenerator/GeneratorExecutionContextExt.cs
+++ b/src/LibKubernetesGenerator/GeneratorExecutionContextExt.cs
@@ -8,11 +8,6 @@ namespace LibKubernetesGenerator
 {
     internal static class GeneratorExecutionContextExt
     {
-        public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, object sc, string generatedfile)
-        {
-            // TODO remove
-        }
-
         public static void RenderToContext(this IncrementalGeneratorPostInitializationContext context, string templatefile, ScriptObject sc, string generatedfile)
         {
             var tc = new TemplateContext();

--- a/src/LibKubernetesGenerator/INustacheHelper.cs
+++ b/src/LibKubernetesGenerator/INustacheHelper.cs
@@ -1,7 +1,0 @@
-namespace LibKubernetesGenerator
-{
-    public interface INustacheHelper
-    {
-        void RegisterHelper();
-    }
-}

--- a/src/LibKubernetesGenerator/IScriptObjectHelper.cs
+++ b/src/LibKubernetesGenerator/IScriptObjectHelper.cs
@@ -1,0 +1,8 @@
+using Scriban.Runtime;
+
+namespace LibKubernetesGenerator;
+
+internal interface IScriptObjectHelper
+{
+    void RegisterHelper(ScriptObject scriptObject);
+}

--- a/src/LibKubernetesGenerator/KubernetesClientSourceGenerator.cs
+++ b/src/LibKubernetesGenerator/KubernetesClientSourceGenerator.cs
@@ -13,8 +13,6 @@ namespace LibKubernetesGenerator
     [Generator]
     public class KubernetesClientSourceGenerator : IIncrementalGenerator
     {
-        private static readonly object Execlock = new object();
-
         private static (OpenApiDocument, IContainer) BuildContainer()
         {
             var swagger = OpenApiDocument.FromJsonAsync(EmbedResource.GetResource("swagger.json")).GetAwaiter().GetResult();
@@ -81,17 +79,14 @@ namespace LibKubernetesGenerator
 #if GENERATE_BASIC
             generatorContext.RegisterPostInitializationOutput(ctx =>
             {
-                lock (Execlock)
-                {
-                    var (swagger, container) = BuildContainer();
+                var (swagger, container) = BuildContainer();
 
-                    container.Resolve<VersionGenerator>().Generate(swagger, ctx);
+                container.Resolve<VersionGenerator>().Generate(swagger, ctx);
 
-                    container.Resolve<ModelGenerator>().Generate(swagger, ctx);
-                    container.Resolve<ModelExtGenerator>().Generate(swagger, ctx);
-                    container.Resolve<VersionConverterStubGenerator>().Generate(swagger, ctx);
-                    container.Resolve<ApiGenerator>().Generate(swagger, ctx);
-                }
+                container.Resolve<ModelGenerator>().Generate(swagger, ctx);
+                container.Resolve<ModelExtGenerator>().Generate(swagger, ctx);
+                container.Resolve<VersionConverterStubGenerator>().Generate(swagger, ctx);
+                container.Resolve<ApiGenerator>().Generate(swagger, ctx);
             });
 #endif
 
@@ -99,12 +94,8 @@ namespace LibKubernetesGenerator
             var automappersrc = generatorContext.CompilationProvider.Select((c, _) => c.SyntaxTrees.First(s => PathSuffixMath(s.FilePath, "AutoMapper/VersionConverter.cs")));
             generatorContext.RegisterSourceOutput(automappersrc, (ctx, srctree) =>
             {
-                lock (Execlock)
-                {
-                    var (swagger, container) = BuildContainer();
-
-                    container.Resolve<VersionConverterAutoMapperGenerator>().Generate(swagger, ctx, srctree);
-                }
+                var (swagger, container) = BuildContainer();
+                container.Resolve<VersionConverterAutoMapperGenerator>().Generate(swagger, ctx, srctree);
             });
 #endif
         }

--- a/src/LibKubernetesGenerator/KubernetesClientSourceGenerator.cs
+++ b/src/LibKubernetesGenerator/KubernetesClientSourceGenerator.cs
@@ -88,9 +88,9 @@ namespace LibKubernetesGenerator
                     container.Resolve<VersionGenerator>().Generate(swagger, ctx);
 
                     container.Resolve<ModelGenerator>().Generate(swagger, ctx);
-                     container.Resolve<ModelExtGenerator>().Generate(swagger, ctx);
-                     container.Resolve<VersionConverterStubGenerator>().Generate(swagger, ctx);
-                     container.Resolve<ApiGenerator>().Generate(swagger, ctx);
+                    container.Resolve<ModelExtGenerator>().Generate(swagger, ctx);
+                    container.Resolve<VersionConverterStubGenerator>().Generate(swagger, ctx);
+                    container.Resolve<ApiGenerator>().Generate(swagger, ctx);
                 }
             });
 #endif

--- a/src/LibKubernetesGenerator/LibKubernetesGenerator.target
+++ b/src/LibKubernetesGenerator/LibKubernetesGenerator.target
@@ -3,6 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <NoWarn>CA1812</NoWarn>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,10 +17,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Scriban" Version="5.9.1" IncludeAssets="Build"/>
         <PackageReference Include="Autofac" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="CaseExtensions" Version="1.1.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="NSwag.Core" Version="13.20.0" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="Nustache" Version="1.16.0.10" GeneratePathProperty="true" PrivateAssets="all" NoWarn="NU1701" />
         <PackageReference Include="NJsonSchema" Version="10.9.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" GeneratePathProperty="true" PrivateAssets="all" />
@@ -36,7 +37,6 @@
             <TargetPathWithTargetPlatformMoniker Include="$(PKGAutofac)\lib\netstandard2.0\Autofac.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGCaseExtensions)\lib\netstandard2.0\CaseExtensions.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNSwag_Core)\lib\netstandard2.0\NSwag.Core.dll" IncludeRuntimeDependency="false" />
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGNustache)\lib\net20\Nustache.Core.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNJsonSchema)\lib\netstandard2.0\NJsonSchema.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNewtonsoft_Json)\lib\netstandard1.0\Newtonsoft.Json.dll" IncludeRuntimeDependency="false" />

--- a/src/LibKubernetesGenerator/LibKubernetesGenerator.target
+++ b/src/LibKubernetesGenerator/LibKubernetesGenerator.target
@@ -40,14 +40,16 @@
 
     <Target Name="GetDependencyTargetPaths">
         <ItemGroup>
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGAutofac)\lib\netstandard2.0\Autofac.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGCaseExtensions)\lib\netstandard2.0\CaseExtensions.dll" IncludeRuntimeDependency="false" />
+
+            <TargetPathWithTargetPlatformMoniker Include="$(PKGAutofac)\lib\netstandard2.0\Autofac.dll" IncludeRuntimeDependency="false" />
+            <TargetPathWithTargetPlatformMoniker Include="$(PKGMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" IncludeRuntimeDependency="false" />
+            <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Diagnostics_DiagnosticSource)\lib\netstandard2.0\System.Diagnostics.DiagnosticSource.dll" IncludeRuntimeDependency="false" />
+
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNSwag_Core)\lib\netstandard2.0\NSwag.Core.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNJsonSchema)\lib\netstandard2.0\NJsonSchema.dll" IncludeRuntimeDependency="false" />
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNewtonsoft_Json)\lib\netstandard1.0\Newtonsoft.Json.dll" IncludeRuntimeDependency="false" />
             <TargetPathWithTargetPlatformMoniker Include="$(PKGNamotion_Reflection)\lib\netstandard2.0\Namotion.Reflection.dll" IncludeRuntimeDependency="false" />
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Diagnostics_DiagnosticSource)\lib\netstandard2.0\System.Diagnostics.DiagnosticSource.dll" IncludeRuntimeDependency="false" />
         </ItemGroup>
     </Target>
 

--- a/src/LibKubernetesGenerator/LibKubernetesGenerator.target
+++ b/src/LibKubernetesGenerator/LibKubernetesGenerator.target
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <NoWarn>CA1812</NoWarn>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
     </PropertyGroup>
@@ -17,15 +16,22 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Scriban No Dependency -->
         <PackageReference Include="Scriban" Version="5.9.1" IncludeAssets="Build"/>
-        <PackageReference Include="Autofac" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+
+        <!-- CaseExtensions No Dependency -->
         <PackageReference Include="CaseExtensions" Version="1.1.0" GeneratePathProperty="true" PrivateAssets="all" />
+
+        <!-- Autofac -->
+        <PackageReference Include="Autofac" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+
+        <!-- NSwag -->
         <PackageReference Include="NSwag.Core" Version="13.20.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="NJsonSchema" Version="10.9.0" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Namotion.Reflection" Version="3.0.1" GeneratePathProperty="true" PrivateAssets="all" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/LibKubernetesGenerator/MetaHelper.cs
+++ b/src/LibKubernetesGenerator/MetaHelper.cs
@@ -1,45 +1,27 @@
 using NJsonSchema;
 using NSwag;
-using Nustache.Core;
+using Scriban.Runtime;
 using System;
 using System.Collections.Generic;
 
 namespace LibKubernetesGenerator
 {
-    internal class MetaHelper : INustacheHelper
+    internal class MetaHelper : IScriptObjectHelper
     {
-        public void RegisterHelper()
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(GetGroup), GetGroup);
-            Helpers.Register(nameof(GetApiVersion), GetApiVersion);
-            Helpers.Register(nameof(GetKind), GetKind);
-            Helpers.Register(nameof(GetPathExpression), GetPathExpression);
-        }
-
-        public static void GetKind(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-            {
-                context.Write(GetKind(arguments[0] as JsonSchema));
-            }
+            scriptObject.Import(nameof(GetGroup), GetGroup);
+            scriptObject.Import(nameof(GetApiVersion), GetApiVersion);
+            scriptObject.Import(nameof(GetKind), GetKind);
+            scriptObject.Import(nameof(GetPathExpression), GetPathExpression);
         }
 
         private static string GetKind(JsonSchema definition)
         {
-           var groupVersionKindElements = (object[])definition.ExtensionData["x-kubernetes-group-version-kind"];
-           var groupVersionKind = (Dictionary<string, object>)groupVersionKindElements[0];
+            var groupVersionKindElements = (object[])definition.ExtensionData["x-kubernetes-group-version-kind"];
+            var groupVersionKind = (Dictionary<string, object>)groupVersionKindElements[0];
 
-           return groupVersionKind["kind"] as string;
-        }
-
-        public static void GetGroup(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-            {
-                context.Write(GetGroup(arguments[0] as JsonSchema));
-            }
+            return groupVersionKind["kind"] as string;
         }
 
         private static string GetGroup(JsonSchema definition)
@@ -50,33 +32,12 @@ namespace LibKubernetesGenerator
             return groupVersionKind["group"] as string;
         }
 
-        public static void GetApiVersion(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-            {
-                context.Write(GetApiVersion(arguments[0] as JsonSchema));
-            }
-        }
-
         private static string GetApiVersion(JsonSchema definition)
         {
             var groupVersionKindElements = (object[])definition.ExtensionData["x-kubernetes-group-version-kind"];
             var groupVersionKind = (Dictionary<string, object>)groupVersionKindElements[0];
 
             return groupVersionKind["version"] as string;
-        }
-
-        public static void GetPathExpression(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options, RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null &&
-                arguments[0] is OpenApiOperationDescription)
-            {
-                var operation = arguments[0] as OpenApiOperationDescription;
-                context.Write(GetPathExpression(operation));
-            }
         }
 
         private static string GetPathExpression(OpenApiOperationDescription operation)

--- a/src/LibKubernetesGenerator/ModelExtGenerator.cs
+++ b/src/LibKubernetesGenerator/ModelExtGenerator.cs
@@ -8,10 +8,12 @@ namespace LibKubernetesGenerator
     internal class ModelExtGenerator
     {
         private readonly ClassNameHelper classNameHelper;
+        private readonly ScriptObjectFactory scriptObjectFactory;
 
-        public ModelExtGenerator(ClassNameHelper classNameHelper)
+        public ModelExtGenerator(ClassNameHelper classNameHelper, ScriptObjectFactory scriptObjectFactory)
         {
             this.classNameHelper = classNameHelper;
+            this.scriptObjectFactory = scriptObjectFactory;
         }
 
         public void Generate(OpenApiDocument swagger, IncrementalGeneratorPostInitializationContext context)
@@ -25,7 +27,10 @@ namespace LibKubernetesGenerator
                          && d.ExtensionData.ContainsKey("x-kubernetes-group-version-kind")
                          && !skippedTypes.Contains(classNameHelper.GetClassName(d)));
 
-            context.RenderToContext("ModelExtensions.cs.template", definitions, "ModelExtensions.g.cs");
+            var sc = scriptObjectFactory.CreateScriptObject();
+            sc.SetValue("definitions", definitions, true);
+
+            context.RenderToContext("ModelExtensions.cs.template", sc, "ModelExtensions.g.cs");
         }
     }
 }

--- a/src/LibKubernetesGenerator/ModelGenerator.cs
+++ b/src/LibKubernetesGenerator/ModelGenerator.cs
@@ -6,22 +6,29 @@ namespace LibKubernetesGenerator
     internal class ModelGenerator
     {
         private readonly ClassNameHelper classNameHelper;
+        private readonly ScriptObjectFactory scriptObjectFactory;
 
-        public ModelGenerator(ClassNameHelper classNameHelper)
+        public ModelGenerator(ClassNameHelper classNameHelper, ScriptObjectFactory scriptObjectFactory)
         {
             this.classNameHelper = classNameHelper;
+            this.scriptObjectFactory = scriptObjectFactory;
         }
 
         public void Generate(OpenApiDocument swagger, IncrementalGeneratorPostInitializationContext context)
         {
+            var sc = scriptObjectFactory.CreateScriptObject();
+
+
             foreach (var kv in swagger.Definitions)
             {
                 var def = kv.Value;
                 var clz = classNameHelper.GetClassNameForSchemaDefinition(def);
-                context.RenderToContext(
-                    "Model.cs.template",
-                    new { clz, def, properties = def.Properties.Values },
-                    $"Models_{clz}.g.cs");
+
+                sc.SetValue("clz", clz, true);
+                sc.SetValue("def", def, true);
+                sc.SetValue("properties", def.Properties.Values, true);
+
+                context.RenderToContext("Model.cs.template", sc, $"Models_{clz}.g.cs");
             }
         }
     }

--- a/src/LibKubernetesGenerator/ParamHelper.cs
+++ b/src/LibKubernetesGenerator/ParamHelper.cs
@@ -17,13 +17,6 @@ namespace LibKubernetesGenerator
             this.typeHelper = typeHelper;
         }
 
-        //public void RegisterHelper()
-        //{
-        //    //Helpers.Register(nameof(IfParamContains), IfParamContains);
-        //    //Helpers.Register(nameof(IfParamDoesNotContain), IfParamDoesNotContain);
-        //    Helpers.Register(nameof(GetModelCtorParam), GetModelCtorParam);
-        //}
-
         public void RegisterHelper(ScriptObject scriptObject)
         {
             scriptObject.Import(nameof(GetModelCtorParam), new Func<JsonSchema, string>(GetModelCtorParam));
@@ -46,94 +39,6 @@ namespace LibKubernetesGenerator
             return found;
         }
 
-
-
-        //public static void IfParamContains(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-        //    if (operation != null)
-        //    {
-        //        string name = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            name = arguments[1] as string;
-        //        }
-
-        //        var found = false;
-
-        //        foreach (var param in operation.Parameters)
-        //        {
-        //            if (param.Name == name)
-        //            {
-        //                found = true;
-        //                break;
-        //            }
-        //        }
-
-        //        if (found)
-        //        {
-        //            fn(null);
-        //        }
-        //    }
-        //}
-
-        //public static void IfParamDoesNotContain(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-        //    if (operation != null)
-        //    {
-        //        string name = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            name = arguments[1] as string;
-        //        }
-
-        //        var found = false;
-
-        //        foreach (var param in operation.Parameters)
-        //        {
-        //            if (param.Name == name)
-        //            {
-        //                found = true;
-        //                break;
-        //            }
-        //        }
-
-        //        if (!found)
-        //        {
-        //            fn(null);
-        //        }
-        //    }
-        //}
-
-        //public void GetModelCtorParam(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var schema = arguments[0] as JsonSchema;
-
-        //    if (schema != null)
-        //    {
-        //        context.Write(string.Join(", ", schema.Properties.Values
-        //            .OrderBy(p => !p.IsRequired)
-        //            .Select(p =>
-        //            {
-        //                var sp =
-        //                    $"{typeHelper.GetDotNetType(p)} {generalNameHelper.GetDotNetName(p.Name, "fieldctor")}";
-
-        //                if (!p.IsRequired)
-        //                {
-        //                    sp = $"{sp} = null";
-        //                }
-
-        //                return sp;
-        //            })));
-        //    }
-        //}
         public string GetModelCtorParam(JsonSchema schema)
         {
             return string.Join(", ", schema.Properties.Values

--- a/src/LibKubernetesGenerator/PluralHelper.cs
+++ b/src/LibKubernetesGenerator/PluralHelper.cs
@@ -1,13 +1,13 @@
 using NJsonSchema;
 using NSwag;
-using Nustache.Core;
+using Scriban.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace LibKubernetesGenerator
 {
-    internal class PluralHelper : INustacheHelper
+    internal class PluralHelper : IScriptObjectHelper
     {
         private readonly Dictionary<string, string> _classNameToPluralMap;
         private readonly ClassNameHelper classNameHelper;
@@ -23,27 +23,33 @@ namespace LibKubernetesGenerator
             _classNameToPluralMap = InitClassNameToPluralMap(swagger);
         }
 
-        public void RegisterHelper()
+        //public void RegisterHelper()
+        //{
+        //    Helpers.Register(nameof(GetPlural), GetPlural);
+        //}
+
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(GetPlural), GetPlural);
+            scriptObject.Import(nameof(GetPlural), new Func<JsonSchema, string>(GetPlural));
         }
 
-        public void GetPlural(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-            {
-                var plural = GetPlural(arguments[0] as JsonSchema);
-                if (plural != null)
-                {
-                    context.Write($"\"{plural}\"");
-                }
-                else
-                {
-                    context.Write("null");
-                }
-            }
-        }
+
+        //public void GetPlural(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
+        //    {
+        //        var plural = GetPlural(arguments[0] as JsonSchema);
+        //        if (plural != null)
+        //        {
+        //            context.Write($"\"{plural}\"");
+        //        }
+        //        else
+        //        {
+        //            context.Write("null");
+        //        }
+        //    }
+        //}
 
         public string GetPlural(JsonSchema definition)
         {

--- a/src/LibKubernetesGenerator/PluralHelper.cs
+++ b/src/LibKubernetesGenerator/PluralHelper.cs
@@ -23,33 +23,10 @@ namespace LibKubernetesGenerator
             _classNameToPluralMap = InitClassNameToPluralMap(swagger);
         }
 
-        //public void RegisterHelper()
-        //{
-        //    Helpers.Register(nameof(GetPlural), GetPlural);
-        //}
-
         public void RegisterHelper(ScriptObject scriptObject)
         {
             scriptObject.Import(nameof(GetPlural), new Func<JsonSchema, string>(GetPlural));
         }
-
-
-        //public void GetPlural(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchema)
-        //    {
-        //        var plural = GetPlural(arguments[0] as JsonSchema);
-        //        if (plural != null)
-        //        {
-        //            context.Write($"\"{plural}\"");
-        //        }
-        //        else
-        //        {
-        //            context.Write("null");
-        //        }
-        //    }
-        //}
 
         public string GetPlural(JsonSchema definition)
         {

--- a/src/LibKubernetesGenerator/ScriptObjectFactory.cs
+++ b/src/LibKubernetesGenerator/ScriptObjectFactory.cs
@@ -1,0 +1,26 @@
+using Scriban.Runtime;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibKubernetesGenerator;
+
+internal class ScriptObjectFactory
+{
+    private readonly List<IScriptObjectHelper> scriptObjectHelpers;
+
+    public ScriptObjectFactory(IEnumerable<IScriptObjectHelper> scriptObjectHelpers)
+    {
+        this.scriptObjectHelpers = scriptObjectHelpers.ToList();
+    }
+
+    public ScriptObject CreateScriptObject()
+    {
+        var scriptObject = new ScriptObject();
+        foreach (var helper in scriptObjectHelpers)
+        {
+            helper.RegisterHelper(scriptObject);
+        }
+
+        return scriptObject;
+    }
+}

--- a/src/LibKubernetesGenerator/StringHelpers.cs
+++ b/src/LibKubernetesGenerator/StringHelpers.cs
@@ -1,15 +1,16 @@
 using NJsonSchema;
-using Nustache.Core;
+using Scriban.Runtime;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace LibKubernetesGenerator
 {
-    internal class StringHelpers : INustacheHelper
+    internal class StringHelpers : IScriptObjectHelper
     {
         private readonly GeneralNameHelper generalNameHelper;
 
@@ -18,42 +19,85 @@ namespace LibKubernetesGenerator
             this.generalNameHelper = generalNameHelper;
         }
 
-        public void RegisterHelper()
+        //public void RegisterHelper()
+        //{
+        //    Helpers.Register(nameof(ToXmlDoc), ToXmlDoc);
+        //    Helpers.Register(nameof(ToInterpolationPathString), ToInterpolationPathString);
+        //    Helpers.Register(nameof(IfGroupPathParamContainsGroup), IfGroupPathParamContainsGroup);
+        //}
+
+
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(ToXmlDoc), ToXmlDoc);
-            Helpers.Register(nameof(ToInterpolationPathString), ToInterpolationPathString);
-            Helpers.Register(nameof(IfGroupPathParamContainsGroup), IfGroupPathParamContainsGroup);
+            scriptObject.Import(nameof(ToXmlDoc), new Func<string, string>(ToXmlDoc));
+            scriptObject.Import(nameof(ToInterpolationPathString), ToInterpolationPathString);
+            scriptObject.Import(nameof(IfGroupPathParamContainsGroup), IfGroupPathParamContainsGroup);
         }
 
-        private void ToXmlDoc(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
+
+        //private void ToXmlDoc(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
+        //    {
+        //        var first = true;
+
+        //        using (var reader = new StringReader(arguments[0] as string))
+        //        {
+        //            string line = null;
+        //            while ((line = reader.ReadLine()) != null)
+        //            {
+        //                foreach (var wline in WordWrap(line, 80))
+        //                {
+        //                    if (!first)
+        //                    {
+        //                        context.Write("\n");
+        //                        context.Write("        /// ");
+        //                    }
+        //                    else
+        //                    {
+        //                        first = false;
+        //                    }
+
+        //                    context.Write(SecurityElement.Escape(wline));
+        //                }
+        //            }
+        //        }
+        //    }
+        //}
+        public static string ToXmlDoc(string arg)
         {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
+            if (arg == null)
             {
-                var first = true;
+                return "";
+            }
 
-                using (var reader = new StringReader(arguments[0] as string))
+            var first = true;
+            var sb = new StringBuilder();
+
+            using (var reader = new StringReader(arg))
+            {
+                string line = null;
+                while ((line = reader.ReadLine()) != null)
                 {
-                    string line = null;
-                    while ((line = reader.ReadLine()) != null)
+                    foreach (var wline in WordWrap(line, 80))
                     {
-                        foreach (var wline in WordWrap(line, 80))
+                        if (!first)
                         {
-                            if (!first)
-                            {
-                                context.Write("\n");
-                                context.Write("        /// ");
-                            }
-                            else
-                            {
-                                first = false;
-                            }
-
-                            context.Write(SecurityElement.Escape(wline));
+                            sb.Append("\n");
+                            sb.Append("        /// ");
                         }
+                        else
+                        {
+                            first = false;
+                        }
+
+                        sb.Append(SecurityElement.Escape(wline));
                     }
                 }
             }
+
+            return sb.ToString();
         }
 
         private static IEnumerable<string> WordWrap(string text, int width)
@@ -91,24 +135,34 @@ namespace LibKubernetesGenerator
             }
         }
 
-        public void ToInterpolationPathString(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
+        //public void ToInterpolationPathString(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var p = arguments?.FirstOrDefault() as string;
+        //    if (p != null)
+        //    {
+        //        context.Write(Regex.Replace(p, "{(.+?)}", (m) => "{" + generalNameHelper.GetDotNetName(m.Groups[1].Value) + "}"));
+        //    }
+        //}
+
+        public string ToInterpolationPathString(string arg)
         {
-            var p = arguments?.FirstOrDefault() as string;
-            if (p != null)
-            {
-                context.Write(Regex.Replace(p, "{(.+?)}", (m) => "{" + generalNameHelper.GetDotNetName(m.Groups[1].Value) + "}"));
-            }
+            return Regex.Replace(arg, "{(.+?)}", (m) => "{" + generalNameHelper.GetDotNetName(m.Groups[1].Value) + "}");
+        }   
+
+        public static bool IfGroupPathParamContainsGroup(string arg)
+        {
+            return arg.StartsWith("apis/{group}");
         }
 
-        public void IfGroupPathParamContainsGroup(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            var p = arguments?.FirstOrDefault() as string;
-            if (p?.StartsWith("apis/{group}") == true)
-            {
-                fn(null);
-            }
-        }
+        //public void IfGroupPathParamContainsGroup(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var p = arguments?.FirstOrDefault() as string;
+        //    if (p?.StartsWith("apis/{group}") == true)
+        //    {
+        //        fn(null);
+        //    }
+        //}
     }
 }

--- a/src/LibKubernetesGenerator/StringHelpers.cs
+++ b/src/LibKubernetesGenerator/StringHelpers.cs
@@ -19,14 +19,6 @@ namespace LibKubernetesGenerator
             this.generalNameHelper = generalNameHelper;
         }
 
-        //public void RegisterHelper()
-        //{
-        //    Helpers.Register(nameof(ToXmlDoc), ToXmlDoc);
-        //    Helpers.Register(nameof(ToInterpolationPathString), ToInterpolationPathString);
-        //    Helpers.Register(nameof(IfGroupPathParamContainsGroup), IfGroupPathParamContainsGroup);
-        //}
-
-
         public void RegisterHelper(ScriptObject scriptObject)
         {
             scriptObject.Import(nameof(ToXmlDoc), new Func<string, string>(ToXmlDoc));
@@ -34,37 +26,6 @@ namespace LibKubernetesGenerator
             scriptObject.Import(nameof(IfGroupPathParamContainsGroup), IfGroupPathParamContainsGroup);
         }
 
-
-        //private void ToXmlDoc(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is string)
-        //    {
-        //        var first = true;
-
-        //        using (var reader = new StringReader(arguments[0] as string))
-        //        {
-        //            string line = null;
-        //            while ((line = reader.ReadLine()) != null)
-        //            {
-        //                foreach (var wline in WordWrap(line, 80))
-        //                {
-        //                    if (!first)
-        //                    {
-        //                        context.Write("\n");
-        //                        context.Write("        /// ");
-        //                    }
-        //                    else
-        //                    {
-        //                        first = false;
-        //                    }
-
-        //                    context.Write(SecurityElement.Escape(wline));
-        //                }
-        //            }
-        //        }
-        //    }
-        //}
         public static string ToXmlDoc(string arg)
         {
             if (arg == null)
@@ -135,34 +96,14 @@ namespace LibKubernetesGenerator
             }
         }
 
-        //public void ToInterpolationPathString(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var p = arguments?.FirstOrDefault() as string;
-        //    if (p != null)
-        //    {
-        //        context.Write(Regex.Replace(p, "{(.+?)}", (m) => "{" + generalNameHelper.GetDotNetName(m.Groups[1].Value) + "}"));
-        //    }
-        //}
-
         public string ToInterpolationPathString(string arg)
         {
             return Regex.Replace(arg, "{(.+?)}", (m) => "{" + generalNameHelper.GetDotNetName(m.Groups[1].Value) + "}");
-        }   
+        }
 
         public static bool IfGroupPathParamContainsGroup(string arg)
         {
             return arg.StartsWith("apis/{group}");
         }
-
-        //public void IfGroupPathParamContainsGroup(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var p = arguments?.FirstOrDefault() as string;
-        //    if (p?.StartsWith("apis/{group}") == true)
-        //    {
-        //        fn(null);
-        //    }
-        //}
     }
 }

--- a/src/LibKubernetesGenerator/TypeHelper.cs
+++ b/src/LibKubernetesGenerator/TypeHelper.cs
@@ -14,13 +14,6 @@ namespace LibKubernetesGenerator
             this.classNameHelper = classNameHelper;
         }
 
-        //public void RegisterHelper()
-        //{
-        //    Helpers.Register(nameof(GetDotNetType), GetDotNetType);
-        //    Helpers.Register(nameof(GetReturnType), GetReturnType);
-        //    Helpers.Register(nameof(IfReturnType), IfReturnType);
-        //    Helpers.Register(nameof(IfType), IfType);
-        //}
         public void RegisterHelper(ScriptObject scriptObject)
         {
             scriptObject.Import(nameof(GetDotNetType), new Func<JsonSchemaProperty, string>(GetDotNetType));
@@ -29,51 +22,6 @@ namespace LibKubernetesGenerator
             scriptObject.Import(nameof(IfReturnType), new Func<OpenApiOperation, string, bool>(IfReturnType));
             scriptObject.Import(nameof(IfType), new Func<JsonSchemaProperty, string, bool>(IfType));
         }
-
-        //public void GetDotNetType(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
-        //    {
-        //        var parameter = arguments[0] as OpenApiParameter;
-
-        //        if (parameter.Schema?.Reference != null)
-        //        {
-        //            context.Write(classNameHelper.GetClassNameForSchemaDefinition(parameter.Schema.Reference));
-        //        }
-        //        else if (parameter.Schema != null)
-        //        {
-        //            context.Write(GetDotNetType(parameter.Schema.Type, parameter.Name, parameter.IsRequired,
-        //                parameter.Schema.Format));
-        //        }
-        //        else
-        //        {
-        //            context.Write(GetDotNetType(parameter.Type, parameter.Name, parameter.IsRequired,
-        //                parameter.Format));
-        //        }
-        //    }
-        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchemaProperty)
-        //    {
-        //        var property = arguments[0] as JsonSchemaProperty;
-        //        context.Write(GetDotNetType(property));
-        //    }
-        //    else if (arguments != null && arguments.Count > 2 && arguments[0] != null && arguments[1] != null &&
-        //             arguments[2] != null && arguments[0] is JsonObjectType && arguments[1] is string &&
-        //             arguments[2] is bool)
-        //    {
-        //        context.Write(GetDotNetType((JsonObjectType)arguments[0], (string)arguments[1], (bool)arguments[2],
-        //            (string)arguments[3]));
-        //    }
-        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null)
-        //    {
-        //        context.Write($"ERROR: Expected OpenApiParameter but got {arguments[0].GetType().FullName}");
-        //    }
-        //    else
-        //    {
-        //        context.Write("ERROR: Expected a OpenApiParameter argument but got none.");
-        //    }
-        //}
 
         private string GetDotNetType(JsonObjectType jsonType, string name, bool required, string format)
         {
@@ -228,24 +176,6 @@ namespace LibKubernetesGenerator
             }
         }
 
-
-        //public void GetReturnType(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-        //    if (operation != null)
-        //    {
-        //        string style = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            style = arguments[1] as string;
-        //        }
-
-        //        context.Write(GetReturnType(operation, style));
-        //    }
-        //}
-
         private string GetReturnType(OpenApiOperation operation, string sytle)
         {
             OpenApiResponse response;
@@ -320,38 +250,8 @@ namespace LibKubernetesGenerator
             return t;
         }
 
-
-        //public void IfReturnType(RenderContext context, IList<object> arguments,
-        //    IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-        //    if (operation != null)
-        //    {
-        //        string type = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            type = arguments[1] as string;
-        //        }
-
-        //        var rt = GetReturnType(operation, "void");
-        //        if (type == "any" && rt != "void")
-        //        {
-        //            fn(null);
-        //        }
-        //        else if (string.Equals(type, rt.ToLower(), StringComparison.OrdinalIgnoreCase))
-        //        {
-        //            fn(null);
-        //        }
-        //        else if (type == "obj" && rt != "void" && rt != "Stream")
-        //        {
-        //            fn(null);
-        //        }
-        //    }
-        //}
         public bool IfReturnType(OpenApiOperation operation, string type)
         {
-
             var rt = GetReturnType(operation, "void");
             if (type == "any" && rt != "void")
             {
@@ -369,31 +269,6 @@ namespace LibKubernetesGenerator
             return false;
         }
 
-
-        //public static void IfType(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var property = arguments?.FirstOrDefault() as JsonSchemaProperty;
-        //    if (property != null)
-        //    {
-        //        string type = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            type = arguments[1] as string;
-        //        }
-
-        //        if (type == "object" && property.Reference != null && !property.IsArray &&
-        //            property.AdditionalPropertiesSchema == null)
-        //        {
-        //            fn(null);
-        //        }
-        //        else if (type == "objectarray" && property.IsArray && property.Item?.Reference != null)
-        //        {
-        //            fn(null);
-        //        }
-        //    }
-        //}
-
         public static bool IfType(JsonSchemaProperty property, string type)
         {
             if (type == "object" && property.Reference != null && !property.IsArray &&
@@ -408,6 +283,5 @@ namespace LibKubernetesGenerator
 
             return false;
         }
-
     }
 }

--- a/src/LibKubernetesGenerator/TypeHelper.cs
+++ b/src/LibKubernetesGenerator/TypeHelper.cs
@@ -1,13 +1,11 @@
 using NJsonSchema;
 using NSwag;
-using Nustache.Core;
+using Scriban.Runtime;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace LibKubernetesGenerator
 {
-    internal class TypeHelper : INustacheHelper
+    internal class TypeHelper : IScriptObjectHelper
     {
         private readonly ClassNameHelper classNameHelper;
 
@@ -16,58 +14,66 @@ namespace LibKubernetesGenerator
             this.classNameHelper = classNameHelper;
         }
 
-        public void RegisterHelper()
+        //public void RegisterHelper()
+        //{
+        //    Helpers.Register(nameof(GetDotNetType), GetDotNetType);
+        //    Helpers.Register(nameof(GetReturnType), GetReturnType);
+        //    Helpers.Register(nameof(IfReturnType), IfReturnType);
+        //    Helpers.Register(nameof(IfType), IfType);
+        //}
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(GetDotNetType), GetDotNetType);
-            Helpers.Register(nameof(GetReturnType), GetReturnType);
-            Helpers.Register(nameof(IfReturnType), IfReturnType);
-            Helpers.Register(nameof(IfType), IfType);
+            scriptObject.Import(nameof(GetDotNetType), new Func<JsonSchemaProperty, string>(GetDotNetType));
+            scriptObject.Import(nameof(GetDotNetTypeOpenApiParameter), new Func<OpenApiParameter, string>(GetDotNetTypeOpenApiParameter));
+            scriptObject.Import(nameof(GetReturnType), new Func<OpenApiOperation, string, string>(GetReturnType));
+            scriptObject.Import(nameof(IfReturnType), new Func<OpenApiOperation, string, bool>(IfReturnType));
+            scriptObject.Import(nameof(IfType), new Func<JsonSchemaProperty, string, bool>(IfType));
         }
 
-        public void GetDotNetType(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
-            {
-                var parameter = arguments[0] as OpenApiParameter;
+        //public void GetDotNetType(RenderContext context, IList<object> arguments,
+        //    IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is OpenApiParameter)
+        //    {
+        //        var parameter = arguments[0] as OpenApiParameter;
 
-                if (parameter.Schema?.Reference != null)
-                {
-                    context.Write(classNameHelper.GetClassNameForSchemaDefinition(parameter.Schema.Reference));
-                }
-                else if (parameter.Schema != null)
-                {
-                    context.Write(GetDotNetType(parameter.Schema.Type, parameter.Name, parameter.IsRequired,
-                        parameter.Schema.Format));
-                }
-                else
-                {
-                    context.Write(GetDotNetType(parameter.Type, parameter.Name, parameter.IsRequired,
-                        parameter.Format));
-                }
-            }
-            else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchemaProperty)
-            {
-                var property = arguments[0] as JsonSchemaProperty;
-                context.Write(GetDotNetType(property));
-            }
-            else if (arguments != null && arguments.Count > 2 && arguments[0] != null && arguments[1] != null &&
-                     arguments[2] != null && arguments[0] is JsonObjectType && arguments[1] is string &&
-                     arguments[2] is bool)
-            {
-                context.Write(GetDotNetType((JsonObjectType)arguments[0], (string)arguments[1], (bool)arguments[2],
-                    (string)arguments[3]));
-            }
-            else if (arguments != null && arguments.Count > 0 && arguments[0] != null)
-            {
-                context.Write($"ERROR: Expected OpenApiParameter but got {arguments[0].GetType().FullName}");
-            }
-            else
-            {
-                context.Write("ERROR: Expected a OpenApiParameter argument but got none.");
-            }
-        }
+        //        if (parameter.Schema?.Reference != null)
+        //        {
+        //            context.Write(classNameHelper.GetClassNameForSchemaDefinition(parameter.Schema.Reference));
+        //        }
+        //        else if (parameter.Schema != null)
+        //        {
+        //            context.Write(GetDotNetType(parameter.Schema.Type, parameter.Name, parameter.IsRequired,
+        //                parameter.Schema.Format));
+        //        }
+        //        else
+        //        {
+        //            context.Write(GetDotNetType(parameter.Type, parameter.Name, parameter.IsRequired,
+        //                parameter.Format));
+        //        }
+        //    }
+        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null && arguments[0] is JsonSchemaProperty)
+        //    {
+        //        var property = arguments[0] as JsonSchemaProperty;
+        //        context.Write(GetDotNetType(property));
+        //    }
+        //    else if (arguments != null && arguments.Count > 2 && arguments[0] != null && arguments[1] != null &&
+        //             arguments[2] != null && arguments[0] is JsonObjectType && arguments[1] is string &&
+        //             arguments[2] is bool)
+        //    {
+        //        context.Write(GetDotNetType((JsonObjectType)arguments[0], (string)arguments[1], (bool)arguments[2],
+        //            (string)arguments[3]));
+        //    }
+        //    else if (arguments != null && arguments.Count > 0 && arguments[0] != null)
+        //    {
+        //        context.Write($"ERROR: Expected OpenApiParameter but got {arguments[0].GetType().FullName}");
+        //    }
+        //    else
+        //    {
+        //        context.Write("ERROR: Expected a OpenApiParameter argument but got none.");
+        //    }
+        //}
 
         private string GetDotNetType(JsonObjectType jsonType, string name, bool required, string format)
         {
@@ -204,22 +210,41 @@ namespace LibKubernetesGenerator
             return GetDotNetType(p.Type, p.Name, p.IsRequired, p.Format);
         }
 
-        public void GetReturnType(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
+        public string GetDotNetTypeOpenApiParameter(OpenApiParameter parameter)
         {
-            var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-            if (operation != null)
+            if (parameter.Schema?.Reference != null)
             {
-                string style = null;
-                if (arguments.Count > 1)
-                {
-                    style = arguments[1] as string;
-                }
-
-                context.Write(GetReturnType(operation, style));
+                return classNameHelper.GetClassNameForSchemaDefinition(parameter.Schema.Reference);
+            }
+            else if (parameter.Schema != null)
+            {
+                return (GetDotNetType(parameter.Schema.Type, parameter.Name, parameter.IsRequired,
+                    parameter.Schema.Format));
+            }
+            else
+            {
+                return (GetDotNetType(parameter.Type, parameter.Name, parameter.IsRequired,
+                    parameter.Format));
             }
         }
+
+
+        //public void GetReturnType(RenderContext context, IList<object> arguments,
+        //    IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
+        //    if (operation != null)
+        //    {
+        //        string style = null;
+        //        if (arguments.Count > 1)
+        //        {
+        //            style = arguments[1] as string;
+        //        }
+
+        //        context.Write(GetReturnType(operation, style));
+        //    }
+        //}
 
         private string GetReturnType(OpenApiOperation operation, string sytle)
         {
@@ -295,57 +320,94 @@ namespace LibKubernetesGenerator
             return t;
         }
 
-        public void IfReturnType(RenderContext context, IList<object> arguments,
-            IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            var operation = arguments?.FirstOrDefault() as OpenApiOperation;
-            if (operation != null)
-            {
-                string type = null;
-                if (arguments.Count > 1)
-                {
-                    type = arguments[1] as string;
-                }
 
-                var rt = GetReturnType(operation, "void");
-                if (type == "any" && rt != "void")
-                {
-                    fn(null);
-                }
-                else if (string.Equals(type, rt.ToLower(), StringComparison.OrdinalIgnoreCase))
-                {
-                    fn(null);
-                }
-                else if (type == "obj" && rt != "void" && rt != "Stream")
-                {
-                    fn(null);
-                }
+        //public void IfReturnType(RenderContext context, IList<object> arguments,
+        //    IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var operation = arguments?.FirstOrDefault() as OpenApiOperation;
+        //    if (operation != null)
+        //    {
+        //        string type = null;
+        //        if (arguments.Count > 1)
+        //        {
+        //            type = arguments[1] as string;
+        //        }
+
+        //        var rt = GetReturnType(operation, "void");
+        //        if (type == "any" && rt != "void")
+        //        {
+        //            fn(null);
+        //        }
+        //        else if (string.Equals(type, rt.ToLower(), StringComparison.OrdinalIgnoreCase))
+        //        {
+        //            fn(null);
+        //        }
+        //        else if (type == "obj" && rt != "void" && rt != "Stream")
+        //        {
+        //            fn(null);
+        //        }
+        //    }
+        //}
+        public bool IfReturnType(OpenApiOperation operation, string type)
+        {
+
+            var rt = GetReturnType(operation, "void");
+            if (type == "any" && rt != "void")
+            {
+                return true;
             }
+            else if (string.Equals(type, rt.ToLower(), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            else if (type == "obj" && rt != "void" && rt != "Stream")
+            {
+                return true;
+            }
+
+            return false;
         }
 
-        public static void IfType(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            var property = arguments?.FirstOrDefault() as JsonSchemaProperty;
-            if (property != null)
-            {
-                string type = null;
-                if (arguments.Count > 1)
-                {
-                    type = arguments[1] as string;
-                }
 
-                if (type == "object" && property.Reference != null && !property.IsArray &&
-                    property.AdditionalPropertiesSchema == null)
-                {
-                    fn(null);
-                }
-                else if (type == "objectarray" && property.IsArray && property.Item?.Reference != null)
-                {
-                    fn(null);
-                }
+        //public static void IfType(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var property = arguments?.FirstOrDefault() as JsonSchemaProperty;
+        //    if (property != null)
+        //    {
+        //        string type = null;
+        //        if (arguments.Count > 1)
+        //        {
+        //            type = arguments[1] as string;
+        //        }
+
+        //        if (type == "object" && property.Reference != null && !property.IsArray &&
+        //            property.AdditionalPropertiesSchema == null)
+        //        {
+        //            fn(null);
+        //        }
+        //        else if (type == "objectarray" && property.IsArray && property.Item?.Reference != null)
+        //        {
+        //            fn(null);
+        //        }
+        //    }
+        //}
+
+        public static bool IfType(JsonSchemaProperty property, string type)
+        {
+            if (type == "object" && property.Reference != null && !property.IsArray &&
+                property.AdditionalPropertiesSchema == null)
+            {
+                return true;
             }
+            else if (type == "objectarray" && property.IsArray && property.Item?.Reference != null)
+            {
+                return true;
+            }
+
+            return false;
         }
+
     }
 }

--- a/src/LibKubernetesGenerator/UtilHelper.cs
+++ b/src/LibKubernetesGenerator/UtilHelper.cs
@@ -1,50 +1,70 @@
 using NSwag;
-using Nustache.Core;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+using Scriban.Runtime;
 
 namespace LibKubernetesGenerator
 {
-    internal class UtilHelper : INustacheHelper
+    internal class UtilHelper : IScriptObjectHelper
     {
-        public void RegisterHelper()
+        public void RegisterHelper(ScriptObject scriptObject)
         {
-            Helpers.Register(nameof(IfKindIs), IfKindIs);
-            Helpers.Register(nameof(IfListNotEmpty), IfListNotEmpty);
+            scriptObject.Import(nameof(IfKindIs), IfKindIs);
         }
 
-        public static void IfKindIs(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
+        //public void RegisterHelper()
+        //{
+        //    Helpers.Register(nameof(IfKindIs), IfKindIs);
+        //    Helpers.Register(nameof(IfListNotEmpty), IfListNotEmpty);
+        //}
+
+        //public static void IfKindIs(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var parameter = arguments?.FirstOrDefault() as OpenApiParameter;
+        //    if (parameter != null)
+        //    {
+        //        string kind = null;
+        //        if (arguments.Count > 1)
+        //        {
+        //            kind = arguments[1] as string;
+        //        }
+
+        //        if (kind == "query" && parameter.Kind == OpenApiParameterKind.Query)
+        //        {
+        //            fn(null);
+        //        }
+        //        else if (kind == "path" && parameter.Kind == OpenApiParameterKind.Path)
+        //        {
+        //            fn(null);
+        //        }
+        //    }
+        //}
+
+        public static bool IfKindIs(OpenApiParameter parameter, string kind)
         {
-            var parameter = arguments?.FirstOrDefault() as OpenApiParameter;
             if (parameter != null)
             {
-                string kind = null;
-                if (arguments.Count > 1)
-                {
-                    kind = arguments[1] as string;
-                }
-
                 if (kind == "query" && parameter.Kind == OpenApiParameterKind.Query)
                 {
-                    fn(null);
+                    return true;
                 }
                 else if (kind == "path" && parameter.Kind == OpenApiParameterKind.Path)
                 {
-                    fn(null);
+                    return true;
                 }
             }
+
+            return false;
         }
 
-        public static void IfListNotEmpty(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-            RenderBlock fn, RenderBlock inverse)
-        {
-            var parameter = arguments?.FirstOrDefault() as ObservableCollection<OpenApiParameter>;
-            if (parameter?.Any() == true)
-            {
-                fn(null);
-            }
-        }
+  
+        //public static void IfListNotEmpty(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
+        //    RenderBlock fn, RenderBlock inverse)
+        //{
+        //    var parameter = arguments?.FirstOrDefault() as ObservableCollection<OpenApiParameter>;
+        //    if (parameter?.Any() == true)
+        //    {
+        //        fn(null);
+        //    }
+        //}
     }
 }

--- a/src/LibKubernetesGenerator/UtilHelper.cs
+++ b/src/LibKubernetesGenerator/UtilHelper.cs
@@ -10,35 +10,6 @@ namespace LibKubernetesGenerator
             scriptObject.Import(nameof(IfKindIs), IfKindIs);
         }
 
-        //public void RegisterHelper()
-        //{
-        //    Helpers.Register(nameof(IfKindIs), IfKindIs);
-        //    Helpers.Register(nameof(IfListNotEmpty), IfListNotEmpty);
-        //}
-
-        //public static void IfKindIs(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var parameter = arguments?.FirstOrDefault() as OpenApiParameter;
-        //    if (parameter != null)
-        //    {
-        //        string kind = null;
-        //        if (arguments.Count > 1)
-        //        {
-        //            kind = arguments[1] as string;
-        //        }
-
-        //        if (kind == "query" && parameter.Kind == OpenApiParameterKind.Query)
-        //        {
-        //            fn(null);
-        //        }
-        //        else if (kind == "path" && parameter.Kind == OpenApiParameterKind.Path)
-        //        {
-        //            fn(null);
-        //        }
-        //    }
-        //}
-
         public static bool IfKindIs(OpenApiParameter parameter, string kind)
         {
             if (parameter != null)
@@ -55,16 +26,5 @@ namespace LibKubernetesGenerator
 
             return false;
         }
-
-  
-        //public static void IfListNotEmpty(RenderContext context, IList<object> arguments, IDictionary<string, object> options,
-        //    RenderBlock fn, RenderBlock inverse)
-        //{
-        //    var parameter = arguments?.FirstOrDefault() as ObservableCollection<OpenApiParameter>;
-        //    if (parameter?.Any() == true)
-        //    {
-        //        fn(null);
-        //    }
-        //}
     }
 }

--- a/src/LibKubernetesGenerator/templates/AbstractKubernetes.cs.template
+++ b/src/LibKubernetesGenerator/templates/AbstractKubernetes.cs.template
@@ -10,7 +10,7 @@ namespace k8s;
 /// </summary>
 public abstract partial class AbstractKubernetes
 {
-    {{#.}}
-    public I{{.}}Operations {{.}} => this;
-    {{/.}}
+    {{for group in groups}}
+    public I{{group}}Operations {{group}} => this;
+    {{end}}
 }

--- a/src/LibKubernetesGenerator/templates/IBasicKubernetes.cs.template
+++ b/src/LibKubernetesGenerator/templates/IBasicKubernetes.cs.template
@@ -10,7 +10,7 @@ namespace k8s;
 /// </summary>
 public partial interface IBasicKubernetes
 {
-    {{#.}}
-    I{{.}}Operations {{.}} { get; }
-    {{/.}}
+    {{for group in groups}}
+    I{{group}}Operations {{group}} { get; }
+    {{end}}
 }

--- a/src/LibKubernetesGenerator/templates/IOperations.cs.template
+++ b/src/LibKubernetesGenerator/templates/IOperations.cs.template
@@ -10,50 +10,50 @@ namespace k8s;
 /// </summary>
 public partial interface I{{name}}Operations
 {
-    {{#apis}}
+    {{for api in apis }}
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+    {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc parameter.description}}
     /// </param>
-    {{/operation.parameters}}
+    {{ end }}
     /// <param name="customHeaders">
     /// The headers that will be added to request.
     /// </param>
     /// <param name="cancellationToken">
     /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
     /// </param>
-    Task<HttpOperationResponse{{GetReturnType operation "<>"}}> {{GetMethodName operation "WithHttpMessagesAsync"}}(
-{{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName . "true"}},
-{{/operation.parameters}}
+    Task<HttpOperationResponse{{GetReturnType api.operation "<>"}}> {{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}},
+{{ end }}
         IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders = null,
         CancellationToken cancellationToken = default);
 
-    {{#IfReturnType operation "object"}}
+    {{if IfReturnType api.operation "object"}}
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+    {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc parameter.description}}
     /// </param>
-    {{/operation.parameters}}
+    {{ end }}
     /// <param name="customHeaders">
     /// The headers that will be added to request.
     /// </param>
     /// <param name="cancellationToken">
     /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
     /// </param>
-    Task<HttpOperationResponse<T>> {{GetMethodName operation "WithHttpMessagesAsync"}}<T>(
-{{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName . "true"}},
-{{/operation.parameters}}
+    Task<HttpOperationResponse<T>> {{GetMethodName api.operation "WithHttpMessagesAsync"}}<T>(
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}},
+{{ end }}
         IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders = null,
         CancellationToken cancellationToken = default);
-    {{/IfReturnType operation "object"}}
+    {{ end }}
 
-    {{/apis}}
+    {{ end }}
 }

--- a/src/LibKubernetesGenerator/templates/Model.cs.template
+++ b/src/LibKubernetesGenerator/templates/Model.cs.template
@@ -22,25 +22,26 @@ namespace k8s.Models
         /// <summary>
         /// Initializes a new instance of the {{GetClassName def}} class.
         /// </summary>
-        {{#properties}}
-        {{#isRequired}}
-        /// <param name="{{GetDotNetName name "fieldctor"}}">
-        /// {{ToXmlDoc description}}
+        {{ for property in properties }}
+        {{ if property.IsRequired }}
+        /// <param name="{{GetDotNetName property.name "fieldctor"}}">
+        /// {{ToXmlDoc property.description}}
         /// </param>
-        {{/isRequired}}
-        {{/properties}}
-        {{#properties}}
-        {{^isRequired}}
-        /// <param name="{{GetDotNetName name "fieldctor"}}">
-        /// {{ToXmlDoc description}}
+        {{ end }}
+        {{ end }}
+
+        {{ for property in properties }}
+        {{ if !property.IsRequired }}
+        /// <param name="{{GetDotNetName property.name "fieldctor"}}">
+        /// {{ToXmlDoc property.description}}
         /// </param>
-        {{/isRequired}}
-        {{/properties}}
+        {{ end }}
+        {{ end }}
         public {{clz}}({{GetModelCtorParam def}})
         {
-            {{#properties}}
-            {{GetDotNetName name "field"}} = {{GetDotNetName name "fieldctor"}};
-            {{/properties}}
+            {{ for property in properties }}
+            {{GetDotNetName property.name "field"}} = {{GetDotNetName property.name "fieldctor"}};
+            {{ end }}
             CustomInit();
         }
 
@@ -48,14 +49,14 @@ namespace k8s.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
-        {{#properties}}
 
+        {{ for property in properties }}
         /// <summary>
-        /// {{ToXmlDoc description}}
+        /// {{ToXmlDoc property.description}}
         /// </summary>
-        [JsonPropertyName("{{name}}")]
-        public {{GetDotNetType .}} {{GetDotNetName name "field"}} { get; set; }
-        {{/properties}}
+        [JsonPropertyName("{{property.name}}")]
+        public {{GetDotNetType property}} {{GetDotNetName property.name "field"}} { get; set; }
+        {{ end }}
 
         /// <summary>
         /// Validate the object.
@@ -65,29 +66,32 @@ namespace k8s.Models
         /// </exception>
         public virtual void Validate()
         {
-            {{#properties}}
-            {{#IfType . "object"}}
-            {{#isRequired}}
-            if ({{GetDotNetName name "field"}} == null)
+            {{ for property in properties }}
+            {{if IfType property "object" }}
+            {{ if property.IsRequired }}
+            if ({{GetDotNetName property.name "field"}} == null)
             {
-                throw new ArgumentNullException("{{GetDotNetName name "field"}}");    
+                throw new ArgumentNullException("{{GetDotNetName property.name "field"}}");    
             }
-            {{/isRequired}}
-            {{/IfType . "object"}}
-            {{/properties}}
-            {{#properties}}
-            {{#IfType . "object"}}
-            {{GetDotNetName name "field"}}?.Validate();
-            {{/IfType . "object"}}
-            {{#IfType . "objectarray"}}
-            if ({{GetDotNetName name "field"}} != null){
-                foreach(var obj in {{GetDotNetName name "field"}})
+            {{ end }}
+            {{ end }}
+            
+            {{ end }}
+
+            {{ for property in properties }}
+            {{if IfType property "object" }}
+            {{GetDotNetName property.name "field"}}?.Validate();
+            {{ end }}
+
+            {{if IfType property "objectarray" }}
+            if ({{GetDotNetName property.name "field"}} != null){
+                foreach(var obj in {{GetDotNetName property.name "field"}})
                 {
                     obj.Validate();
                 }
             }
-            {{/IfType . "objectarray"}}
-            {{/properties}}
+            {{ end }}
+            {{ end }}
         }
     }
 }

--- a/src/LibKubernetesGenerator/templates/ModelExtensions.cs.template
+++ b/src/LibKubernetesGenerator/templates/ModelExtensions.cs.template
@@ -4,25 +4,24 @@
 // </auto-generated>
 namespace k8s.Models
 {
-{{#.}}
+{{ for definition in definitions }}
     [KubernetesEntity(Group=KubeGroup, Kind=KubeKind, ApiVersion=KubeApiVersion, PluralName=KubePluralName)]
-    public partial class {{GetClassName . }} : {{GetInterfaceName . }}
+    public partial class {{ GetClassName definition }} : {{ GetInterfaceName definition }}
     {
-        public const string KubeApiVersion = "{{GetApiVersion . }}";
-        public const string KubeKind = "{{GetKind . }}";
-        public const string KubeGroup = "{{GetGroup . }}";
-        public const string KubePluralName = {{GetPlural . }};
+        public const string KubeApiVersion = "{{ GetApiVersion definition }}";
+        public const string KubeKind = "{{ GetKind definition }}";
+        public const string KubeGroup = "{{ GetGroup definition }}";
+        public const string KubePluralName = "{{ GetPlural definition }}";
     }
-
-{{/.}}
+{{ end }}
 }
 
 #if NET8_0_OR_GREATER
 namespace k8s 
 {
-    {{#.}}
-    [JsonSerializable(typeof({{GetClassName . }}))]
-    {{/.}}
+    {{ for definition in definitions }}
+    [JsonSerializable(typeof({{ GetClassName definition }}))]
+    {{ end }}
     internal partial class SourceGenerationContext : JsonSerializerContext
     {
     }

--- a/src/LibKubernetesGenerator/templates/Operations.cs.template
+++ b/src/LibKubernetesGenerator/templates/Operations.cs.template
@@ -8,139 +8,137 @@ namespace k8s;
 
 public partial class AbstractKubernetes : I{{name}}Operations
 {
-    {{#apis}}
-    {{#IfReturnType operation "void"}}
-    private async Task<HttpOperationResponse> I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}(
-    {{/IfReturnType operation "void"}}
-    {{#IfReturnType operation "obj"}}
-    private async Task<HttpOperationResponse<T>> I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}<T>(
-    {{/IfReturnType operation "obj"}}
-    {{#IfReturnType operation "stream"}}
-    private async Task<HttpOperationResponse<Stream>> I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}(
-    {{/IfReturnType operation "stream"}}
-{{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName .}},
-{{/operation.parameters}}
+    {{for api in apis }}
+    {{if IfReturnType api.operation "void"}}
+    private async Task<HttpOperationResponse> I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+    {{end}}
+    {{if IfReturnType api.operation "obj"}}
+    private async Task<HttpOperationResponse<T>> I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}<T>(
+    {{end}}
+    {{if IfReturnType api.operation "stream"}}
+    private async Task<HttpOperationResponse<Stream>> I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+    {{end}}
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
         IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders,
         CancellationToken cancellationToken)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(HttpClientTimeout);
-        {{#IfParamContains operation "watch"}}
+        {{if IfParamContains api.operation "watch"}}
         if (watch == true)
         {
             cts.CancelAfter(Timeout.InfiniteTimeSpan);
         }
-        {{/IfParamContains operation "watch"}}
+        {{end}}
         cancellationToken = cts.Token;
 
-        {{#operation.parameters}}
-        {{#isRequired}}
-        if ({{GetDotNetName name}} == null)
+        {{ for parameter in api.operation.parameters}}
+        {{ if parameter.IsRequired}}
+        if ({{GetDotNetName parameter.name}} == null)
         {
-            throw new ArgumentNullException("{{GetDotNetName name}}");
+            throw new ArgumentNullException("{{GetDotNetName parameter.name}}");
         }
-        {{/isRequired}}
-        {{/operation.parameters}}
+        {{end}}
+        {{end}}
 
         // Construct URL
-        var url = $"{{ToInterpolationPathString path}}";
-        {{#IfGroupPathParamContainsGroup path}}
+        var url = $"{{ToInterpolationPathString api.path}}";
+        {{if IfGroupPathParamContainsGroup api.path}}
         url = url.Replace("apis//", "api/");
-        {{/IfGroupPathParamContainsGroup}}
-        {{#IfListNotEmpty operation.parameters}}
+        {{end}}
+        {{if (array.size api.operation.parameters) > 0}}
         var q = new QueryBuilder();
-        {{#operation.parameters}}
-        {{#IfKindIs . "query"}}
-        q.Append("{{name}}", {{GetDotNetName name}});
-        {{/IfKindIs . "query"}}
-        {{/operation.parameters}}
+        {{ for parameter in api.operation.parameters}}
+        {{if IfKindIs parameter "query"}}
+        q.Append("{{parameter.name}}", {{GetDotNetName parameter.name}});
+        {{end}}
+        {{end}}
         url += q.ToString();
-        {{/IfListNotEmpty operation.parameters}}
+        {{end}}
 
         // Create HTTP transport
-        {{#IfParamContains operation "body"}}
-        var httpResponse = await SendRequest(url, HttpMethods.{{Method}}, customHeaders, body, cancellationToken);
-        {{/IfParamContains operation "body"}}
-        {{#IfParamDoesNotContain operation "body"}}
-        var httpResponse = await SendRequest<object>(url, HttpMethods.{{Method}}, customHeaders, null, cancellationToken);
-        {{/IfParamDoesNotContain operation "body"}}
+        {{if IfParamContains api.operation "body"}}
+        var httpResponse = await SendRequest(url, HttpMethods.{{api.method}}, customHeaders, body, cancellationToken);
+        {{ else }}
+        var httpResponse = await SendRequest<object>(url, HttpMethods.{{api.method}}, customHeaders, null, cancellationToken);
+        {{end}}
         // Create Result
         var httpRequest = httpResponse.RequestMessage;
-        {{#IfReturnType operation "void"}}
+        {{if IfReturnType api.operation "void"}}
         HttpOperationResponse result = new HttpOperationResponse() { Request = httpRequest, Response =  httpResponse };
-        {{/IfReturnType operation "void"}}
-        {{#IfReturnType operation "obj"}}
+        {{end}}
+        {{if IfReturnType api.operation "obj"}}
         var result = await CreateResultAsync<T>(
             httpRequest,
             httpResponse,
-            {{#IfParamContains operation "watch"}}
+            {{if IfParamContains api.operation "watch"}}
             watch,
-            {{/IfParamContains operation "watch"}}
-            {{#IfParamDoesNotContain operation "watch"}}
+            {{else}}
             false,
-            {{/IfParamDoesNotContain operation "watch"}}
+            {{end}}
             cancellationToken);
-        {{/IfReturnType operation "obj"}}
-        {{#IfReturnType operation "stream"}}
+        {{end}}
+        {{if IfReturnType api.operation "stream"}}
         var result = new HttpOperationResponse<Stream>() {
                             Request = httpRequest,
                             Response = httpResponse,
                             Body = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false) };
-        {{/IfReturnType operation "stream"}}
+        {{end}}
         return result;
     }
 
     /// <inheritdoc/>
-    async Task<HttpOperationResponse{{GetReturnType operation "<>"}}> I{{name}}Operations.{{GetMethodName operation "WithHttpMessagesAsync"}}(
-{{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName .}},
-{{/operation.parameters}}
+    async Task<HttpOperationResponse{{GetReturnType api.operation "<>"}}> I{{name}}Operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
         IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders,
         CancellationToken cancellationToken)
     {
-        {{#IfReturnType operation "void"}}
-        return await I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}(
-        {{#operation.parameters}}
-            {{GetDotNetName .}},
-        {{/operation.parameters}}
+        {{if IfReturnType api.operation "void"}}
+        return await I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+           {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             customHeaders,
             cancellationToken).ConfigureAwait(false);
-        {{/IfReturnType operation "void"}}
-        {{#IfReturnType operation "obj"}}
-        return await I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}{{GetReturnType operation "<>"}}(
-        {{#operation.parameters}}
-            {{GetDotNetName .}},
-        {{/operation.parameters}}
+        {{end}}
+        {{if IfReturnType api.operation "obj"}}
+        return await I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}{{GetReturnType api.operation "<>"}}(
+{{ for parameter in api.operation.parameters}}
+           {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             customHeaders,
             cancellationToken).ConfigureAwait(false);
-        {{/IfReturnType operation "obj"}}
-        {{#IfReturnType operation "stream"}}
-        return await I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}(
-        {{#operation.parameters}}
-            {{GetDotNetName .}},
-        {{/operation.parameters}}
+        {{end}}
+        {{if IfReturnType api.operation "stream"}}
+        return await I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+           {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             customHeaders,
             cancellationToken).ConfigureAwait(false);
-        {{/IfReturnType operation "stream"}}
+        {{end}}
     }
 
-    {{#IfReturnType operation "object"}}
+    {{if IfReturnType api.operation "object"}}
     /// <inheritdoc/>
-    async Task<HttpOperationResponse<T>> I{{name}}Operations.{{GetMethodName operation "WithHttpMessagesAsync"}}<T>(
-{{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName .}},
-{{/operation.parameters}}
+    async Task<HttpOperationResponse<T>> I{{name}}Operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}<T>(
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
         IReadOnlyDictionary<string, IReadOnlyList<string>> customHeaders,
         CancellationToken cancellationToken)
     {
-        return await I{{name}}Operations_{{GetMethodName operation "WithHttpMessagesAsync"}}<T>(
-        {{#operation.parameters}}
-            {{GetDotNetName .}},
-        {{/operation.parameters}}
+        return await I{{name}}Operations_{{GetMethodName api.operation "WithHttpMessagesAsync"}}<T>(
+{{ for parameter in api.operation.parameters}}
+           {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             customHeaders,
             cancellationToken).ConfigureAwait(false);
     }
-    {{/IfReturnType operation "object"}}
-    {{/apis}}
+    {{end}}
+    {{end}}
 }

--- a/src/LibKubernetesGenerator/templates/OperationsExtensions.cs.template
+++ b/src/LibKubernetesGenerator/templates/OperationsExtensions.cs.template
@@ -11,148 +11,148 @@ namespace k8s;
 /// </summary>
 public static partial class {{name}}OperationsExtensions
 {
-    {{#apis}}
+    {{for api in apis }}
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
     /// <param name='operations'>
     /// The operations group for this extension method.
     /// </param>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+     {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc api.description}}
     /// </param>
-    {{/operation.parameters}}
-    public static {{GetReturnType operation "void"}} {{GetMethodName operation ""}}(
+     {{ end }}
+    public static {{GetReturnType api.operation "void"}} {{GetMethodName api.operation ""}}(
         this I{{name}}Operations operations
-{{#operation.parameters}}
-        ,{{GetDotNetType .}} {{GetDotNetName . "true"}}
-{{/operation.parameters}}
+{{ for parameter in api.operation.parameters}}
+        ,{{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}}
+{{end}}
         )
    {
-         {{GetReturnType operation "return"}}  operations.{{GetMethodName operation "Async"}}(
-{{#operation.parameters}}
-            {{GetDotNetName .}},
-{{/operation.parameters}}
+         {{GetReturnType api.operation "return"}}  operations.{{GetMethodName api.operation "Async"}}(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
              CancellationToken.None
         ).GetAwaiter().GetResult();
     }
 
-    {{#IfReturnType operation "object"}}
+    {{if IfReturnType api.operation "object"}}
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
     /// <param name='operations'>
     /// The operations group for this extension method.
     /// </param>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+    {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc parameter.description}}
     /// </param>
-    {{/operation.parameters}}
-    public static T {{GetMethodName operation ""}}<T>(
+    {{end}}
+    public static T {{GetMethodName api.operation ""}}<T>(
         this I{{name}}Operations operations
-{{#operation.parameters}}
-        ,{{GetDotNetType .}} {{GetDotNetName . "true"}}
-{{/operation.parameters}}
+{{ for parameter in api.operation.parameters}}
+        ,{{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}}
+{{end}}
         )
    {
-         return operations.{{GetMethodName operation "Async"}}<T>(
-{{#operation.parameters}}
-            {{GetDotNetName .}},
-{{/operation.parameters}}
+         return operations.{{GetMethodName api.operation "Async"}}<T>(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
              CancellationToken.None
         ).GetAwaiter().GetResult();
     }
-    {{/IfReturnType operation "object"}}
+    {{end}}
 
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
     /// <param name='operations'>
     /// The operations group for this extension method.
     /// </param>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+    {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc parameter.description}}
     /// </param>
-    {{/operation.parameters}}
+    {{end}}
     /// <param name="cancellationToken">
     /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
     /// </param>
-    public static async Task{{GetReturnType operation "<>"}} {{GetMethodName operation "Async"}}(
+    public static async Task{{GetReturnType api.operation "<>"}} {{GetMethodName api.operation "Async"}}(
         this I{{name}}Operations operations,
-        {{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName . "true"}},
-        {{/operation.parameters}}
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}},
+{{ end }}
         CancellationToken cancellationToken = default(CancellationToken))
     {
-        {{#IfReturnType operation "stream"}}
-        var _result = await operations.{{GetMethodName operation "WithHttpMessagesAsync"}}(
-            {{#operation.parameters}}
-            {{GetDotNetName .}},
-            {{/operation.parameters}}
+        {{if IfReturnType api.operation "stream"}}
+        var _result = await operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             null,
             cancellationToken);
         _result.Request.Dispose();
-        {{GetReturnType operation "_result.Body"}};
-        {{/IfReturnType operation "stream"}}
-        {{#IfReturnType operation "obj"}}
-        using (var _result = await operations.{{GetMethodName operation "WithHttpMessagesAsync"}}(
-            {{#operation.parameters}}
-            {{GetDotNetName .}},
-            {{/operation.parameters}}
+        {{GetReturnType api.operation "_result.Body"}};
+        {{end}}
+        {{if IfReturnType api.operation "obj"}}
+        using (var _result = await operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             null,
             cancellationToken).ConfigureAwait(false))
         {
-            {{GetReturnType operation "_result.Body"}};
+            {{GetReturnType api.operation "_result.Body"}};
         }
-        {{/IfReturnType operation "obj"}}
-        {{#IfReturnType operation "void"}}
-        using (var _result = await operations.{{GetMethodName operation "WithHttpMessagesAsync"}}(
-            {{#operation.parameters}}
-            {{GetDotNetName .}},
-            {{/operation.parameters}}
+        {{end}}
+        {{if IfReturnType api.operation "void"}}
+        using (var _result = await operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             null,
             cancellationToken).ConfigureAwait(false))
         {
         }
-        {{/IfReturnType operation "void"}}
+        {{end}}
     }
 
-    {{#IfReturnType operation "object"}}
+    {{if IfReturnType api.operation "object"}}
     /// <summary>
-    /// {{ToXmlDoc operation.description}}
+    /// {{ToXmlDoc api.operation.description}}
     /// </summary>
     /// <param name='operations'>
     /// The operations group for this extension method.
     /// </param>
-    {{#operation.parameters}}
-    /// <param name="{{GetDotNetName .}}">
-    /// {{ToXmlDoc description}}
+    {{ for parameter in api.operation.parameters}}
+    /// <param name="{{GetDotNetNameOpenApiParameter parameter "false"}}">
+    /// {{ToXmlDoc parameter.description}}
     /// </param>
-    {{/operation.parameters}}
+    {{end}}
     /// <param name="cancellationToken">
     /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
     /// </param>
-    public static async Task<T> {{GetMethodName operation "Async"}}<T>(
+    public static async Task<T> {{GetMethodName api.operation "Async"}}<T>(
         this I{{name}}Operations operations,
-        {{#operation.parameters}}
-        {{GetDotNetType .}} {{GetDotNetName . "true"}},
-        {{/operation.parameters}}
+{{ for parameter in api.operation.parameters}}
+        {{GetDotNetTypeOpenApiParameter parameter}} {{GetDotNetNameOpenApiParameter parameter "true"}},
+{{ end }}
         CancellationToken cancellationToken = default(CancellationToken))
     {
-        using (var _result = await operations.{{GetMethodName operation "WithHttpMessagesAsync"}}<T>(
-            {{#operation.parameters}}
-            {{GetDotNetName .}},
-            {{/operation.parameters}}
+        using (var _result = await operations.{{GetMethodName api.operation "WithHttpMessagesAsync"}}<T>(
+{{ for parameter in api.operation.parameters}}
+            {{GetDotNetNameOpenApiParameter parameter "false"}},
+{{end}}
             null,
             cancellationToken).ConfigureAwait(false))
         {
             return _result.Body;
         }
     }
-    {{/IfReturnType}}
+    {{end}}
 
-    {{/apis}}
+    {{end}}
 }


### PR DESCRIPTION
This pull request refactors the code structure of the LibKubernetesGenerator project. 

# Why

the old template Nustache is inactive and did not recieve any update in last 5 yr.

The syntax of Nustache is not friendly to developers:
 - no `else` 
 - hard to define customize func
 - lack of built in utils

# New Template Engine

https://github.com/scriban/scriban/

The scriban templating engine was chosen over other options due to its unique features that make it suitable for code generation. One of these features is the embed mode, which is specifically designed for this purpose.

Furthermore, scriban offers a rich syntax that meets the requirements of the current SDK build. This means it provides a wide range of functionalities that can handle complex templating tasks, making it an excellent choice for this use case.