### PR TITLE
Combine open Dependabot dependency updates into a single branch

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,14 +10,14 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
@@ -26,7 +26,7 @@
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.0.0" />
-    <PackageVersion Include="Wiremock.Net" Version="1.12.0" />
+    <PackageVersion Include="Wiremock.Net" Version="2.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />

--- a/examples/openTelemetryConsole/openTelemetryConsole.csproj
+++ b/examples/openTelemetryConsole/openTelemetryConsole.csproj
@@ -6,10 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.Console" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="10.0.7" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+  </ItemGroup>
     
 </Project>

--- a/tests/E2E.Tests/MinikubeTests.cs
+++ b/tests/E2E.Tests/MinikubeTests.cs
@@ -752,19 +752,18 @@ namespace k8s.E2E
 
                 // replace + get (retry on conflict due to Kubernetes optimistic concurrency)
                 {
-                    var retries = 5;
-                    while (retries-- > 0)
+                    const int maxAttempts = 5;
+                    for (var attempt = 1; attempt <= maxAttempts; attempt++)
                     {
+                        var pod = await clientSet.CoreV1.Pod.GetAsync(podName, namespaceParameter).ConfigureAwait(false);
+                        pod.Spec.Containers[0].Image = "httpd";
                         try
                         {
-                            var pod = await clientSet.CoreV1.Pod.GetAsync(podName, namespaceParameter).ConfigureAwait(false);
-                            pod.Spec.Containers[0].Image = "httpd";
                             await clientSet.CoreV1.Pod.UpdateAsync(pod, podName, namespaceParameter).ConfigureAwait(false);
                             break;
                         }
-                        catch (HttpOperationException e) when (e.Response.StatusCode == System.Net.HttpStatusCode.Conflict)
+                        catch (HttpOperationException e) when (e.Response.StatusCode == System.Net.HttpStatusCode.Conflict && attempt < maxAttempts)
                         {
-                            if (retries == 0) throw;
                             await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         }
                     }

--- a/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
+++ b/tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs
@@ -1,6 +1,7 @@
 using k8s.LeaderElection;
 using Moq;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -84,8 +85,8 @@ namespace k8s.Tests.LeaderElection
         [Fact]
         public void LeaderElection()
         {
-            var electionHistory = new List<string>();
-            var leadershipHistory = new List<string>();
+            var electionHistory = new ConcurrentQueue<string>();
+            var leadershipHistory = new ConcurrentQueue<string>();
             var electionHistoryCountdown = new CountdownEvent(7);
 
             var renewCountA = 3;
@@ -95,19 +96,19 @@ namespace k8s.Tests.LeaderElection
             {
                 renewCountA--;
 
-                electionHistory.Add("A creates record");
-                leadershipHistory.Add("A gets leadership");
+                electionHistory.Enqueue("A creates record");
+                leadershipHistory.Enqueue("A gets leadership");
                 electionHistoryCountdown.Signal();
             };
 
             mockLockA.OnUpdate += (_) =>
             {
                 renewCountA--;
-                electionHistory.Add("A updates record");
+                electionHistory.Enqueue("A updates record");
                 electionHistoryCountdown.Signal();
             };
 
-            mockLockA.OnChange += (_) => { leadershipHistory.Add("A gets leadership"); };
+            mockLockA.OnChange += (_) => { leadershipHistory.Enqueue("A gets leadership"); };
 
             var leaderElectionConfigA = new LeaderElectionConfig(mockLockA)
             {
@@ -123,19 +124,19 @@ namespace k8s.Tests.LeaderElection
             {
                 renewCountB--;
 
-                electionHistory.Add("B creates record");
+                electionHistory.Enqueue("B creates record");
                 electionHistoryCountdown.Signal();
-                leadershipHistory.Add("B gets leadership");
+                leadershipHistory.Enqueue("B gets leadership");
             };
 
             mockLockB.OnUpdate += (_) =>
             {
                 renewCountB--;
-                electionHistory.Add("B updates record");
+                electionHistory.Enqueue("B updates record");
                 electionHistoryCountdown.Signal();
             };
 
-            mockLockB.OnChange += (_) => { leadershipHistory.Add("B gets leadership"); };
+            mockLockB.OnChange += (_) => { leadershipHistory.Enqueue("B gets leadership"); };
 
             var leaderElectionConfigB = new LeaderElectionConfig(mockLockB)
             {
@@ -153,13 +154,13 @@ namespace k8s.Tests.LeaderElection
 
                 leaderElector.OnStartedLeading += () =>
                 {
-                    leadershipHistory.Add("A starts leading");
+                    leadershipHistory.Enqueue("A starts leading");
                     testLeaderElectionLatch.Signal();
                 };
 
                 leaderElector.OnStoppedLeading += () =>
                 {
-                    leadershipHistory.Add("A stops leading");
+                    leadershipHistory.Enqueue("A stops leading");
                     testLeaderElectionLatch.Signal();
                     lockAStopLeading.Set();
                 };
@@ -176,13 +177,13 @@ namespace k8s.Tests.LeaderElection
 
                 leaderElector.OnStartedLeading += () =>
                 {
-                    leadershipHistory.Add("B starts leading");
+                    leadershipHistory.Enqueue("B starts leading");
                     testLeaderElectionLatch.Signal();
                 };
 
                 leaderElector.OnStoppedLeading += () =>
                 {
-                    leadershipHistory.Add("B stops leading");
+                    leadershipHistory.Enqueue("B stops leading");
                     testLeaderElectionLatch.Signal();
                 };
 


### PR DESCRIPTION
## Summary
This PR combines the currently open Dependabot updates into one integration PR to simplify review and CI.

Included updates:
- `actions/checkout` from `6.0.2` to `6.0.3`
- `Autofac` from `9.1.0` to `9.2.0`
- `Microsoft.Extensions.Logging` to `10.0.9`
- `Microsoft.Bcl.AsyncInterfaces` and `System.Text.Json` dependency updates from the Dependabot multi-package branch
- `OpenTelemetry.Instrumentation.Http` from `1.12.0` to `1.15.1`
- `WireMock.Net` from `1.12.0` to `2.6.0`

> **Note:** `Xunit.StaFact` remains at `1.2.69`. Upgrading to `3.0.13` was attempted but reverted because `Xunit.StaFact 3.x` pulls in `xunit.v3.core`, which conflicts with the existing `xunit 2.9.3` dependency. A full xunit v3 migration is a separate effort.

## Additional test fixes carried with dependency branches
- Conflict-retry test updates in `tests/E2E.Tests/MinikubeTests.cs`
- Leader election test stabilization updates in `tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs`

## Files in scope
- `.github/workflows/buildtest.yaml`
- `Directory.Packages.props`
- `examples/openTelemetryConsole/openTelemetryConsole.csproj`
- `tests/E2E.Tests/MinikubeTests.cs`
- `tests/KubernetesClient.Tests/LeaderElection/LeaderElectionTests.cs`

## Validation note
Local `dotnet test` could not be executed in this dev container because installed SDK is `8.0.422` while projects target `net9.0` (`NETSDK1045`). CI and/or a .NET 9 environment should perform final validation.