### PR TITLE
Add missing Dispose() calls

### DIFF
--- a/src/KubernetesClient/Kubernetes.cs
+++ b/src/KubernetesClient/Kubernetes.cs
@@ -209,6 +209,7 @@ namespace k8s
 
                 // Dispose the client
                 HttpClient?.Dispose();
+                HttpClient = null;
 
                 // Dispose the certificates
                 if (CaCerts is not null)
@@ -221,11 +222,13 @@ namespace k8s
                     CaCerts.Clear();
                 }
 
-
                 ClientCert?.Dispose();
+                ClientCert = null;
 
-                HttpClient = null;
+                FirstMessageHandler?.Dispose();
                 FirstMessageHandler = null;
+
+                HttpClientHandler?.Dispose();
                 HttpClientHandler = null;
             }
         }


### PR DESCRIPTION
While not recommended, if you repeatedly create a Kubernetes client inside of a loop, there appears to be a memory leak, even if you dispose it.

This PR adds the following to fix this:

* Adds `.Dispose()` for `FirstMessageHandler`
* Adds `.Dispose()` for `HttpClientHandler`
* A few other minor changes in the `Dispose()` method
* ~~Adds `Using` for `httpRequest` (while unrelated to the Kubernetes client lifecycle, I believe this should also be disposed)~~

Possible fix for #1539 (I suspect that issue is not related only to aot).

## Test Results

I tested this using the following console program and running in Rider using memory profiling (sampled allocations):
```
using k8s;

var config = KubernetesClientConfiguration.BuildConfigFromConfigFile();

for (var i = 0; i < 1000; i++)
{
    using var client = new Kubernetes(config);
    var list = client.CoreV1.ListNamespacedPod("kube-system");
    Console.WriteLine(string.Join(", ", list.Items.Select(x => x.Metadata.Name)));
}
```

### Before the fix
Memory increases slowly, eventually reaching ~163MB by the end of the program:
![BeforeFix1](https://github.com/kubernetes-client/csharp/assets/4977542/c33f6519-d3c8-4b1b-94eb-d34979c806d5)


### After the fix
Memory holds stead around ~123MB:
![AfterFix1](https://github.com/kubernetes-client/csharp/assets/4977542/cd3bd3ab-b1b4-44eb-9b6f-95dd6d18c16b)


