### PR TITLE
Pass cluster info to exec credential plugins (provideClusterInfo)

### DIFF
--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -307,20 +307,20 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
-                    CaData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
+                    CertificateAuthorityData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
 #if NET9_0_OR_GREATER
-                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(CaData)));
+                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(CertificateAuthorityData)));
 #else
                     string nullPassword = null;
                     // This null password is to change the constructor to fix this KB:
                     // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(CaData), nullPassword));
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(CertificateAuthorityData), nullPassword));
 #endif
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
                     var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
-                    CaData = Convert.ToBase64String(caBytes);
+                    CertificateAuthorityData = Convert.ToBase64String(caBytes);
 #if NET9_0_OR_GREATER
                     SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(caBytes));
 #else
@@ -424,7 +424,7 @@ namespace k8s
                         Server = this.Host,
                         SkipTlsVerify = this.SkipTlsVerify,
                         TlsServerName = this.TlsServerName,
-                        CertificateAuthorityData = this.CaData,
+                        CertificateAuthorityData = this.CertificateAuthorityData,
                     };
                 }
 

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -319,12 +319,13 @@ namespace k8s
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
-                    var caPath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
-                    CaData = Convert.ToBase64String(File.ReadAllBytes(caPath));
+                    var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
+                    CaData = Convert.ToBase64String(caBytes);
 #if NET9_0_OR_GREATER
-                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificateFromFile(caPath));
+                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(caBytes));
 #else
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(caPath));
+                    string nullPassword = null;
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(caBytes, nullPassword));
 #endif
                 }
             }
@@ -492,7 +493,12 @@ namespace k8s
             return node;
         }
 
-        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null, ClusterEndpoint cluster = null)
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null)
+        {
+            return CreateRunnableExternalProcess(config, captureStdError, null);
+        }
+
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError, ClusterEndpoint cluster)
         {
             if (config == null)
             {
@@ -502,7 +508,11 @@ namespace k8s
             var spec = new JsonObject { ["interactive"] = Environment.UserInteractive };
             if (config.ProvideClusterInfo)
             {
-                spec["cluster"] = ToExecClusterInfo(cluster);
+                var clusterNode = ToExecClusterInfo(cluster);
+                if (clusterNode != null)
+                {
+                    spec["cluster"] = clusterNode;
+                }
             }
 
             var execInfo = new JsonObject
@@ -557,7 +567,12 @@ namespace k8s
         /// <returns>
         /// The token, client certificate data, and the client key data received from the external command execution
         /// </returns>
-        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster = null)
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config)
+        {
+            return ExecuteExternalCommand(config, null);
+        }
+
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster)
         {
             if (config == null)
             {

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json.Nodes;
 
 namespace k8s
@@ -321,12 +322,8 @@ namespace k8s
                 {
                     var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
                     CertificateAuthorityData = Convert.ToBase64String(caBytes);
-#if NET9_0_OR_GREATER
-                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(caBytes));
-#else
-                    string nullPassword = null;
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(caBytes, nullPassword));
-#endif
+                    SslCaCerts = new X509Certificate2Collection();
+                    SslCaCerts.ImportFromPem(Encoding.UTF8.GetString(caBytes));
                 }
             }
         }

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Text.Json.Nodes;
 
 namespace k8s
@@ -320,10 +319,17 @@ namespace k8s
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
-                    var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
-                    CertificateAuthorityData = Convert.ToBase64String(caBytes);
-                    SslCaCerts = new X509Certificate2Collection();
-                    SslCaCerts.ImportFromPem(Encoding.UTF8.GetString(caBytes));
+                    var caPath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
+                    CertificateAuthorityData = Convert.ToBase64String(File.ReadAllBytes(caPath));
+
+                    // File-path loaders auto-detect cert format (PEM/DER/PFX), which the
+                    // byte-based APIs do not reliably do on pre-.NET 9. The second read is
+                    // intentional to preserve format flexibility for SslCaCerts.
+#if NET9_0_OR_GREATER
+                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificateFromFile(caPath));
+#else
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(caPath));
+#endif
                 }
             }
         }

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json.Nodes;
 
 namespace k8s
 {
@@ -306,26 +307,24 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
-                    var data = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
+                    CaData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
 #if NET9_0_OR_GREATER
-                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(data)));
+                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(CaData)));
 #else
                     string nullPassword = null;
                     // This null password is to change the constructor to fix this KB:
                     // https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(data), nullPassword));
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(Convert.FromBase64String(CaData), nullPassword));
 #endif
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
+                    var caPath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
+                    CaData = Convert.ToBase64String(File.ReadAllBytes(caPath));
 #if NET9_0_OR_GREATER
-                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificateFromFile(GetFullPath(
-                        k8SConfig,
-                        clusterDetails.ClusterEndpoint.CertificateAuthority)));
+                    SslCaCerts = new X509Certificate2Collection(X509CertificateLoader.LoadCertificateFromFile(caPath));
 #else
-                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(GetFullPath(
-                        k8SConfig,
-                        clusterDetails.ClusterEndpoint.CertificateAuthority)));
+                    SslCaCerts = new X509Certificate2Collection(new X509Certificate2(caPath));
 #endif
                 }
             }
@@ -416,7 +415,19 @@ namespace k8s
                     throw new KubeConfigException("External command execution missing ApiVersion key");
                 }
 
-                var response = ExecuteExternalCommand(userDetails.UserCredentials.ExternalExecution);
+                ClusterEndpoint clusterEndpoint = null;
+                if (userDetails.UserCredentials.ExternalExecution.ProvideClusterInfo)
+                {
+                    clusterEndpoint = new ClusterEndpoint
+                    {
+                        Server = this.Host,
+                        SkipTlsVerify = this.SkipTlsVerify,
+                        TlsServerName = this.TlsServerName,
+                        CertificateAuthorityData = this.CaData,
+                    };
+                }
+
+                var response = ExecuteExternalCommand(userDetails.UserCredentials.ExternalExecution, clusterEndpoint);
                 AccessToken = response.Status.Token;
                 // When reading ClientCertificateData from a config file it will be base64 encoded, and code later in the system (see CertUtils.GeneratePfx)
                 // expects ClientCertificateData and ClientCertificateKeyData to be base64 encoded because of this. However the string returned by external
@@ -429,7 +440,7 @@ namespace k8s
                 // TODO: support client certificates here too.
                 if (AccessToken != null)
                 {
-                    TokenProvider = new ExecTokenProvider(userDetails.UserCredentials.ExternalExecution);
+                    TokenProvider = new ExecTokenProvider(userDetails.UserCredentials.ExternalExecution, clusterEndpoint);
                 }
             }
 
@@ -440,16 +451,70 @@ namespace k8s
             }
         }
 
-        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null)
+        /// <summary>
+        /// Converts a resolved <see cref="ClusterEndpoint"/> into the
+        /// <c>spec.cluster</c> JSON representation defined by the exec credential plugin
+        /// protocol (client.authentication.k8s.io/v1). Returns <c>null</c> if
+        /// <paramref name="cluster"/> is <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// The AOT <see cref="ClusterEndpoint"/> does not include Extensions (dynamic types
+        /// are incompatible with AOT), so <c>spec.cluster.config</c> is not populated.
+        /// </remarks>
+        /// <seealso href="https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#Cluster"/>
+        internal static JsonNode ToExecClusterInfo(ClusterEndpoint cluster)
+        {
+            if (cluster == null)
+            {
+                return null;
+            }
+
+            var node = new JsonObject
+            {
+                ["server"] = cluster.Server,
+            };
+
+            if (cluster.SkipTlsVerify)
+            {
+                node["insecure-skip-tls-verify"] = true;
+            }
+
+            if (!string.IsNullOrEmpty(cluster.CertificateAuthorityData))
+            {
+                node["certificate-authority-data"] = cluster.CertificateAuthorityData;
+            }
+
+            if (!string.IsNullOrEmpty(cluster.TlsServerName))
+            {
+                node["tls-server-name"] = cluster.TlsServerName;
+            }
+
+            return node;
+        }
+
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null, ClusterEndpoint cluster = null)
         {
             if (config == null)
             {
                 throw new ArgumentNullException(nameof(config));
             }
 
+            var spec = new JsonObject { ["interactive"] = Environment.UserInteractive };
+            if (config.ProvideClusterInfo)
+            {
+                spec["cluster"] = ToExecClusterInfo(cluster);
+            }
+
+            var execInfo = new JsonObject
+            {
+                ["apiVersion"] = config.ApiVersion,
+                ["kind"] = "ExecCredentials",
+                ["spec"] = spec,
+            };
+
             var process = new Process();
 
-            process.StartInfo.EnvironmentVariables.Add("KUBERNETES_EXEC_INFO", $"{{ \"apiVersion\":\"{config.ApiVersion}\",\"kind\":\"ExecCredentials\",\"spec\":{{ \"interactive\":{Environment.UserInteractive.ToString().ToLower()} }} }}");
+            process.StartInfo.EnvironmentVariables.Add("KUBERNETES_EXEC_INFO", execInfo.ToJsonString());
             if (config.EnvironmentVariables != null)
             {
                 foreach (var configEnvironmentVariable in config.EnvironmentVariables)
@@ -492,7 +557,7 @@ namespace k8s
         /// <returns>
         /// The token, client certificate data, and the client key data received from the external command execution
         /// </returns>
-        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config)
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster = null)
         {
             if (config == null)
             {
@@ -500,7 +565,7 @@ namespace k8s
             }
 
             var captureStdError = ExecStdError;
-            var process = CreateRunnableExternalProcess(config, captureStdError);
+            var process = CreateRunnableExternalProcess(config, captureStdError, cluster);
 
             try
             {

--- a/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient.Aot/KubernetesClientConfiguration.ConfigFile.cs
@@ -278,6 +278,10 @@ namespace k8s
             SkipTlsVerify = clusterDetails.ClusterEndpoint.SkipTlsVerify;
             TlsServerName = clusterDetails.ClusterEndpoint.TlsServerName;
 
+            // Reset CA data so it always reflects the cluster currently being resolved
+            // and is never carried over from a prior state.
+            CertificateAuthorityData = null;
+
             if (!Uri.TryCreate(Host, UriKind.Absolute, out var uri))
             {
                 throw new KubeConfigException($"Bad server host URL `{Host}` (cannot be parsed)");

--- a/src/KubernetesClient/Authentication/ExecTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/ExecTokenProvider.cs
@@ -9,7 +9,12 @@ namespace k8s.Authentication
         private readonly ClusterEndpoint cluster;
         private ExecCredentialResponse response;
 
-        public ExecTokenProvider(ExternalExecution exec, ClusterEndpoint cluster = null)
+        public ExecTokenProvider(ExternalExecution exec)
+            : this(exec, null)
+        {
+        }
+
+        public ExecTokenProvider(ExternalExecution exec, ClusterEndpoint cluster)
         {
             this.exec = exec;
             this.cluster = cluster;

--- a/src/KubernetesClient/Authentication/ExecTokenProvider.cs
+++ b/src/KubernetesClient/Authentication/ExecTokenProvider.cs
@@ -6,11 +6,13 @@ namespace k8s.Authentication
     public class ExecTokenProvider : ITokenProvider
     {
         private readonly ExternalExecution exec;
+        private readonly ClusterEndpoint cluster;
         private ExecCredentialResponse response;
 
-        public ExecTokenProvider(ExternalExecution exec)
+        public ExecTokenProvider(ExternalExecution exec, ClusterEndpoint cluster = null)
         {
             this.exec = exec;
+            this.cluster = cluster;
         }
 
         private bool NeedsRefresh()
@@ -41,7 +43,7 @@ namespace k8s.Authentication
         private async Task RefreshToken()
         {
             response =
-                await Task.Run(() => KubernetesClientConfiguration.ExecuteExternalCommand(this.exec)).ConfigureAwait(false);
+                await Task.Run(() => KubernetesClientConfiguration.ExecuteExternalCommand(this.exec, this.cluster)).ConfigureAwait(false);
         }
     }
 }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -307,14 +307,14 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
-                    CaData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
-                    var pemText = Encoding.UTF8.GetString(Convert.FromBase64String(CaData));
+                    CertificateAuthorityData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
+                    var pemText = Encoding.UTF8.GetString(Convert.FromBase64String(CertificateAuthorityData));
                     SslCaCerts = CertUtils.LoadFromPemText(pemText);
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
                     var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
-                    CaData = Convert.ToBase64String(caBytes);
+                    CertificateAuthorityData = Convert.ToBase64String(caBytes);
                     var pemText = Encoding.UTF8.GetString(caBytes);
                     SslCaCerts = CertUtils.LoadFromPemText(pemText);
                 }
@@ -441,7 +441,7 @@ namespace k8s
                         Server = this.Host,
                         SkipTlsVerify = this.SkipTlsVerify,
                         TlsServerName = this.TlsServerName,
-                        CertificateAuthorityData = this.CaData,
+                        CertificateAuthorityData = this.CertificateAuthorityData,
                         Extensions = rawCluster?.Extensions,
                     };
                 }

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -11,6 +11,8 @@ namespace k8s
 {
     public partial class KubernetesClientConfiguration
     {
+        internal const string ExecExtensionName = "client.authentication.k8s.io/exec";
+
         /// <summary>
         ///     kubeconfig Default Location
         /// </summary>
@@ -505,13 +507,13 @@ namespace k8s
             }
 
             var execExtension = cluster.Extensions?
-                .FirstOrDefault(e => e.Name == "client.authentication.k8s.io/exec");
+                .FirstOrDefault(e => e.Name == ExecExtensionName);
             if (execExtension != null)
             {
                 object extConfig = execExtension.Extension;
                 if (extConfig != null)
                 {
-                    node["config"] = JsonNode.Parse(JsonSerializer.Serialize(extConfig));
+                    node["config"] = JsonSerializer.SerializeToNode(extConfig);
                 }
             }
 

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -280,6 +280,10 @@ namespace k8s
             SkipTlsVerify = clusterDetails.ClusterEndpoint.SkipTlsVerify;
             TlsServerName = clusterDetails.ClusterEndpoint.TlsServerName;
 
+            // Reset CA data so it always reflects the cluster currently being resolved
+            // and is never carried over from a prior state.
+            CertificateAuthorityData = null;
+
             if (!Uri.TryCreate(Host, UriKind.Absolute, out var uri))
             {
                 throw new KubeConfigException($"Bad server host URL `{Host}` (cannot be parsed)");

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -313,9 +313,10 @@ namespace k8s
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
-                    var caPath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
-                    CaData = Convert.ToBase64String(File.ReadAllBytes(caPath));
-                    SslCaCerts = CertUtils.LoadPemFileCert(caPath);
+                    var caBytes = File.ReadAllBytes(GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority));
+                    CaData = Convert.ToBase64String(caBytes);
+                    var pemText = Encoding.UTF8.GetString(caBytes);
+                    SslCaCerts = CertUtils.LoadFromPemText(pemText);
                 }
             }
         }
@@ -517,7 +518,12 @@ namespace k8s
             return node;
         }
 
-        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null, ClusterEndpoint cluster = null)
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null)
+        {
+            return CreateRunnableExternalProcess(config, captureStdError, null);
+        }
+
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError, ClusterEndpoint cluster)
         {
             if (config == null)
             {
@@ -527,7 +533,11 @@ namespace k8s
             var spec = new JsonObject { ["interactive"] = Environment.UserInteractive };
             if (config.ProvideClusterInfo)
             {
-                spec["cluster"] = ToExecClusterInfo(cluster);
+                var clusterNode = ToExecClusterInfo(cluster);
+                if (clusterNode != null)
+                {
+                    spec["cluster"] = clusterNode;
+                }
             }
 
             var execInfo = new JsonObject
@@ -582,7 +592,12 @@ namespace k8s
         /// <returns>
         /// The token, client certificate data, and the client key data received from the external command execution
         /// </returns>
-        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster = null)
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config)
+        {
+            return ExecuteExternalCommand(config, null);
+        }
+
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster)
         {
             if (config == null)
             {

--- a/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.ConfigFile.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Nodes;
 
 namespace k8s
 {
@@ -306,15 +307,15 @@ namespace k8s
             {
                 if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthorityData))
                 {
-                    var data = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
-                    var pemText = Encoding.UTF8.GetString(Convert.FromBase64String(data));
+                    CaData = clusterDetails.ClusterEndpoint.CertificateAuthorityData;
+                    var pemText = Encoding.UTF8.GetString(Convert.FromBase64String(CaData));
                     SslCaCerts = CertUtils.LoadFromPemText(pemText);
                 }
                 else if (!string.IsNullOrEmpty(clusterDetails.ClusterEndpoint.CertificateAuthority))
                 {
-                    SslCaCerts = CertUtils.LoadPemFileCert(GetFullPath(
-                        k8SConfig,
-                        clusterDetails.ClusterEndpoint.CertificateAuthority));
+                    var caPath = GetFullPath(k8SConfig, clusterDetails.ClusterEndpoint.CertificateAuthority);
+                    CaData = Convert.ToBase64String(File.ReadAllBytes(caPath));
+                    SslCaCerts = CertUtils.LoadPemFileCert(caPath);
                 }
             }
         }
@@ -426,7 +427,25 @@ namespace k8s
                     throw new KubeConfigException("External command execution missing ApiVersion key");
                 }
 
-                var response = ExecuteExternalCommand(userDetails.UserCredentials.ExternalExecution);
+                ClusterEndpoint clusterEndpoint = null;
+                if (userDetails.UserCredentials.ExternalExecution.ProvideClusterInfo)
+                {
+                    var clusterDetails = k8SConfig.Clusters.FirstOrDefault(c => c.Name.Equals(
+                        activeContext.ContextDetails.Cluster,
+                        StringComparison.OrdinalIgnoreCase));
+                    var rawCluster = clusterDetails?.ClusterEndpoint;
+
+                    clusterEndpoint = new ClusterEndpoint
+                    {
+                        Server = this.Host,
+                        SkipTlsVerify = this.SkipTlsVerify,
+                        TlsServerName = this.TlsServerName,
+                        CertificateAuthorityData = this.CaData,
+                        Extensions = rawCluster?.Extensions,
+                    };
+                }
+
+                var response = ExecuteExternalCommand(userDetails.UserCredentials.ExternalExecution, clusterEndpoint);
                 AccessToken = response.Status.Token;
                 // When reading ClientCertificateData from a config file it will be base64 encoded, and code later in the system (see CertUtils.GeneratePfx)
                 // expects ClientCertificateData and ClientCertificateKeyData to be base64 encoded because of this. However the string returned by external
@@ -439,7 +458,7 @@ namespace k8s
                 // TODO: support client certificates here too.
                 if (AccessToken != null)
                 {
-                    TokenProvider = new ExecTokenProvider(userDetails.UserCredentials.ExternalExecution);
+                    TokenProvider = new ExecTokenProvider(userDetails.UserCredentials.ExternalExecution, clusterEndpoint);
                 }
             }
 
@@ -450,23 +469,77 @@ namespace k8s
             }
         }
 
-        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null)
+        /// <summary>
+        /// Converts a <see cref="ClusterEndpoint"/> (kubeconfig model) into the
+        /// <c>spec.cluster</c> JSON representation defined by the exec credential plugin
+        /// protocol (client.authentication.k8s.io/v1). Returns <c>null</c> if
+        /// <paramref name="cluster"/> is <c>null</c>.
+        /// </summary>
+        /// <seealso href="https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#Cluster"/>
+        internal static JsonNode ToExecClusterInfo(ClusterEndpoint cluster)
+        {
+            if (cluster == null)
+            {
+                return null;
+            }
+
+            var node = new JsonObject
+            {
+                ["server"] = cluster.Server,
+            };
+
+            if (cluster.SkipTlsVerify)
+            {
+                node["insecure-skip-tls-verify"] = true;
+            }
+
+            if (!string.IsNullOrEmpty(cluster.CertificateAuthorityData))
+            {
+                node["certificate-authority-data"] = cluster.CertificateAuthorityData;
+            }
+
+            if (!string.IsNullOrEmpty(cluster.TlsServerName))
+            {
+                node["tls-server-name"] = cluster.TlsServerName;
+            }
+
+            var execExtension = cluster.Extensions?
+                .FirstOrDefault(e => e.Name == "client.authentication.k8s.io/exec");
+            if (execExtension != null)
+            {
+                object extConfig = execExtension.Extension;
+                if (extConfig != null)
+                {
+                    node["config"] = JsonNode.Parse(JsonSerializer.Serialize(extConfig));
+                }
+            }
+
+            return node;
+        }
+
+        public static Process CreateRunnableExternalProcess(ExternalExecution config, EventHandler<DataReceivedEventArgs> captureStdError = null, ClusterEndpoint cluster = null)
         {
             if (config == null)
             {
                 throw new ArgumentNullException(nameof(config));
             }
 
-            var execInfo = new Dictionary<string, dynamic>
+            var spec = new JsonObject { ["interactive"] = Environment.UserInteractive };
+            if (config.ProvideClusterInfo)
             {
-                { "apiVersion", config.ApiVersion },
-                { "kind", "ExecCredentials" },
-                { "spec", new Dictionary<string, bool> { { "interactive", Environment.UserInteractive } } },
+                spec["cluster"] = ToExecClusterInfo(cluster);
+            }
+
+            var execInfo = new JsonObject
+            {
+                ["apiVersion"] = config.ApiVersion,
+                ["kind"] = "ExecCredentials",
+                ["spec"] = spec,
             };
 
             var process = new Process();
 
-            process.StartInfo.EnvironmentVariables.Add("KUBERNETES_EXEC_INFO", JsonSerializer.Serialize(execInfo));
+            process.StartInfo.EnvironmentVariables.Add("KUBERNETES_EXEC_INFO", execInfo.ToJsonString());
             if (config.EnvironmentVariables != null)
             {
                 foreach (var configEnvironmentVariable in config.EnvironmentVariables)
@@ -509,7 +582,7 @@ namespace k8s
         /// <returns>
         /// The token, client certificate data, and the client key data received from the external command execution
         /// </returns>
-        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config)
+        public static ExecCredentialResponse ExecuteExternalCommand(ExternalExecution config, ClusterEndpoint cluster = null)
         {
             if (config == null)
             {
@@ -517,7 +590,7 @@ namespace k8s
             }
 
             var captureStdError = ExecStdError;
-            var process = CreateRunnableExternalProcess(config, captureStdError);
+            var process = CreateRunnableExternalProcess(config, captureStdError, cluster);
 
             try
             {

--- a/src/KubernetesClient/KubernetesClientConfiguration.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.cs
@@ -62,6 +62,12 @@ namespace k8s
         public string TlsServerName { get; set; }
 
         /// <summary>
+        ///     Gets the base64-encoded PEM certificate authority data, resolved from either
+        ///     inline data or file path during cluster configuration.
+        /// </summary>
+        public string CaData { get; set; }
+
+        /// <summary>
         ///     Gets or sets the HTTP user agent.
         /// </summary>
         /// <value>Http user agent.</value>

--- a/src/KubernetesClient/KubernetesClientConfiguration.cs
+++ b/src/KubernetesClient/KubernetesClientConfiguration.cs
@@ -65,7 +65,7 @@ namespace k8s
         ///     Gets the base64-encoded PEM certificate authority data, resolved from either
         ///     inline data or file path during cluster configuration.
         /// </summary>
-        public string CaData { get; set; }
+        public string CertificateAuthorityData { get; set; }
 
         /// <summary>
         ///     Gets or sets the HTTP user agent.

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -99,6 +99,7 @@ namespace k8s.Tests
                     Command = "my-credential-plugin",
                     ProvideClusterInfo = true,
                 },
+                captureStdError: null,
                 cluster: cluster);
 
             var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
@@ -121,6 +122,7 @@ namespace k8s.Tests
                     Command = "my-credential-plugin",
                     ProvideClusterInfo = false,
                 },
+                captureStdError: null,
                 cluster: cluster);
 
             var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
@@ -167,6 +169,23 @@ namespace k8s.Tests
 
             Assert.NotNull(result);
             Assert.True(result["insecure-skip-tls-verify"]?.GetValue<bool>());
+        }
+
+        [Fact]
+        public void CreateRunnableExternalProcessOmitsClusterWhenProvideClusterInfoIsTrueButClusterIsNull()
+        {
+            var actual = KubernetesClientConfiguration.CreateRunnableExternalProcess(
+                new ExternalExecution
+                {
+                    ApiVersion = "client.authentication.k8s.io/v1",
+                    Command = "my-credential-plugin",
+                    ProvideClusterInfo = true,
+                },
+                captureStdError: null,
+                cluster: null);
+
+            var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
+            Assert.False(json["spec"].AsObject().ContainsKey("cluster"));
         }
 
         private static Dictionary<object, object> BuildNestedExtension()

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -42,7 +42,7 @@ namespace k8s.Tests
                 {
                     new NamedExtension
                     {
-                        Name = "client.authentication.k8s.io/exec",
+                        Name = KubernetesClientConfiguration.ExecExtensionName,
                         Extension = new Dictionary<object, object> { { "audience", "06e3fbd18de8" } },
                     },
                 },
@@ -139,7 +139,7 @@ namespace k8s.Tests
                 {
                     new NamedExtension
                     {
-                        Name = "client.authentication.k8s.io/exec",
+                        Name = KubernetesClientConfiguration.ExecExtensionName,
                         Extension = BuildNestedExtension(),
                     },
                 },

--- a/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
+++ b/tests/KubernetesClient.Tests/ExternalExecutionTests.cs
@@ -1,6 +1,6 @@
 using k8s.KubeConfigModels;
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace k8s.Tests
@@ -19,13 +19,173 @@ namespace k8s.Tests
                     { new Dictionary<string, string> { { "name", "testkey" }, { "value", "testvalue" } } },
             });
 
-            var actualExecInfo = JsonSerializer.Deserialize<IDictionary<string, dynamic>>(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
-            Assert.Equal("testingversion", actualExecInfo["apiVersion"].ToString());
-            Assert.Equal("ExecCredentials", actualExecInfo["kind"].ToString());
+            var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
+            Assert.Equal("testingversion", json["apiVersion"]?.GetValue<string>());
+            Assert.Equal("ExecCredentials", json["kind"]?.GetValue<string>());
+            Assert.False(json["spec"].AsObject().ContainsKey("cluster"));
 
             Assert.Equal("command", actual.StartInfo.FileName);
             Assert.Equal("arg1 arg2", actual.StartInfo.Arguments);
             Assert.Equal("testvalue", actual.StartInfo.EnvironmentVariables["testkey"]);
+        }
+
+        [Fact]
+        public void ToExecClusterInfoMapsFieldsCorrectly()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com:6443",
+                CertificateAuthorityData = "LS0tLS1CRUdJTi0t",
+                SkipTlsVerify = false,
+                TlsServerName = "my-cluster.example.com",
+                Extensions = new List<NamedExtension>
+                {
+                    new NamedExtension
+                    {
+                        Name = "client.authentication.k8s.io/exec",
+                        Extension = new Dictionary<object, object> { { "audience", "06e3fbd18de8" } },
+                    },
+                },
+            };
+
+            var result = KubernetesClientConfiguration.ToExecClusterInfo(cluster);
+
+            Assert.NotNull(result);
+            Assert.Equal("https://my-cluster.example.com:6443", result["server"]?.GetValue<string>());
+            Assert.False(result.AsObject().ContainsKey("insecure-skip-tls-verify"));
+            Assert.Equal("LS0tLS1CRUdJTi0t", result["certificate-authority-data"]?.GetValue<string>());
+            Assert.Equal("my-cluster.example.com", result["tls-server-name"]?.GetValue<string>());
+            Assert.Equal("06e3fbd18de8", result["config"]?["audience"]?.GetValue<string>());
+        }
+
+        [Fact]
+        public void ToExecClusterInfoReturnsNullForNullCluster()
+        {
+            Assert.Null(KubernetesClientConfiguration.ToExecClusterInfo(null));
+        }
+
+        [Fact]
+        public void ToExecClusterInfoOmitsOptionalEmptyFields()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com",
+                SkipTlsVerify = false,
+            };
+
+            var result = KubernetesClientConfiguration.ToExecClusterInfo(cluster);
+
+            Assert.NotNull(result);
+            Assert.Equal("https://my-cluster.example.com", result["server"]?.GetValue<string>());
+            Assert.False(result.AsObject().ContainsKey("insecure-skip-tls-verify"));
+            Assert.False(result.AsObject().ContainsKey("certificate-authority-data"));
+            Assert.False(result.AsObject().ContainsKey("tls-server-name"));
+            Assert.False(result.AsObject().ContainsKey("config"));
+        }
+
+        [Fact]
+        public void CreateRunnableExternalProcessIncludesClusterWhenProvideClusterInfoIsTrue()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com",
+                SkipTlsVerify = false,
+            };
+
+            var actual = KubernetesClientConfiguration.CreateRunnableExternalProcess(
+                new ExternalExecution
+                {
+                    ApiVersion = "client.authentication.k8s.io/v1",
+                    Command = "my-credential-plugin",
+                    ProvideClusterInfo = true,
+                },
+                cluster: cluster);
+
+            var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
+            Assert.Equal("https://my-cluster.example.com", json["spec"]?["cluster"]?["server"]?.GetValue<string>());
+        }
+
+        [Fact]
+        public void CreateRunnableExternalProcessOmitsClusterWhenProvideClusterInfoIsFalse()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com",
+                SkipTlsVerify = false,
+            };
+
+            var actual = KubernetesClientConfiguration.CreateRunnableExternalProcess(
+                new ExternalExecution
+                {
+                    ApiVersion = "client.authentication.k8s.io/v1",
+                    Command = "my-credential-plugin",
+                    ProvideClusterInfo = false,
+                },
+                cluster: cluster);
+
+            var json = JsonNode.Parse(actual.StartInfo.EnvironmentVariables["KUBERNETES_EXEC_INFO"]);
+            Assert.False(json["spec"].AsObject().ContainsKey("cluster"));
+        }
+
+        [Fact]
+        public void ToExecClusterInfoHandlesNestedExtensions()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com",
+                Extensions = new List<NamedExtension>
+                {
+                    new NamedExtension
+                    {
+                        Name = "client.authentication.k8s.io/exec",
+                        Extension = BuildNestedExtension(),
+                    },
+                },
+            };
+
+            var result = KubernetesClientConfiguration.ToExecClusterInfo(cluster);
+
+            Assert.NotNull(result);
+            Assert.Equal("06e3fbd18de8", result["config"]?["audience"]?.GetValue<string>());
+            Assert.Equal("value1", result["config"]?["nested"]?["key1"]?.GetValue<string>());
+            Assert.Equal("innervalue", result["config"]?["nested"]?["deep"]?["inner"]?.GetValue<string>());
+            Assert.Equal("a", result["config"]?["tags"]?[0]?.GetValue<string>());
+            Assert.Equal("b", result["config"]?["tags"]?[1]?.GetValue<string>());
+            Assert.Equal("c", result["config"]?["tags"]?[2]?.GetValue<string>());
+        }
+
+        [Fact]
+        public void ToExecClusterInfoEmitsInsecureSkipTlsVerifyWhenTrue()
+        {
+            var cluster = new ClusterEndpoint
+            {
+                Server = "https://my-cluster.example.com",
+                SkipTlsVerify = true,
+            };
+
+            var result = KubernetesClientConfiguration.ToExecClusterInfo(cluster);
+
+            Assert.NotNull(result);
+            Assert.True(result["insecure-skip-tls-verify"]?.GetValue<bool>());
+        }
+
+        private static Dictionary<object, object> BuildNestedExtension()
+        {
+            var deep = new Dictionary<object, object>
+            {
+                { "inner", "innervalue" },
+            };
+            var nested = new Dictionary<object, object>
+            {
+                { "key1", "value1" },
+                { "deep", deep },
+            };
+            return new Dictionary<object, object>
+            {
+                { "audience", "06e3fbd18de8" },
+                { "nested", nested },
+                { "tags", new List<object> { "a", "b", "c" } },
+            };
         }
     }
 }


### PR DESCRIPTION
Implements support for `provideClusterInfo: true` in a kubeconfig user's `exec` block. Per the exec credential plugin protocol (`client.authentication.k8s.io`), when this flag is set the client passes the cluster's connection details to the plugin via `spec.cluster` in `KUBERNETES_EXEC_INFO`. The `provideClusterInfo` / `installHint` fields were added in #620, but forwarding the cluster info was left as a TODO (#618 / #620). This PR completes that.

Forwards `server`, `insecure-skip-tls-verify`, `certificate-authority-data` (resolved from inline data or a CA file path), `tls-server-name`, and the `exec` extension `config`.

Note: the AOT client forwards all scalar cluster fields but not [config](https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#client-authentication-k8s-io-v1-Cluster). The AOT `ClusterEndpoint` anyway omits `Extensions` currently.