### PR TITLE
Enable JSON Patch in AOT

### DIFF
--- a/examples/patch-aot/Program.cs
+++ b/examples/patch-aot/Program.cs
@@ -1,0 +1,32 @@
+using k8s;
+using k8s.Models;
+
+var config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
+IKubernetes client = new Kubernetes(config);
+Console.WriteLine("Starting Request!");
+
+var pod = client.CoreV1.ListNamespacedPod("default").Items.First();
+var name = pod.Metadata.Name;
+PrintLabels(pod);
+
+var patchStr = @"
+{
+    ""metadata"": {
+        ""labels"": {
+            ""test"": ""test""
+        }
+    }
+}";
+
+client.CoreV1.PatchNamespacedPod(new V1Patch(patchStr, V1Patch.PatchType.MergePatch), name, "default");
+PrintLabels(client.CoreV1.ReadNamespacedPod(name, "default"));
+
+static void PrintLabels(V1Pod pod)
+{
+    Console.WriteLine($"Labels: for {pod.Metadata.Name}");
+    foreach (var (k, v) in pod.Metadata.Labels)
+    {
+        Console.WriteLine($"{k} : {v}");
+    }
+    Console.WriteLine("=-=-=-=-=-=-=-=-=-=-=");
+}

--- a/examples/patch-aot/patch-aot.csproj
+++ b/examples/patch-aot/patch-aot.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KubernetesClient.Aot\KubernetesClient.Aot.csproj"/>
+  </ItemGroup>
+</Project>

--- a/src/KubernetesClient.Aot/KubernetesJson.cs
+++ b/src/KubernetesClient.Aot/KubernetesJson.cs
@@ -91,6 +91,11 @@ namespace k8s
 
         public static string Serialize(object value, JsonSerializerOptions jsonSerializerOptions = null)
         {
+            if (value is V1Patch { Content: string jsonValue })
+            {
+                return jsonValue;
+            }
+
             var info = SourceGenerationContext.Default.GetTypeInfo(value.GetType());
             return JsonSerializer.Serialize(value, info);
         }


### PR DESCRIPTION
Updates `KubernetesJson.Serialize` with a special case for seializing `V1Patch` when the content is string, as based on the examples and the converter implementation, the expectation in this case is that the conent already be JSON.

fixes #1587