### PR TITLE
migrating to record for data objects

### DIFF
--- a/examples/customResource/cResource.cs
+++ b/examples/customResource/cResource.cs
@@ -25,7 +25,7 @@ namespace customResource
         public string CityName { get; set; }
     }
 
-    public class CResourceStatus : V1Status
+    public record CResourceStatus : V1Status
     {
         [JsonPropertyName("temperature")]
         public string Temperature { get; set; }

--- a/src/KubernetesClient/Models/IntstrIntOrString.cs
+++ b/src/KubernetesClient/Models/IntstrIntOrString.cs
@@ -1,7 +1,7 @@
 namespace k8s.Models
 {
     [JsonConverter(typeof(IntOrStringJsonConverter))]
-    public partial class IntstrIntOrString
+    public partial record IntstrIntOrString
     {
         public static implicit operator IntstrIntOrString(int v)
         {
@@ -23,30 +23,30 @@ namespace k8s.Models
             return new IntstrIntOrString(v);
         }
 
-        protected bool Equals(IntstrIntOrString other)
-        {
-            return string.Equals(Value, other?.Value);
-        }
+        //protected bool Equals(IntstrIntOrString other)
+        //{
+        //    return string.Equals(Value, other?.Value);
+        //}
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+        //public override bool Equals(object obj)
+        //V1Status{
+        //    if (ReferenceEquals(null, obj))
+        //    {
+        //        return false;
+        //    }
 
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+        //    if (ReferenceEquals(this, obj))
+        //    {
+        //        return true;
+        //    }
 
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
+        //    if (obj.GetType() != GetType())
+        //    {
+        //        return false;
+        //    }
 
-            return Equals((IntstrIntOrString)obj);
-        }
+        //    return Equals((IntstrIntOrString)obj);
+        //}
 
         public override int GetHashCode()
         {

--- a/src/KubernetesClient/Models/ResourceQuantity.cs
+++ b/src/KubernetesClient/Models/ResourceQuantity.cs
@@ -54,7 +54,7 @@ namespace k8s.Models
     ///     cause implementors to also use a fixed point implementation.
     /// </summary>
     [JsonConverter(typeof(ResourceQuantityJsonConverter))]
-    public partial class ResourceQuantity
+    public partial record ResourceQuantity
     {
         public enum SuffixFormat
         {
@@ -97,30 +97,30 @@ namespace k8s.Models
             return CanonicalizeString();
         }
 
-        protected bool Equals(ResourceQuantity other)
-        {
-            return _unitlessValue.Equals(other?._unitlessValue);
-        }
+        //protected bool Equals(ResourceQuantity other)
+        //{
+        //    return _unitlessValue.Equals(other?._unitlessValue);
+        //}
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+        //public override bool Equals(object obj)
+        //{
+        //    if (ReferenceEquals(null, obj))
+        //    {
+        //        return false;
+        //    }
 
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+        //    if (ReferenceEquals(this, obj))
+        //    {
+        //        return true;
+        //    }
 
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
+        //    if (obj.GetType() != GetType())
+        //    {
+        //        return false;
+        //    }
 
-            return Equals((ResourceQuantity)obj);
-        }
+        //    return Equals((ResourceQuantity)obj);
+        //}
 
         public override int GetHashCode()
         {

--- a/src/KubernetesClient/Models/V1Patch.cs
+++ b/src/KubernetesClient/Models/V1Patch.cs
@@ -1,7 +1,7 @@
 namespace k8s.Models
 {
     [JsonConverter(typeof(V1PatchJsonConverter))]
-    public partial class V1Patch
+    public partial record V1Patch
     {
         public enum PatchType
         {

--- a/src/KubernetesClient/Models/V1PodTemplateSpec.cs
+++ b/src/KubernetesClient/Models/V1PodTemplateSpec.cs
@@ -4,7 +4,7 @@ namespace k8s.Models
     /// Partial implementation of the IMetadata interface
     /// to open this class up to ModelExtensions methods
     /// </summary>
-    public partial class V1PodTemplateSpec : IMetadata<V1ObjectMeta>
+    public partial record V1PodTemplateSpec : IMetadata<V1ObjectMeta>
     {
     }
 }

--- a/src/KubernetesClient/Models/V1Status.ObjectView.cs
+++ b/src/KubernetesClient/Models/V1Status.ObjectView.cs
@@ -1,6 +1,6 @@
 namespace k8s.Models
 {
-    public partial class V1Status
+    public partial record V1Status
     {
         internal sealed class V1StatusObjectViewConverter : JsonConverter<V1Status>
         {

--- a/src/KubernetesClient/Models/V1Status.cs
+++ b/src/KubernetesClient/Models/V1Status.cs
@@ -2,7 +2,7 @@ using System.Net;
 
 namespace k8s.Models
 {
-    public partial class V1Status
+    public partial record V1Status
     {
         /// <summary>Converts a <see cref="V1Status"/> object into a short description of the status.</summary>
         /// <returns>string description of the status</returns>

--- a/src/LibKubernetesGenerator/VersionConverterStubGenerator.cs
+++ b/src/LibKubernetesGenerator/VersionConverterStubGenerator.cs
@@ -54,11 +54,11 @@ namespace k8s.Models;
             foreach (var (t0, t1) in typePairs)
             {
                 sbmodel.AppendLine($@"
-    public partial class {t0}
+    public partial record {t0}
     {{
         public static explicit operator {t0}({t1} s) => ModelVersionConverter.Convert<{t1}, {t0}>(s);
     }}
-    public partial class {t1}
+    public partial record {t1}
     {{
         public static explicit operator {t1}({t0} s) => ModelVersionConverter.Convert<{t0}, {t1}>(s);
     }}");

--- a/src/LibKubernetesGenerator/templates/Model.cs.template
+++ b/src/LibKubernetesGenerator/templates/Model.cs.template
@@ -9,7 +9,7 @@ namespace k8s.Models
     /// <summary>
     /// {{ToXmlDoc def.description}}
     /// </summary>
-    public partial class {{clz}}
+    public partial record {{clz}}
     {
         /// <summary>
         /// Initializes a new instance of the {{GetClassName def}} class.

--- a/src/LibKubernetesGenerator/templates/ModelExtensions.cs.template
+++ b/src/LibKubernetesGenerator/templates/ModelExtensions.cs.template
@@ -6,7 +6,7 @@ namespace k8s.Models
 {
 {{ for definition in definitions }}
     [KubernetesEntity(Group=KubeGroup, Kind=KubeKind, ApiVersion=KubeApiVersion, PluralName=KubePluralName)]
-    public partial class {{ GetClassName definition }} : {{ GetInterfaceName definition }}
+    public partial record {{ GetClassName definition }} : {{ GetInterfaceName definition }}
     {
         public const string KubeApiVersion = "{{ GetApiVersion definition }}";
         public const string KubeKind = "{{ GetKind definition }}";

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -33,7 +33,7 @@ metadata:
         }
 
 #pragma warning disable CA1812 // Class is used for YAML deserialization tests
-        private class MyPod : V1Pod
+        private record MyPod : V1Pod
         {
         }
 #pragma warning restore CA1812


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record

grants users move flexibility to use data objects, for example, built-in deconstruction.