### PR TITLE
feat: add non-generic Deserialize method to KubernetesJson

### DIFF
--- a/src/KubernetesClient/KubernetesJson.cs
+++ b/src/KubernetesClient/KubernetesJson.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 
 #if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 #endif
 
@@ -126,6 +127,13 @@ namespace k8s
 
             configure(JsonSerializerOptions);
         }
+
+#if NET8_0_OR_GREATER
+        [RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+#endif
+        public static object Deserialize(string json, Type returnType, JsonSerializerOptions jsonSerializerOptions = null)
+            => JsonSerializer.Deserialize(json, returnType, jsonSerializerOptions ?? JsonSerializerOptions);
 
         public static TValue Deserialize<TValue>(string json, JsonSerializerOptions jsonSerializerOptions = null)
         {

--- a/src/KubernetesClient/KubernetesJson.cs
+++ b/src/KubernetesClient/KubernetesJson.cs
@@ -127,6 +127,16 @@ namespace k8s
             configure(JsonSerializerOptions);
         }
 
+        /// <summary>
+        /// Deserializes the JSON string to an object of the specified <paramref name="returnType"/>.
+        /// This method provides a non-generic alternative to <see cref="Deserialize{TValue}(string, JsonSerializerOptions)"/>.
+        /// </summary>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <param name="returnType">The type of the object to create.</param>
+        /// <param name="jsonSerializerOptions">Optional <see cref="JsonSerializerOptions"/> to use during deserialization. If <c>null</c>, the default options are used.</param>
+        /// <returns>
+        /// An object of type <paramref name="returnType"/> deserialized from the JSON string.
+        /// </returns>
         public static object Deserialize(string json, Type returnType, JsonSerializerOptions jsonSerializerOptions = null)
         {
 #if NET8_0_OR_GREATER

--- a/src/KubernetesClient/KubernetesJson.cs
+++ b/src/KubernetesClient/KubernetesJson.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using System.Xml;
 
 #if NET8_0_OR_GREATER
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 #endif
 
@@ -128,12 +127,15 @@ namespace k8s
             configure(JsonSerializerOptions);
         }
 
-#if NET8_0_OR_GREATER
-        [RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-        [RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-#endif
         public static object Deserialize(string json, Type returnType, JsonSerializerOptions jsonSerializerOptions = null)
-            => JsonSerializer.Deserialize(json, returnType, jsonSerializerOptions ?? JsonSerializerOptions);
+        {
+#if NET8_0_OR_GREATER
+            var info = (jsonSerializerOptions ?? JsonSerializerOptions).GetTypeInfo(returnType);
+            return JsonSerializer.Deserialize(json, info);
+#else
+            return JsonSerializer.Deserialize(json, returnType, jsonSerializerOptions ?? JsonSerializerOptions);
+#endif
+        }
 
         public static TValue Deserialize<TValue>(string json, JsonSerializerOptions jsonSerializerOptions = null)
         {

--- a/tests/KubernetesClient.Tests/KubernetesJsonTests.cs
+++ b/tests/KubernetesClient.Tests/KubernetesJsonTests.cs
@@ -169,4 +169,27 @@ public class KubernetesJsonTests
         // Also verify it doesn't have 5 digits (which would fail in Kubernetes)
         Assert.DoesNotContain("2025-11-17T22:52:34.96217Z", json);
     }
+
+    [Fact]
+    public void NonGenericDeserializeReturnsInstanceOfReturnType()
+    {
+        const string json = """
+                            {
+                              "apiVersion": "v1",
+                              "kind": "Secret",
+                              "metadata": {
+                                "name": "typed-secret"
+                              },
+                              "type": "Opaque"
+                            }
+                            """;
+
+#pragma warning disable CA2263
+        var result = KubernetesJson.Deserialize(json, typeof(V1Secret));
+#pragma warning restore CA2263
+
+        var secret = Assert.IsType<V1Secret>(result);
+        Assert.Equal("typed-secret", secret.Metadata.Name);
+        Assert.Equal("Opaque", secret.Type);
+    }
 }


### PR DESCRIPTION
this PR adds a non-generic Deserialise method to `KubernetesJson.cs`

**Reason:**

based on this [discussion](https://github.com/kubernetes-client/csharp/discussions/1683) adding a non generic `Deserialize` method gives the opportunity to use the same json serialisation mechanism everywhere - when using KubernetesClient package.