### PR TITLE
Added OnError event to MetaObjectLock

### DIFF
--- a/src/KubernetesClient/LeaderElection/ResourceLock/MetaObjectLock.cs
+++ b/src/KubernetesClient/LeaderElection/ResourceLock/MetaObjectLock.cs
@@ -9,6 +9,11 @@ namespace k8s.LeaderElection.ResourceLock
         private readonly string identity;
         private T metaObjCache;
 
+        /// <summary>
+        /// OnError is called when there is a http operation error.
+        /// </summary>
+        public event Action<HttpOperationException> OnError;
+
         protected MetaObjectLock(IKubernetes client, string @namespace, string name, string identity)
         {
             this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -47,8 +52,9 @@ namespace k8s.LeaderElection.ResourceLock
                 Interlocked.Exchange(ref metaObjCache, createdObj);
                 return true;
             }
-            catch (HttpOperationException)
+            catch (HttpOperationException e)
             {
+                OnError?.Invoke(e);
                 // ignore
             }
 
@@ -79,8 +85,9 @@ namespace k8s.LeaderElection.ResourceLock
                 Interlocked.Exchange(ref metaObjCache, replacedObj);
                 return true;
             }
-            catch (HttpOperationException)
+            catch (HttpOperationException e)
             {
+                OnError?.Invoke(e);
                 // ignore
             }
 

--- a/src/KubernetesClient/LeaderElection/ResourceLock/MetaObjectLock.cs
+++ b/src/KubernetesClient/LeaderElection/ResourceLock/MetaObjectLock.cs
@@ -10,9 +10,9 @@ namespace k8s.LeaderElection.ResourceLock
         private T metaObjCache;
 
         /// <summary>
-        /// OnError is called when there is a http operation error.
+        /// OnHttpError is called when there is a http operation error.
         /// </summary>
-        public event Action<HttpOperationException> OnError;
+        public event Action<HttpOperationException> OnHttpError;
 
         protected MetaObjectLock(IKubernetes client, string @namespace, string name, string identity)
         {
@@ -54,7 +54,7 @@ namespace k8s.LeaderElection.ResourceLock
             }
             catch (HttpOperationException e)
             {
-                OnError?.Invoke(e);
+                OnHttpError?.Invoke(e);
                 // ignore
             }
 
@@ -87,7 +87,7 @@ namespace k8s.LeaderElection.ResourceLock
             }
             catch (HttpOperationException e)
             {
-                OnError?.Invoke(e);
+                OnHttpError?.Invoke(e);
                 // ignore
             }
 


### PR DESCRIPTION
Exposes HTTP operation exceptions for logging or tracing.

Fixes #1584 