### PR TITLE
Actually assign loaded cert when generating pfx

### DIFF
--- a/src/KubernetesClient/CertUtils.cs
+++ b/src/KubernetesClient/CertUtils.cs
@@ -81,7 +81,7 @@ namespace k8s
                 if (config.ClientCertificateKeyStoreFlags.HasValue)
                 {
 #if NET9_0_OR_GREATER
-                    X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pkcs12), nullPassword, config.ClientCertificateKeyStoreFlags.Value);
+                    cert = X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pkcs12), nullPassword, config.ClientCertificateKeyStoreFlags.Value);
 #else
                     cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12), nullPassword, config.ClientCertificateKeyStoreFlags.Value);
 #endif
@@ -90,7 +90,7 @@ namespace k8s
                 else
                 {
 #if NET9_0_OR_GREATER
-                    X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pkcs12), nullPassword);
+                    cert = X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pkcs12), nullPassword);
 #else
                     cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12), nullPassword);
 #endif

--- a/tests/KubernetesClient.Tests/AuthTests.cs
+++ b/tests/KubernetesClient.Tests/AuthTests.cs
@@ -167,8 +167,8 @@ namespace k8s.Tests
             }
         }
 
-        // this test doesn't work on OSX and is inconsistent on windows
-        [OperatingSystemDependentFact(Exclude = OperatingSystems.OSX | OperatingSystems.Windows)]
+        // this test doesn't work on OSX
+        [OperatingSystemDependentFact(Exclude = OperatingSystems.OSX)]
         public void Cert()
         {
             var serverCertificateData = File.ReadAllText("assets/apiserver-pfx-data.txt");
@@ -273,7 +273,7 @@ namespace k8s.Tests
             }
         }
 
-        [OperatingSystemDependentFact(Exclude = OperatingSystems.OSX | OperatingSystems.Windows)]
+        [OperatingSystemDependentFact(Exclude = OperatingSystems.OSX)]
         public void ExternalCertificate()
         {
             const string name = "testing_irrelevant";


### PR DESCRIPTION
Fix regression in .net 9 when migrating to X509CertificateLoader.