### PR TITLE
Update KubernetesClient DiagnosticSource dependency

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+        <PackageReference Condition="'$(TargetFramework)'=='net6.0'" Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
         <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
         <PackageReference Include="Fractions" Version="7.3.0" />


### PR DESCRIPTION
`System.Diagnostics.DiagnosticSource` has been included in the framework reference, no need to reference for net8

fixes https://github.com/kubernetes-client/csharp/issues/1553