### PR TITLE
fix ExecCredentialResponse deserializion in aot

### DIFF
--- a/src/KubernetesClient.Aot/KubeConfigModels/ExecCredentialResponse.cs
+++ b/src/KubernetesClient.Aot/KubeConfigModels/ExecCredentialResponse.cs
@@ -8,9 +8,13 @@ namespace k8s.KubeConfigModels
         public class ExecStatus
         {
 #nullable enable
+            [JsonPropertyName("expirationTimestamp")]
             public DateTime? ExpirationTimestamp { get; set; }
+            [JsonPropertyName("token")]
             public string? Token { get; set; }
+            [JsonPropertyName("clientCertificateData")]
             public string? ClientCertificateData { get; set; }
+            [JsonPropertyName("clientKeyData")]
             public string? ClientKeyData { get; set; }
 #nullable disable
 

--- a/src/KubernetesClient.Aot/KubeConfigModels/ExecCredentialResponseContext.cs
+++ b/src/KubernetesClient.Aot/KubeConfigModels/ExecCredentialResponseContext.cs
@@ -1,0 +1,7 @@
+namespace k8s.KubeConfigModels
+{
+    [JsonSerializable(typeof(ExecCredentialResponse))]
+    internal partial class ExecCredentialResponseContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -523,7 +523,10 @@ namespace k8s
                     throw new KubeConfigException("external exec failed due to timeout");
                 }
 
-                var responseObject = KubernetesJson.Deserialize<ExecCredentialResponse>(process.StandardOutput.ReadToEnd());
+                var responseObject = JsonSerializer.Deserialize(
+                    process.StandardOutput.ReadToEnd(),
+                    ExecCredentialResponseContext.Default.ExecCredentialResponse);
+
                 if (responseObject == null || responseObject.ApiVersion != config.ApiVersion)
                 {
                     throw new KubeConfigException(


### PR DESCRIPTION
- Fix for #1602 
- Made 'ExecCredentialResponse' deserializable in aot so tokens can be extracted initializing Kubernetes object