### PR TITLE
Update devcontainer to support .NET 9 and .NET 10

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,5 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; \
     chmod +x /tmp/dotnet-install.sh; \
-    /tmp/dotnet-install.sh --channel 9.0 --quality ga --install-dir /usr/share/dotnet; \
+    /tmp/dotnet-install.sh --channel 9.0 --quality ga --install-dir /usr/share/dotnet --skip-non-versioned-files; \
     rm -f /tmp/dotnet-install.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+# Install .NET 9 SDK side-by-side so the container supports both net9.0 and net10.0 builds.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; \
+    chmod +x /tmp/dotnet-install.sh; \
+    /tmp/dotnet-install.sh --channel 9.0 --quality ga --install-dir /usr/share/dotnet; \
+    rm -f /tmp/dotnet-install.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 
-# Install .NET 9 SDK side-by-side so the container supports both net9.0 and net10.0 builds.
+# Install .NET 8 and .NET 9 SDKs side-by-side so the container supports net8.0, net9.0 and net10.0 builds.
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates; \
@@ -8,4 +8,5 @@ RUN set -eux; \
     curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; \
     chmod +x /tmp/dotnet-install.sh; \
     /tmp/dotnet-install.sh --channel 9.0 --quality ga --install-dir /usr/share/dotnet --skip-non-versioned-files; \
+    /tmp/dotnet-install.sh --channel 8.0 --quality ga --install-dir /usr/share/dotnet --skip-non-versioned-files; \
     rm -f /tmp/dotnet-install.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,6 @@
     "name": "csharp",
     "build": {
         "dockerfile": "Dockerfile",
-        "context": ".."
+        "context": "."
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,7 @@
 {
-    "image": "mcr.microsoft.com/dotnet/sdk:8.0"
+    "name": "csharp",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    }
 }


### PR DESCRIPTION
## Summary
- switch `.devcontainer/devcontainer.json` from a fixed `.NET 8` image to a Dockerfile-based build
- add `.devcontainer/Dockerfile` based on `mcr.microsoft.com/dotnet/sdk:10.0`
- install `.NET 9 SDK` side-by-side via `dotnet-install.sh`

## Why
The repository currently targets newer TFMs in CI and local workflows. This devcontainer update ensures contributors can build and test net9.0/net10.0 projects from the container environment.

## Validation
- branch builds with updated devcontainer configuration files
- `.NET 9` and `.NET 10` SDK availability is provisioned by container build steps