### PR TITLE
Limit workflow triggers to relevant path changes

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -168,3 +168,17 @@ jobs:
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'examples/**'
+      - '.github/e2e/**'
+      - '*.props'
+      - '*.targets'
+      - '*.ruleset'
+      - 'Directory.*'
+      - 'CodeCoverage.runsettings'
+      - 'global.json'
+      - 'nuget.config'
+      - 'kubernetes-client.proj'
+      - '.github/workflows/buildtest.yaml'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,9 +8,33 @@ permissions:
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'examples/**'
+      - '*.props'
+      - '*.targets'
+      - '*.ruleset'
+      - 'Directory.*'
+      - 'global.json'
+      - 'nuget.config'
+      - 'swagger.json'
+      - '.github/workflows/codeql-analysis.yml'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'examples/**'
+      - '*.props'
+      - '*.targets'
+      - '*.ruleset'
+      - 'Directory.*'
+      - 'global.json'
+      - 'nuget.config'
+      - 'swagger.json'
+      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '15 23 * * 1'
 

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -3,6 +3,11 @@ name: Docfx
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'doc/**'
+      - 'src/**'
+      - 'README.md'
+      - '.github/workflows/docfx.yaml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -6,6 +6,19 @@ permissions:
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'examples/**'
+      - '*.props'
+      - '*.targets'
+      - '*.ruleset'
+      - 'Directory.*'
+      - 'global.json'
+      - 'nuget.config'
+      - 'version.json'
+      - 'kubernetes-client.proj'
+      - '.github/workflows/draft.yaml'
     
 jobs:
   draft:


### PR DESCRIPTION
## Summary
Add path filters to commit-triggered GitHub Actions workflows so they run only when relevant files are modified.

## Changes
- Add `paths` filters to `push` and `pull_request` in `.github/workflows/codeql-analysis.yml`
- Add `paths` filters to `pull_request` in `.github/workflows/buildtest.yaml`
- Add `paths` filters to `push` in `.github/workflows/docfx.yaml`
- Add `paths` filters to `push` in `.github/workflows/draft.yaml`

## Notes
- `schedule` in CodeQL and `workflow_dispatch` in Docfx are unchanged.
- `.github/workflows/nuget.yaml` is release-triggered and intentionally unchanged.

## Why
This reduces unnecessary CI load and shortens feedback time by skipping workflow runs for unrelated changes.