### PR TITLE
fix: yaml ByteArrayStringYamlConverter output new lines

### DIFF
--- a/src/KubernetesClient/KubernetesYaml.cs
+++ b/src/KubernetesClient/KubernetesYaml.cs
@@ -92,11 +92,16 @@ namespace k8s
             public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
             {
                 var obj = (byte[])value;
+                var strValue = Encoding.UTF8.GetString(obj);
+
+                // Check if the string is multi-line by looking for a newline character.
+                var scalarStyle = strValue.Contains('\n') ? ScalarStyle.Literal : ScalarStyle.Any;
+
                 emitter.Emit(new Scalar(
                     AnchorName.Empty,
                     TagName.Empty,
-                    Encoding.UTF8.GetString(obj),
-                    ScalarStyle.Literal,  // renders as |
+                    strValue,
+                    scalarStyle,
                     true,
                     true));
             }

--- a/src/KubernetesClient/KubernetesYaml.cs
+++ b/src/KubernetesClient/KubernetesYaml.cs
@@ -92,7 +92,14 @@ namespace k8s
             public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
             {
                 var obj = (byte[])value;
-                emitter?.Emit(new Scalar(Encoding.UTF8.GetString(obj)));
+                emitter.Emit(new Scalar(
+                    AnchorName.Empty,
+                    TagName.Empty,
+                    Encoding.UTF8.GetString(obj),
+                    ScalarStyle.Literal,  // renders as |
+                    true,
+                    true
+                ));
             }
         }
 

--- a/src/KubernetesClient/KubernetesYaml.cs
+++ b/src/KubernetesClient/KubernetesYaml.cs
@@ -98,8 +98,7 @@ namespace k8s
                     Encoding.UTF8.GetString(obj),
                     ScalarStyle.Literal,  // renders as |
                     true,
-                    true
-                ));
+                    true));
             }
         }
 

--- a/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesYamlTests.cs
@@ -818,6 +818,30 @@ data:
         }
 
         [Fact]
+        public void WriteSecret()
+        {
+            var kManifest = """
+apiVersion: v1
+data:
+  username: bXktYXBw
+  tls2.crt: |
+    -----BEGIN CERTIFICATE-----
+    FAKE CERT
+    FAKE CERT
+    FAKE CERT
+    -----END CERTIFICATE-----
+kind: Secret
+metadata:
+  name: test-secret
+""";
+
+            var result = KubernetesYaml.Deserialize<V1Secret>(kManifest, true);
+            var yaml = KubernetesYaml.Serialize(result);
+
+            Assert.Equal(kManifest, yaml);
+        }
+
+        [Fact]
         public void DeserializeWithJsonPropertyName()
         {
             var kManifest = @"


### PR DESCRIPTION
### Fix

This PR resolves the formatting problem where KubernetesYaml.Serialize() was introducing extra newlines in the output. Secrets and other multi-line values now serialize without unintended blank lines.

Before:
<img width="627" height="573" alt="image" src="https://github.com/user-attachments/assets/cfee4088-fba1-42f4-9d31-2f09cfb78127" />
After:
<img width="622" height="365" alt="image" src="https://github.com/user-attachments/assets/c5f975f9-5caa-42ee-b4da-402648ab7e2a" />
